### PR TITLE
feat: add ASR model version selector (v2/v3)

### DIFF
--- a/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
@@ -51,7 +51,7 @@ actor OpenRouterClient {
                     guard let httpResponse = response as? HTTPURLResponse,
                           (200...299).contains(httpResponse.statusCode) else {
                         let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-                        continuation.finish(throwing: OpenRouterError.httpError(statusCode))
+                        continuation.finish(throwing: OpenRouterError.httpError(statusCode, targetURL))
                         return
                     }
 
@@ -111,7 +111,7 @@ actor OpenRouterClient {
         guard let httpResponse = response as? HTTPURLResponse,
               (200...299).contains(httpResponse.statusCode) else {
             let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
-            throw OpenRouterError.httpError(statusCode)
+            throw OpenRouterError.httpError(statusCode, targetURL)
         }
 
         let completionResponse = try JSONDecoder().decode(CompletionResponse.self, from: data)
@@ -119,11 +119,13 @@ actor OpenRouterClient {
     }
 
     enum OpenRouterError: Error, LocalizedError {
-        case httpError(Int)
+        case httpError(Int, URL?)
 
         var errorDescription: String? {
             switch self {
-            case .httpError(let code): "OpenRouter API error (HTTP \(code))"
+            case .httpError(let code, let url):
+                let host = url?.host ?? "unknown"
+                return "LLM API error (HTTP \(code)) from \(host)"
             }
         }
     }

--- a/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
+++ b/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
@@ -34,6 +34,20 @@ enum EmbeddingProvider: String, CaseIterable, Identifiable {
     }
 }
 
+enum AsrModelVersionSetting: String, CaseIterable, Identifiable {
+    case v2
+    case v3
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .v2: "Parakeet TDT v2 (English only)"
+        case .v3: "Parakeet TDT v3 (25 languages)"
+        }
+    }
+}
+
 @Observable
 @MainActor
 final class AppSettings {
@@ -103,6 +117,10 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(hasAcknowledgedRecordingConsent, forKey: "hasAcknowledgedRecordingConsent") }
     }
 
+    var asrModelVersion: AsrModelVersionSetting {
+        didSet { UserDefaults.standard.set(asrModelVersion.rawValue, forKey: "asrModelVersion") }
+    }
+
     /// When true, all app windows are invisible to screen sharing / recording.
     var hideFromScreenShare: Bool {
         didSet {
@@ -137,6 +155,7 @@ final class AppSettings {
         self.openAIEmbedApiKey = KeychainHelper.load(key: "openAIEmbedApiKey") ?? ""
         self.openAIEmbedModel = defaults.string(forKey: "openAIEmbedModel") ?? "text-embedding-3-small"
         self.hasAcknowledgedRecordingConsent = defaults.bool(forKey: "hasAcknowledgedRecordingConsent")
+        self.asrModelVersion = AsrModelVersionSetting(rawValue: defaults.string(forKey: "asrModelVersion") ?? "") ?? .v3
 
         // Default to true (hidden) if key has never been set
         if defaults.object(forKey: "hideFromScreenShare") == nil {

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -32,6 +32,7 @@ final class TranscriptionEngine {
     private let systemCapture = SystemAudioCapture()
     private let micCapture = MicCapture()
     private let transcriptStore: TranscriptStore
+    private let settings: AppSettings
 
     /// Audio level from mic for the UI meter.
     var audioLevel: Float { micCapture.audioLevel }
@@ -54,10 +55,16 @@ final class TranscriptionEngine {
     /// Listens for default input device changes at the OS level.
     private var defaultDeviceListenerBlock: AudioObjectPropertyListenerBlock?
 
-    init(transcriptStore: TranscriptStore) {
+    private var asrVersion: AsrModelVersion {
+        settings.asrModelVersion == .v2 ? .v2 : .v3
+    }
+
+    init(transcriptStore: TranscriptStore, settings: AppSettings) {
         self.transcriptStore = transcriptStore
+        self.settings = settings
+        let version: AsrModelVersion = settings.asrModelVersion == .v2 ? .v2 : .v3
         self.needsModelDownload = !AsrModels.modelsExist(
-            at: AsrModels.defaultCacheDirectory(for: .v2), version: .v2
+            at: AsrModels.defaultCacheDirectory(for: version), version: version
         )
     }
 
@@ -79,7 +86,7 @@ final class TranscriptionEngine {
         assetStatus = needsModelDownload ? "Downloading ASR model (~600MB)..." : "Loading ASR model..."
         diagLog("[ENGINE-1] loading FluidAudio ASR models...")
         do {
-            let models = try await AsrModels.downloadAndLoad(version: .v2)
+            let models = try await AsrModels.downloadAndLoad(version: asrVersion)
             assetStatus = "Initializing ASR..."
             let asr = AsrManager(config: .default)
             try await asr.initialize(models: models)
@@ -166,7 +173,7 @@ final class TranscriptionEngine {
             }
         }
 
-        assetStatus = "Transcribing (Parakeet-TDT v2)"
+        assetStatus = "Transcribing (Parakeet-TDT \(settings.asrModelVersion.rawValue))"
         diagLog("[ENGINE-6] all transcription tasks started")
 
         // Install CoreAudio listener for default input device changes

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -139,7 +139,7 @@ struct ContentView: View {
             if knowledgeBase == nil {
                 let kb = KnowledgeBase(settings: settings)
                 knowledgeBase = kb
-                transcriptionEngine = TranscriptionEngine(transcriptStore: transcriptStore)
+                transcriptionEngine = TranscriptionEngine(transcriptStore: transcriptStore, settings: settings)
                 suggestionEngine = SuggestionEngine(
                     transcriptStore: transcriptStore,
                     knowledgeBase: kb,

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -126,8 +126,19 @@ struct SettingsView: View {
             }
 
             Section("Transcription") {
+                Picker("ASR Model", selection: $settings.asrModelVersion) {
+                    ForEach(AsrModelVersionSetting.allCases) { version in
+                        Text(version.displayName).tag(version)
+                    }
+                }
+                .font(.system(size: 12))
+
                 TextField("Locale (e.g. en-US)", text: $settings.transcriptionLocale)
                     .font(.system(size: 12, design: .monospaced))
+
+                Text("Model change takes effect next time you start a session. v2 is English-only with highest recall. v3 supports 25 European languages including German.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
             }
 
             Section("Privacy") {


### PR DESCRIPTION
## Summary
- Add a settings picker to choose between Parakeet TDT v2 (English-only, highest recall) and v3 (25 European languages including German)
- Fix misleading error messages in `OpenRouterClient` that always showed "OpenRouter API error" even when using Ollama — now shows the actual failing host

## Changes
- **AppSettings**: New `AsrModelVersionSetting` enum and persisted `asrModelVersion` property (defaults to v3)
- **SettingsView**: ASR model picker in the Transcription section with description text
- **TranscriptionEngine**: Reads the setting to decide which model version to download/load; status bar shows active version
- **ContentView**: Pass settings to TranscriptionEngine
- **OpenRouterClient**: Error now includes the target URL host for clearer diagnostics

## Test plan
- [ ] Switch between v2 and v3 in Settings, restart a session, verify correct model loads
- [ ] Confirm v3 transcribes German speech correctly
- [ ] Confirm v2 still works for English-only transcription
- [ ] Trigger an LLM error with Ollama stopped and verify the error message shows `localhost` not `openrouter.ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)