### PR TITLE
Add separate audio routing for user and attendees

### DIFF
--- a/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
+++ b/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
@@ -88,6 +88,20 @@ enum EmbeddingProvider: String, CaseIterable, Identifiable {
     }
 }
 
+enum AttendeeAudioSource: String, CaseIterable, Identifiable {
+    case systemAudio
+    case inputDevice
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .systemAudio: "System Audio"
+        case .inputDevice: "Input Device"
+        }
+    }
+}
+
 @Observable
 @MainActor
 final class AppSettings {
@@ -114,6 +128,15 @@ final class AppSettings {
     /// Stored as the AudioDeviceID integer. 0 means "use system default".
     var inputDeviceID: AudioDeviceID {
         didSet { UserDefaults.standard.set(Int(inputDeviceID), forKey: "inputDeviceID") }
+    }
+
+    var attendeeAudioSource: AttendeeAudioSource {
+        didSet { UserDefaults.standard.set(attendeeAudioSource.rawValue, forKey: "attendeeAudioSource") }
+    }
+
+    /// Stored as the AudioDeviceID integer. 0 means "use system default".
+    var attendeeInputDeviceID: AudioDeviceID {
+        didSet { UserDefaults.standard.set(Int(attendeeInputDeviceID), forKey: "attendeeInputDeviceID") }
     }
 
     var openRouterApiKey: String {
@@ -187,6 +210,10 @@ final class AppSettings {
             rawValue: defaults.string(forKey: "transcriptionModel") ?? ""
         ) ?? .parakeetV2
         self.inputDeviceID = AudioDeviceID(defaults.integer(forKey: "inputDeviceID"))
+        self.attendeeAudioSource = AttendeeAudioSource(
+            rawValue: defaults.string(forKey: "attendeeAudioSource") ?? ""
+        ) ?? .systemAudio
+        self.attendeeInputDeviceID = AudioDeviceID(defaults.integer(forKey: "attendeeInputDeviceID"))
         self.openRouterApiKey = KeychainHelper.load(key: "openRouterApiKey") ?? ""
         self.voyageApiKey = KeychainHelper.load(key: "voyageApiKey") ?? ""
         self.llmProvider = LLMProvider(rawValue: defaults.string(forKey: "llmProvider") ?? "") ?? .openRouter
@@ -225,6 +252,7 @@ final class AppSettings {
 
         let keysToMigrate = [
             "kbFolderPath", "selectedModel", "transcriptionLocale", "transcriptionModel", "inputDeviceID",
+            "attendeeAudioSource", "attendeeInputDeviceID",
             "llmProvider", "embeddingProvider", "ollamaBaseURL", "ollamaLLMModel",
             "ollamaEmbedModel", "hideFromScreenShare",
             "isTranscriptExpanded", "hasCompletedOnboarding"
@@ -261,6 +289,7 @@ final class AppSettings {
 
         let keysToMigrate = [
             "kbFolderPath", "selectedModel", "transcriptionLocale", "transcriptionModel", "inputDeviceID",
+            "attendeeAudioSource", "attendeeInputDeviceID",
             "llmProvider", "embeddingProvider", "ollamaBaseURL", "ollamaLLMModel",
             "ollamaEmbedModel", "hideFromScreenShare",
             "isTranscriptExpanded", "hasCompletedOnboarding",

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -31,6 +31,7 @@ final class TranscriptionEngine {
 
     private let systemCapture = SystemAudioCapture()
     private let micCapture = MicCapture()
+    private let attendeeMicCapture = MicCapture()
     private let transcriptStore: TranscriptStore
     private let settings: AppSettings
 
@@ -39,6 +40,7 @@ final class TranscriptionEngine {
 
     private var micTask: Task<Void, Never>?
     private var sysTask: Task<Void, Never>?
+    private var attendeeRestartTask: Task<Void, Never>?
     /// Keeps the mic stream alive for the audio level meter when transcription isn't running.
     private var micKeepAliveTask: Task<Void, Never>?
 
@@ -56,6 +58,10 @@ final class TranscriptionEngine {
 
     /// Tracks whether user selected "System Default" (0) or a specific device.
     private var userSelectedDeviceID: AudioDeviceID = 0
+    private var attendeeSelectedDeviceID: AudioDeviceID = 0
+    private var attendeeAudioSource: AttendeeAudioSource = .systemAudio
+    private var currentAttendeeMicDeviceID: AudioDeviceID = 0
+    private var pendingAttendeeRouting: (source: AttendeeAudioSource, inputDeviceID: AudioDeviceID)?
 
     /// Listens for default input device changes at the OS level.
     private var defaultDeviceListenerBlock: AudioObjectPropertyListenerBlock?
@@ -75,6 +81,8 @@ final class TranscriptionEngine {
     func start(
         locale: Locale,
         inputDeviceID: AudioDeviceID = 0,
+        attendeeAudioSource: AttendeeAudioSource = .systemAudio,
+        attendeeInputDeviceID: AudioDeviceID = 0,
         transcriptionModel: TranscriptionModel
     ) async {
         diagLog("[ENGINE-0] start() called, isRunning=\(isRunning)")
@@ -177,41 +185,16 @@ final class TranscriptionEngine {
             deviceID: targetMicID
         )
 
-        // 3. Start system audio capture
-        diagLog("[ENGINE-4] starting system audio capture...")
-        let sysStreams: SystemAudioCapture.CaptureStreams?
-        do {
-            sysStreams = try await systemCapture.bufferStream()
-            diagLog("[ENGINE-5] system audio capture started OK")
-        } catch {
-            let msg = "Failed to start system audio: \(error.localizedDescription)"
-            diagLog("[ENGINE-5-FAIL] \(msg)")
-            lastError = msg
-            sysStreams = nil
-        }
-
-        let store = transcriptStore
-
-        // 4. Start system audio transcription
-        if let sysStream = sysStreams?.systemAudio {
-            let sysTranscriber = makeTranscriber(
-                locale: locale,
-                speaker: .them,
-                vadManager: vadManager,
-                onPartial: { text in
-                    Task { @MainActor in store.volatileThemText = text }
-                },
-                onFinal: { text in
-                    Task { @MainActor in
-                        store.volatileThemText = ""
-                        store.append(Utterance(text: text, speaker: .them))
-                    }
-                }
-            )
-            sysTask = Task.detached {
-                await sysTranscriber.run(stream: sysStream)
-            }
-        }
+        // 3. Start attendee capture
+        self.attendeeAudioSource = attendeeAudioSource
+        attendeeSelectedDeviceID = attendeeInputDeviceID
+        await startAttendeeCapture(
+            locale: locale,
+            transcriptionModel: currentTranscriptionModel ?? transcriptionModel,
+            vadManager: vadManager,
+            source: attendeeAudioSource,
+            inputDeviceID: attendeeInputDeviceID
+        )
 
         assetStatus = "Transcribing (\(transcriptionModel.displayName))"
         diagLog("[ENGINE-6] all transcription tasks started")
@@ -242,6 +225,29 @@ final class TranscriptionEngine {
         }
     }
 
+    func restartAttendeeCapture(source: AttendeeAudioSource, inputDeviceID: AudioDeviceID) {
+        guard isRunning else { return }
+        pendingAttendeeRouting = (source, inputDeviceID)
+
+        if attendeeRestartTask != nil {
+            diagLog("[ENGINE-THEM-SWAP] queued restart for source=\(source.rawValue) device=\(inputDeviceID)")
+            return
+        }
+
+        attendeeRestartTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.attendeeRestartTask = nil }
+
+            while self.isRunning, let requestedRouting = self.pendingAttendeeRouting {
+                self.pendingAttendeeRouting = nil
+                await self.performAttendeeRestart(
+                    source: requestedRouting.source,
+                    inputDeviceID: requestedRouting.inputDeviceID
+                )
+            }
+        }
+    }
+
     // MARK: - Default Device Listener
 
     private func installDefaultDeviceListener() {
@@ -256,9 +262,13 @@ final class TranscriptionEngine {
         let block: AudioObjectPropertyListenerBlock = { [weak self] _, _ in
             guard let self else { return }
             Task { @MainActor in
-                guard self.isRunning, self.userSelectedDeviceID == 0 else { return }
-                // User has "System Default" selected — follow the OS default
-                self.restartMic(inputDeviceID: 0)
+                guard self.isRunning else { return }
+                if self.userSelectedDeviceID == 0 {
+                    self.restartMic(inputDeviceID: 0)
+                }
+                if self.attendeeAudioSource == .inputDevice, self.attendeeSelectedDeviceID == 0 {
+                    self.restartAttendeeCapture(source: .inputDevice, inputDeviceID: 0)
+                }
             }
         }
         defaultDeviceListenerBlock = block
@@ -315,14 +325,18 @@ final class TranscriptionEngine {
     func finalize() async {
         removeDefaultDeviceListener()
         micRestartTask?.cancel()
+        attendeeRestartTask?.cancel()
         micRestartTask = nil
+        attendeeRestartTask = nil
         pendingMicDeviceID = nil
+        pendingAttendeeRouting = nil
         micKeepAliveTask?.cancel()
 
         // Finish the async streams — causes StreamingTranscriber.run()
         // to exit its for-await loop and hit the final speechSamples flush
         micCapture.finishStream()
         systemCapture.finishStream()
+        attendeeMicCapture.finishStream()
 
         // Wait for transcriber tasks to complete (includes final flush)
         await micTask?.value
@@ -331,12 +345,15 @@ final class TranscriptionEngine {
         // Now safe to tear down audio hardware
         micCapture.stop()
         await systemCapture.stop()
+        attendeeMicCapture.stop()
 
         micTask = nil
         sysTask = nil
         pendingMicDeviceID = nil
+        pendingAttendeeRouting = nil
         micKeepAliveTask = nil
         currentMicDeviceID = 0
+        currentAttendeeMicDeviceID = 0
         currentTranscriptionModel = nil
         isRunning = false
         assetStatus = "Ready"
@@ -345,8 +362,11 @@ final class TranscriptionEngine {
     func stop() {
         removeDefaultDeviceListener()
         micRestartTask?.cancel()
+        attendeeRestartTask?.cancel()
         micRestartTask = nil
+        attendeeRestartTask = nil
         pendingMicDeviceID = nil
+        pendingAttendeeRouting = nil
         micTask?.cancel()
         sysTask?.cancel()
         micKeepAliveTask?.cancel()
@@ -355,7 +375,9 @@ final class TranscriptionEngine {
         micKeepAliveTask = nil
         Task { await systemCapture.stop() }
         micCapture.stop()
+        attendeeMicCapture.stop()
         currentMicDeviceID = 0
+        currentAttendeeMicDeviceID = 0
         currentTranscriptionModel = nil
         isRunning = false
         assetStatus = "Ready"
@@ -401,6 +423,51 @@ final class TranscriptionEngine {
         diagLog("[ENGINE-MIC-SWAP] mic restarted on device \(targetMicID)")
     }
 
+    private func performAttendeeRestart(
+        source: AttendeeAudioSource,
+        inputDeviceID: AudioDeviceID
+    ) async {
+        guard isRunning, let vadManager else { return }
+
+        let previousSource = attendeeAudioSource
+        let previousDeviceID = attendeeSelectedDeviceID
+        attendeeAudioSource = source
+        attendeeSelectedDeviceID = inputDeviceID
+
+        let routingChanged = source != previousSource || inputDeviceID != previousDeviceID
+        if !routingChanged, source == .inputDevice,
+           let targetID = resolvedMicDeviceID(for: inputDeviceID),
+           targetID == currentAttendeeMicDeviceID {
+            diagLog("[ENGINE-THEM-SWAP] same attendee device \(targetID), skipping")
+            return
+        }
+        if !routingChanged, source == .systemAudio {
+            diagLog("[ENGINE-THEM-SWAP] already using system audio, skipping")
+            return
+        }
+
+        sysTask?.cancel()
+        attendeeMicCapture.finishStream()
+        systemCapture.finishStream()
+        await sysTask?.value
+        sysTask = nil
+        attendeeMicCapture.stop()
+        await systemCapture.stop()
+        currentAttendeeMicDeviceID = 0
+
+        if Task.isCancelled || !isRunning {
+            return
+        }
+
+        await startAttendeeCapture(
+            locale: settings.locale,
+            transcriptionModel: currentTranscriptionModel ?? settings.transcriptionModel,
+            vadManager: vadManager,
+            source: source,
+            inputDeviceID: inputDeviceID
+        )
+    }
+
     private func startMicStream(
         locale: Locale,
         transcriptionModel: TranscriptionModel,
@@ -425,6 +492,80 @@ final class TranscriptionEngine {
         )
         micTask = Task.detached {
             await micTranscriber.run(stream: micStream)
+        }
+    }
+
+    private func startAttendeeCapture(
+        locale: Locale,
+        transcriptionModel: TranscriptionModel,
+        vadManager: VadManager,
+        source: AttendeeAudioSource,
+        inputDeviceID: AudioDeviceID
+    ) async {
+        attendeeAudioSource = source
+        attendeeSelectedDeviceID = inputDeviceID
+
+        switch source {
+        case .systemAudio:
+            diagLog("[ENGINE-4] starting system audio capture...")
+            do {
+                let sysStreams = try await systemCapture.bufferStream()
+                diagLog("[ENGINE-5] system audio capture started OK")
+                startAttendeeTranscriber(
+                    locale: locale,
+                    vadManager: vadManager,
+                    stream: sysStreams.systemAudio
+                )
+                lastError = nil
+            } catch {
+                let msg = "Failed to start system audio: \(error.localizedDescription)"
+                diagLog("[ENGINE-5-FAIL] \(msg)")
+                lastError = msg
+            }
+        case .inputDevice:
+            guard let targetDeviceID = resolvedMicDeviceID(for: inputDeviceID) else {
+                let msg = unavailableMicMessage(for: inputDeviceID, role: "attendee microphone")
+                diagLog("[ENGINE-THEM-FAIL] \(msg)")
+                lastError = msg
+                return
+            }
+
+            diagLog("[ENGINE-THEM] starting attendee mic capture on device \(targetDeviceID)")
+            currentAttendeeMicDeviceID = targetDeviceID
+            let attendeeStream = attendeeMicCapture.bufferStream(deviceID: targetDeviceID)
+            startAttendeeTranscriber(
+                locale: locale,
+                vadManager: vadManager,
+                stream: attendeeStream
+            )
+            lastError = nil
+        }
+    }
+
+    private func startAttendeeTranscriber(
+        locale: Locale,
+        vadManager: VadManager,
+        stream: AsyncStream<AVAudioPCMBuffer>
+    ) {
+        let store = transcriptStore
+        let attendeeTranscriber = makeTranscriber(
+            locale: locale,
+            speaker: .them,
+            vadManager: vadManager,
+            onPartial: { text in
+                Task { @MainActor in store.volatileThemText = text }
+            },
+            onFinal: { text in
+                Task { @MainActor in
+                    store.volatileThemText = ""
+                    store.append(Utterance(text: text, speaker: .them))
+                }
+            }
+        )
+
+        let attendeeStream = stream
+        sysTask = Task { [attendeeTranscriber, attendeeStream] in
+            await attendeeTranscriber.run(stream: attendeeStream)
         }
     }
 
@@ -473,12 +614,12 @@ final class TranscriptionEngine {
         return MicCapture.defaultInputDeviceID()
     }
 
-    private func unavailableMicMessage(for inputDeviceID: AudioDeviceID) -> String {
+    private func unavailableMicMessage(for inputDeviceID: AudioDeviceID, role: String = "microphone") -> String {
         if inputDeviceID > 0 {
-            return "The selected microphone is no longer available."
+            return "The selected \(role) is no longer available."
         }
 
-        return "No default microphone is currently available."
+        return "No default \(role) is currently available."
     }
 
     private static func modelNeedsDownload(_ model: TranscriptionModel) -> Bool {

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -18,6 +18,62 @@ struct ContentView: View {
     @State private var audioLevel: Float = 0
 
     var body: some View {
+        rootContent
+            .frame(minWidth: 360, maxWidth: 600, minHeight: 400)
+            .background(.ultraThinMaterial)
+            .overlay { overlayContent }
+            .onChange(of: showOnboarding, initial: false) { _, isVisible in
+                if !isVisible {
+                    hasCompletedOnboarding = true
+                }
+            }
+            .onChange(of: showConsentSheet, initial: false) { _, isVisible in
+                // Auto-start session after consent is acknowledged
+                if !isVisible && settings.hasAcknowledgedRecordingConsent && !isRunning {
+                    startSession()
+                }
+            }
+            .task { await initializeIfNeeded() }
+            .onChange(of: settings.kbFolderPath, initial: false) { _, newValue in
+                if newValue.isEmpty {
+                    knowledgeBase?.clear()
+                } else {
+                    indexKBIfNeeded()
+                }
+            }
+            .onChange(of: settings.notesFolderPath, initial: false) { _, newValue in
+                handleNotesFolderChange(newValue)
+            }
+            .onChange(of: settings.voyageApiKey, initial: false) { _, _ in
+                indexKBIfNeeded()
+            }
+            .onChange(of: settings.transcriptionModel, initial: false) { _, _ in
+                transcriptionEngine?.refreshModelAvailability()
+            }
+            .onChange(of: settings.inputDeviceID, initial: false) { _, newValue in
+                if isRunning {
+                    transcriptionEngine?.restartMic(inputDeviceID: newValue)
+                }
+            }
+            .onChange(of: settings.attendeeAudioSource, initial: false) { _, _ in
+                handleAttendeeRoutingChange()
+            }
+            .onChange(of: settings.attendeeInputDeviceID, initial: false) { _, _ in
+                handleAttendeeRoutingChange()
+            }
+            .onChange(of: transcriptStore.utterances.count, initial: false) { _, _ in
+                handleNewUtterance()
+            }
+            .onKeyPress(.escape) {
+                overlayManager.hide()
+                return .handled
+            }
+            .onReceive(Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()) { _ in
+                updateAudioLevel()
+            }
+    }
+
+    private var rootContent: some View {
         VStack(spacing: 0) {
             // Compact header
             topBar
@@ -107,96 +163,20 @@ struct ContentView: View {
                 onConfirmDownload: confirmDownloadAndStart
             )
         }
-        .frame(minWidth: 360, maxWidth: 600, minHeight: 400)
-        .background(.ultraThinMaterial)
-        .overlay {
-            if showOnboarding {
-                OnboardingView(isPresented: $showOnboarding)
-                    .transition(.opacity)
-            }
-            if showConsentSheet {
-                RecordingConsentView(
-                    isPresented: $showConsentSheet,
-                    settings: settings
-                )
+    }
+
+    @ViewBuilder
+    private var overlayContent: some View {
+        if showOnboarding {
+            OnboardingView(isPresented: $showOnboarding)
                 .transition(.opacity)
-            }
         }
-        .onChange(of: showOnboarding) {
-            if !showOnboarding {
-                hasCompletedOnboarding = true
-            }
-        }
-        .onChange(of: showConsentSheet) {
-            // Auto-start session after consent is acknowledged
-            if !showConsentSheet && settings.hasAcknowledgedRecordingConsent && !isRunning {
-                startSession()
-            }
-        }
-        .task {
-            if !hasCompletedOnboarding {
-                showOnboarding = true
-            }
-            if knowledgeBase == nil {
-                let kb = KnowledgeBase(settings: settings)
-                knowledgeBase = kb
-                transcriptionEngine = TranscriptionEngine(
-                    transcriptStore: transcriptStore,
-                    settings: settings
-                )
-                suggestionEngine = SuggestionEngine(
-                    transcriptStore: transcriptStore,
-                    knowledgeBase: kb,
-                    settings: settings
-                )
-                transcriptLogger = TranscriptLogger(
-                    directory: URL(fileURLWithPath: settings.notesFolderPath)
-                )
-            }
-            indexKBIfNeeded()
-        }
-        .onChange(of: settings.kbFolderPath) {
-            if settings.kbFolderPath.isEmpty {
-                knowledgeBase?.clear()
-            } else {
-                indexKBIfNeeded()
-            }
-        }
-        .onChange(of: settings.notesFolderPath) {
-            Task {
-                await transcriptLogger?.updateDirectory(
-                    URL(fileURLWithPath: settings.notesFolderPath)
-                )
-            }
-        }
-        .onChange(of: settings.voyageApiKey) {
-            indexKBIfNeeded()
-        }
-        .onChange(of: settings.transcriptionModel) {
-            transcriptionEngine?.refreshModelAvailability()
-        }
-        .onChange(of: settings.inputDeviceID) {
-            if isRunning {
-                transcriptionEngine?.restartMic(inputDeviceID: settings.inputDeviceID)
-            }
-        }
-        .onChange(of: transcriptStore.utterances.count) {
-            handleNewUtterance()
-        }
-        .onKeyPress(.escape) {
-            overlayManager.hide()
-            return .handled
-        }
-        .onReceive(Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()) { _ in
-            guard let engine = transcriptionEngine else {
-                if audioLevel != 0 { audioLevel = 0 }
-                return
-            }
-            if engine.isRunning {
-                audioLevel = engine.audioLevel
-            } else if audioLevel != 0 {
-                audioLevel = 0
-            }
+        if showConsentSheet {
+            RecordingConsentView(
+                isPresented: $showConsentSheet,
+                settings: settings
+            )
+            .transition(.opacity)
         }
     }
 
@@ -329,6 +309,60 @@ struct ContentView: View {
         startSession()
     }
 
+    private func initializeIfNeeded() async {
+        if !hasCompletedOnboarding {
+            showOnboarding = true
+        }
+        if knowledgeBase == nil {
+            let kb = KnowledgeBase(settings: settings)
+            knowledgeBase = kb
+            transcriptionEngine = TranscriptionEngine(
+                transcriptStore: transcriptStore,
+                settings: settings
+            )
+            suggestionEngine = SuggestionEngine(
+                transcriptStore: transcriptStore,
+                knowledgeBase: kb,
+                settings: settings
+            )
+            transcriptLogger = TranscriptLogger(
+                directory: URL(fileURLWithPath: settings.notesFolderPath)
+            )
+        }
+        indexKBIfNeeded()
+    }
+
+    private func handleNotesFolderChange(_ path: String) {
+        Task {
+            await transcriptLogger?.updateDirectory(
+                URL(fileURLWithPath: path)
+            )
+        }
+    }
+
+    private func handleAttendeeRoutingChange() {
+        guard isRunning else { return }
+        guard settings.attendeeAudioSource == .systemAudio || settings.attendeeAudioSource == .inputDevice else {
+            return
+        }
+        transcriptionEngine?.restartAttendeeCapture(
+            source: settings.attendeeAudioSource,
+            inputDeviceID: settings.attendeeInputDeviceID
+        )
+    }
+
+    private func updateAudioLevel() {
+        guard let engine = transcriptionEngine else {
+            if audioLevel != 0 { audioLevel = 0 }
+            return
+        }
+        if engine.isRunning {
+            audioLevel = engine.audioLevel
+        } else if audioLevel != 0 {
+            audioLevel = 0
+        }
+    }
+
     private func startSession() {
         // Gate recording behind consent acknowledgment
         guard settings.hasAcknowledgedRecordingConsent else {
@@ -345,6 +379,8 @@ struct ContentView: View {
             await transcriptionEngine?.start(
                 locale: settings.locale,
                 inputDeviceID: settings.inputDeviceID,
+                attendeeAudioSource: settings.attendeeAudioSource,
+                attendeeInputDeviceID: settings.attendeeInputDeviceID,
                 transcriptionModel: settings.transcriptionModel
             )
         }

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -120,14 +120,39 @@ struct SettingsView: View {
                 }
             }
 
-            Section("Audio Input") {
-                Picker("Microphone", selection: $settings.inputDeviceID) {
+            Section("Audio Routing") {
+                Text("Choose which source should count as you and which source should count as the rest of the meeting.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+
+                Picker("Your microphone", selection: $settings.inputDeviceID) {
                     Text("System Default").tag(AudioDeviceID(0))
                     ForEach(inputDevices, id: \.id) { device in
                         Text(device.name).tag(device.id)
                     }
                 }
                 .font(.system(size: 12))
+
+                Picker("Meeting attendees", selection: $settings.attendeeAudioSource) {
+                    ForEach(AttendeeAudioSource.allCases) { source in
+                        Text(source.displayName).tag(source)
+                    }
+                }
+                .font(.system(size: 12))
+
+                if settings.attendeeAudioSource == .inputDevice {
+                    Picker("Attendee input", selection: $settings.attendeeInputDeviceID) {
+                        Text("System Default").tag(AudioDeviceID(0))
+                        ForEach(inputDevices, id: \.id) { device in
+                            Text(device.name).tag(device.id)
+                        }
+                    }
+                    .font(.system(size: 12))
+
+                    Text("Use this when the other side of the meeting is coming from a second microphone or headset instead of macOS system audio.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Section("Transcription") {


### PR DESCRIPTION
**Summary**
Adds configurable audio routing so OpenOats can treat your voice and the rest of the meeting as separate sources.

**What Changed**
Added a new Audio Routing section in Settings
Kept Your microphone as a selectable input device
Added Meeting attendees source selection:
System Audio
Input Device
Added a second Attendee input picker when Input Device is selected
Updated the transcription engine to route them audio from either system audio or a second microphone/input device
Added live rerouting while a session is already running
**Example Use Case**
Your microphone: AirPods
Meeting attendees: Input Device
Attendee input: MacBook microphone
This lets the app label AirPods mic input as You and the MacBook mic input as Them.

**Notes**
Speaker separation is source-based, not voiceprint-based
This works best when each side is primarily captured by a different device with minimal audio bleed
**Verification**
swift build passes
Built and tested locally via packaged macOS app/dmg