### PR TITLE
Move transcription lifecycle from ContentView to AppCoordinator

### DIFF
--- a/OpenOats/Package.swift
+++ b/OpenOats/Package.swift
@@ -21,5 +21,10 @@ let package = Package(
             path: "Sources/OpenOats",
             exclude: ["Info.plist", "OpenOats.entitlements", "Assets"]
         ),
+        .testTarget(
+            name: "OpenOatsTests",
+            dependencies: ["OpenOats"],
+            path: "Tests/OpenOatsTests"
+        ),
     ]
 )

--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -20,6 +20,7 @@ struct ExternalCommandRequest: Identifiable, Equatable {
 
 /// Shared state coordinator injected into all window scenes.
 /// Bridges the main window (transcription) and Notes window (history + generation).
+/// Owns TranscriptStore, TranscriptLogger, TranscriptionEngine, and the recording lifecycle.
 @Observable
 @MainActor
 final class AppCoordinator {
@@ -31,6 +32,9 @@ final class AppCoordinator {
 
     @ObservationIgnored private let _notesEngine = NotesEngine()
     nonisolated var notesEngine: NotesEngine { _notesEngine }
+
+    @ObservationIgnored private let _transcriptStore = TranscriptStore()
+    nonisolated var transcriptStore: TranscriptStore { _transcriptStore }
 
     @ObservationIgnored nonisolated(unsafe) private var _selectedTemplate: MeetingTemplate?
     var selectedTemplate: MeetingTemplate? {
@@ -69,14 +73,79 @@ final class AppCoordinator {
         set { withMutation(keyPath: \.sessionHistory) { _sessionHistory = newValue } }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _state: MeetingState = .idle
+    private(set) var state: MeetingState {
+        get { access(keyPath: \.state); return _state }
+        set { withMutation(keyPath: \.state) { _state = newValue } }
+    }
+
+    var transcriptLogger: TranscriptLogger?
+    var transcriptionEngine: TranscriptionEngine?
+    var refinementEngine: TranscriptRefinementEngine?
+    var audioRecorder: AudioRecorder?
+
     /// The template snapshot frozen at session start (not stop).
     private var sessionTemplateSnapshot: TemplateSnapshot?
 
-    /// Start a new recording session, optionally with a template.
-    func startSession(transcriptStore: TranscriptStore) async {
-        lastEndedSession = nil
+    /// Guard against finalization hanging forever.
+    private var finalizationTimeoutTask: Task<Void, Never>?
 
-        // Clear transcript from previous session
+    // MARK: - State Machine
+
+    /// Drive the meeting lifecycle through the state machine, then dispatch side effects.
+    func handle(_ event: MeetingEvent, settings: AppSettings? = nil) {
+        let oldState = state
+        state = transition(from: oldState, on: event)
+
+        // Only dispatch side effects when the state actually changed
+        guard state != oldState else { return }
+
+        performSideEffects(for: event, settings: settings)
+    }
+
+    // MARK: - Side Effects
+
+    private func performSideEffects(for event: MeetingEvent, settings: AppSettings?) {
+        switch event {
+        case .userStarted(let metadata):
+            Task {
+                await startTranscription(metadata: metadata, settings: settings)
+            }
+
+        case .userStopped:
+            finalizationTimeoutTask = Task {
+                try? await Task.sleep(for: .seconds(30))
+                guard !Task.isCancelled else { return }
+                handle(.finalizationTimeout)
+            }
+            Task {
+                await finalizeCurrentSession(settings: settings)
+                finalizationTimeoutTask?.cancel()
+                finalizationTimeoutTask = nil
+                handle(.finalizationComplete)
+            }
+
+        case .userDiscarded:
+            Task {
+                transcriptionEngine?.stop()
+                await transcriptLogger?.endSession()
+                transcriptStore.clear()
+                await sessionStore.endSession()
+            }
+
+        case .finalizationComplete:
+            finalizationTimeoutTask?.cancel()
+            finalizationTimeoutTask = nil
+
+        case .finalizationTimeout:
+            finalizationTimeoutTask = nil
+        }
+    }
+
+    // MARK: - Transcription Lifecycle
+
+    private func startTranscription(metadata: MeetingMetadata, settings: AppSettings?) async {
+        lastEndedSession = nil
         transcriptStore.clear()
 
         // Freeze template choice at start time
@@ -90,21 +159,32 @@ final class AppCoordinator {
 
         let templateID = selectedTemplate?.id
         await sessionStore.startSession(templateID: templateID)
+        await transcriptLogger?.startSession()
+
+        if let settings {
+            if settings.saveAudioRecording {
+                audioRecorder?.startSession()
+                transcriptionEngine?.audioRecorder = audioRecorder
+            } else {
+                transcriptionEngine?.audioRecorder = nil
+            }
+
+            await transcriptionEngine?.start(
+                locale: settings.locale,
+                inputDeviceID: settings.inputDeviceID,
+                transcriptionModel: settings.transcriptionModel
+            )
+        }
     }
 
-    /// Gracefully stop a session: drain audio, drain JSONL writes, write sidecar, close files.
-    func finalizeSession(
-        transcriptStore: TranscriptStore,
-        transcriptionEngine: TranscriptionEngine?,
-        transcriptLogger: TranscriptLogger?,
-        audioRecorder: AudioRecorder? = nil,
-        refinementEngine: TranscriptRefinementEngine? = nil
-    ) async {
+    private func finalizeCurrentSession(settings: AppSettings? = nil) async {
         // 1. Drain audio buffers (flush final speech)
         await transcriptionEngine?.finalize()
 
         // 1b. Drain pending refinements (5-second timeout)
-        await refinementEngine?.drain(timeout: .seconds(5))
+        if let settings, settings.enableTranscriptRefinement {
+            await refinementEngine?.drain(timeout: .seconds(5))
+        }
 
         // 2. Drain delayed JSONL writes
         await sessionStore.awaitPendingWrites()
@@ -136,13 +216,17 @@ final class AppCoordinator {
         await transcriptLogger?.endSession()
 
         // 6b. Merge and encode audio recording (after all audio drained)
-        await audioRecorder?.finalizeRecording()
+        if let settings, settings.saveAudioRecording {
+            await audioRecorder?.finalizeRecording()
+        }
 
         // 7. Update UI state + refresh history so Notes window sees the new session
         lastEndedSession = index
         sessionTemplateSnapshot = nil
         await loadHistory()
     }
+
+    // MARK: - History
 
     /// Load session history from sidecars (lightweight index only).
     func loadHistory() async {

--- a/OpenOats/Sources/OpenOats/Meeting/MeetingState.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/MeetingState.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+// MARK: - Meeting State
+
+/// The lifecycle state of a meeting recording session.
+/// Designed as a pure value type for testability.
+enum MeetingState: Sendable, Equatable {
+    /// No active session. The system is waiting.
+    case idle
+
+    /// A session is actively recording.
+    case recording(MeetingMetadata)
+
+    /// Recording has stopped; the session is being finalized (draining audio, writing files).
+    case ending(MeetingMetadata)
+}
+
+// MARK: - Meeting Event
+
+/// Events that drive state transitions in the meeting lifecycle.
+enum MeetingEvent: Sendable {
+    /// The user pressed Start.
+    case userStarted(MeetingMetadata)
+
+    /// The user pressed Stop.
+    case userStopped
+
+    /// The user discarded the current session (delete files, return to idle).
+    case userDiscarded
+
+    /// Finalization (drain + write sidecar) completed.
+    case finalizationComplete
+
+    /// Finalization timed out. Force transition to idle.
+    case finalizationTimeout
+}
+
+// MARK: - Pure Transition Function
+
+/// Pure function: given a state and event, returns the next state.
+/// No side effects. All side effects are dispatched by the coordinator after transition.
+func transition(from state: MeetingState, on event: MeetingEvent) -> MeetingState {
+    switch (state, event) {
+
+    // idle + userStarted -> recording
+    case (.idle, .userStarted(let metadata)):
+        return .recording(metadata)
+
+    // recording + userStopped -> ending
+    case (.recording(let metadata), .userStopped):
+        return .ending(metadata)
+
+    // recording + userDiscarded -> idle (discard without finalizing)
+    case (.recording, .userDiscarded):
+        return .idle
+
+    // ending + finalizationComplete -> idle
+    case (.ending, .finalizationComplete):
+        return .idle
+
+    // ending + finalizationTimeout -> idle (forced)
+    case (.ending, .finalizationTimeout):
+        return .idle
+
+    // All other combinations are no-ops (e.g., double-start, stop while idle)
+    default:
+        return state
+    }
+}

--- a/OpenOats/Sources/OpenOats/Meeting/MeetingTypes.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/MeetingTypes.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+// MARK: - Meeting App Detection
+
+/// A running application that may host meetings.
+struct MeetingApp: Sendable, Hashable, Codable {
+    let bundleID: String
+    let name: String
+}
+
+/// A single entry in the list of known meeting apps.
+struct MeetingAppEntry: Sendable, Hashable, Codable {
+    let bundleID: String
+    let displayName: String
+}
+
+// MARK: - Detection Signal
+
+/// Describes why the system believes a meeting started or ended.
+enum DetectionSignal: Sendable, Hashable, Codable {
+    /// User pressed Start manually.
+    case manual
+    /// A known meeting app was detected running.
+    case appLaunched(MeetingApp)
+    /// A calendar event started.
+    case calendarEvent(CalendarEvent)
+    /// Audio activity was detected from a meeting source.
+    case audioActivity
+}
+
+// MARK: - Detection Context
+
+/// Aggregated context about an active or pending meeting.
+struct DetectionContext: Sendable, Equatable, Codable {
+    let signal: DetectionSignal
+    let detectedAt: Date
+    let meetingApp: MeetingApp?
+    let calendarEvent: CalendarEvent?
+}
+
+// MARK: - Calendar Integration
+
+/// Minimal representation of a calendar event relevant to meeting detection.
+struct CalendarEvent: Sendable, Hashable, Codable, Identifiable {
+    let id: String
+    let title: String
+    let startDate: Date
+    let endDate: Date
+    let organizer: String?
+    let participants: [Participant]
+    let isOnlineMeeting: Bool
+    let meetingURL: URL?
+}
+
+/// A meeting participant from a calendar event.
+struct Participant: Sendable, Hashable, Codable {
+    let name: String?
+    let email: String?
+}
+
+// MARK: - Meeting Metadata
+
+/// Metadata assembled during a meeting session (detection context + calendar info).
+struct MeetingMetadata: Sendable, Equatable, Codable {
+    let detectionContext: DetectionContext?
+    let calendarEvent: CalendarEvent?
+    let title: String?
+    let startedAt: Date
+    var endedAt: Date?
+}

--- a/OpenOats/Sources/OpenOats/Storage/SessionStore.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionStore.swift
@@ -300,4 +300,39 @@ actor SessionStore {
     }
 
     var sessionsDirectoryURL: URL { sessionsDirectory }
+
+    // MARK: - Recently Deleted
+
+    private var recentlyDeletedDirectory: URL {
+        sessionsDirectory.appendingPathComponent(".recently-deleted", isDirectory: true)
+    }
+
+    /// Move a session's JSONL and sidecar files to .recently-deleted/.
+    func moveToRecentlyDeleted(sessionID: String) {
+        let fm = FileManager.default
+        try? fm.createDirectory(at: recentlyDeletedDirectory, withIntermediateDirectories: true)
+
+        let jsonl = jsonlURL(for: sessionID)
+        let sidecar = sidecarURL(for: sessionID)
+
+        if fm.fileExists(atPath: jsonl.path) {
+            let dest = recentlyDeletedDirectory.appendingPathComponent(jsonl.lastPathComponent)
+            try? fm.moveItem(at: jsonl, to: dest)
+        }
+        if fm.fileExists(atPath: sidecar.path) {
+            let dest = recentlyDeletedDirectory.appendingPathComponent(sidecar.lastPathComponent)
+            try? fm.moveItem(at: sidecar, to: dest)
+        }
+    }
+
+    /// Permanently remove all files in the .recently-deleted/ folder.
+    func purgeRecentlyDeleted() {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: recentlyDeletedDirectory, includingPropertiesForKeys: nil) else {
+            return
+        }
+        for file in files {
+            try? fm.removeItem(at: file)
+        }
+    }
 }

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -33,13 +33,8 @@ struct ContentView: View {
     @Bindable var settings: AppSettings
     @Environment(AppCoordinator.self) private var coordinator
     @Environment(\.openWindow) private var openWindow
-    @State private var transcriptStore = TranscriptStore()
     @State private var knowledgeBase: KnowledgeBase?
-    @State private var transcriptionEngine: TranscriptionEngine?
     @State private var suggestionEngine: SuggestionEngine?
-    @State private var transcriptLogger: TranscriptLogger?
-    @State private var refinementEngine: TranscriptRefinementEngine?
-    @State private var audioRecorder: AudioRecorder?
     @State private var overlayManager = OverlayManager()
     @AppStorage("isTranscriptExpanded") private var isTranscriptExpanded = true
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
@@ -263,23 +258,23 @@ struct ContentView: View {
             if knowledgeBase == nil {
                 let kb = KnowledgeBase(settings: settings)
                 knowledgeBase = kb
-                transcriptionEngine = TranscriptionEngine(
-                    transcriptStore: transcriptStore,
+                coordinator.transcriptionEngine = TranscriptionEngine(
+                    transcriptStore: coordinator.transcriptStore,
                     settings: settings
                 )
                 suggestionEngine = SuggestionEngine(
-                    transcriptStore: transcriptStore,
+                    transcriptStore: coordinator.transcriptStore,
                     knowledgeBase: kb,
                     settings: settings
                 )
-                transcriptLogger = TranscriptLogger(
+                coordinator.transcriptLogger = TranscriptLogger(
                     directory: URL(fileURLWithPath: settings.notesFolderPath)
                 )
-                refinementEngine = TranscriptRefinementEngine(
+                coordinator.refinementEngine = TranscriptRefinementEngine(
                     settings: settings,
-                    transcriptStore: transcriptStore
+                    transcriptStore: coordinator.transcriptStore
                 )
-                audioRecorder = AudioRecorder(
+                coordinator.audioRecorder = AudioRecorder(
                     outputDirectory: URL(fileURLWithPath: settings.notesFolderPath)
                 )
             }
@@ -318,34 +313,24 @@ struct ContentView: View {
             return
         }
 
-        Task {
-            suggestionEngine?.clear()
-            await coordinator.startSession(transcriptStore: transcriptStore)
-            await transcriptLogger?.startSession()
-            if settings.saveAudioRecording {
-                audioRecorder?.startSession()
-                transcriptionEngine?.audioRecorder = audioRecorder
-            } else {
-                transcriptionEngine?.audioRecorder = nil
-            }
-            await transcriptionEngine?.start(
-                locale: settings.locale,
-                inputDeviceID: settings.inputDeviceID,
-                transcriptionModel: settings.transcriptionModel
-            )
-        }
+        suggestionEngine?.clear()
+        let metadata = MeetingMetadata(
+            detectionContext: DetectionContext(
+                signal: .manual,
+                detectedAt: Date(),
+                meetingApp: nil,
+                calendarEvent: nil
+            ),
+            calendarEvent: nil,
+            title: nil,
+            startedAt: Date(),
+            endedAt: nil
+        )
+        coordinator.handle(.userStarted(metadata), settings: settings)
     }
 
     private func stopSession() {
-        Task {
-            await coordinator.finalizeSession(
-                transcriptStore: transcriptStore,
-                transcriptionEngine: transcriptionEngine,
-                transcriptLogger: transcriptLogger,
-                audioRecorder: settings.saveAudioRecording ? audioRecorder : nil,
-                refinementEngine: settings.enableTranscriptRefinement ? refinementEngine : nil
-            )
-        }
+        coordinator.handle(.userStopped, settings: settings)
     }
 
     private func toggleOverlay() {
@@ -380,7 +365,7 @@ struct ContentView: View {
 
         switch request.command {
         case .startSession:
-            guard transcriptionEngine != nil, suggestionEngine != nil, transcriptLogger != nil else {
+            guard coordinator.transcriptionEngine != nil, suggestionEngine != nil, coordinator.transcriptLogger != nil else {
                 return
             }
             if !viewState.isRunning {
@@ -401,7 +386,7 @@ struct ContentView: View {
     private func handleNewUtterance(_ last: Utterance) {
         // Persist to transcript log
         Task {
-            await transcriptLogger?.append(
+            await coordinator.transcriptLogger?.append(
                 speaker: last.speaker == .you ? "You" : "Them",
                 text: last.text,
                 timestamp: last.timestamp
@@ -409,7 +394,7 @@ struct ContentView: View {
         }
 
         // Trigger transcript refinement if enabled
-        if settings.enableTranscriptRefinement, let engine = refinementEngine {
+        if settings.enableTranscriptRefinement, let engine = coordinator.refinementEngine {
             Task {
                 await engine.refine(last)
             }
@@ -430,7 +415,7 @@ struct ContentView: View {
                     baseRecord: baseRecord,
                     utteranceID: last.id,
                     suggestionEngine: suggestionEngine,
-                    transcriptStore: transcriptStore
+                    transcriptStore: coordinator.transcriptStore
                 )
             }
         } else {
@@ -446,7 +431,7 @@ struct ContentView: View {
     }
 
     private func handleNewUtterances(startingAt startIndex: Int) {
-        let utterances = transcriptStore.utterances
+        let utterances = coordinator.transcriptStore.utterances
         guard startIndex < utterances.count else { return }
 
         for utterance in utterances[startIndex...] {
@@ -467,21 +452,21 @@ struct ContentView: View {
         }
 
         var nextViewState = ViewState()
-        nextViewState.isRunning = transcriptionEngine?.isRunning ?? false
+        nextViewState.isRunning = coordinator.transcriptionEngine?.isRunning ?? false
         nextViewState.lastEndedSession = lastEndedSession
         nextViewState.lastSessionHasNotes = lastSessionHasNotes
         nextViewState.modelDisplayName = activeModelRaw.split(separator: "/").last.map(String.init) ?? activeModelRaw
         nextViewState.transcriptionPrompt = settings.transcriptionModel.downloadPrompt
-        nextViewState.statusMessage = transcriptionEngine?.assetStatus
-        nextViewState.errorMessage = transcriptionEngine?.lastError
-        nextViewState.needsDownload = transcriptionEngine?.needsModelDownload ?? false
+        nextViewState.statusMessage = coordinator.transcriptionEngine?.assetStatus
+        nextViewState.errorMessage = coordinator.transcriptionEngine?.lastError
+        nextViewState.needsDownload = coordinator.transcriptionEngine?.needsModelDownload ?? false
         nextViewState.kbIndexingProgress = knowledgeBase?.indexingProgress ?? ""
         nextViewState.suggestions = suggestionEngine?.suggestions ?? []
         nextViewState.isGeneratingSuggestions = suggestionEngine?.isGenerating ?? false
         nextViewState.showLiveTranscript = settings.showLiveTranscript
-        nextViewState.utterances = transcriptStore.utterances
-        nextViewState.volatileYouText = transcriptStore.volatileYouText
-        nextViewState.volatileThemText = transcriptStore.volatileThemText
+        nextViewState.utterances = coordinator.transcriptStore.utterances
+        nextViewState.volatileYouText = coordinator.transcriptStore.volatileYouText
+        nextViewState.volatileThemText = coordinator.transcriptStore.volatileThemText
         nextViewState.kbFolderPath = settings.kbFolderPath
         nextViewState.notesFolderPath = settings.notesFolderPath
         nextViewState.voyageApiKey = settings.voyageApiKey
@@ -508,9 +493,9 @@ struct ContentView: View {
             observedNotesFolderPath = currentViewState.notesFolderPath
             let url = URL(fileURLWithPath: currentViewState.notesFolderPath)
             Task {
-                await transcriptLogger?.updateDirectory(url)
+                await coordinator.transcriptLogger?.updateDirectory(url)
             }
-            audioRecorder?.updateDirectory(url)
+            coordinator.audioRecorder?.updateDirectory(url)
         }
 
         if currentViewState.voyageApiKey != observedVoyageApiKey {
@@ -520,14 +505,14 @@ struct ContentView: View {
 
         if currentViewState.transcriptionModel != observedTranscriptionModel {
             observedTranscriptionModel = currentViewState.transcriptionModel
-            transcriptionEngine?.refreshModelAvailability()
+            coordinator.transcriptionEngine?.refreshModelAvailability()
         }
 
         if currentViewState.inputDeviceID != observedInputDeviceID {
             observedInputDeviceID = currentViewState.inputDeviceID
             if currentViewState.isRunning {
                 Task {
-                    transcriptionEngine?.restartMic(inputDeviceID: currentViewState.inputDeviceID)
+                    coordinator.transcriptionEngine?.restartMic(inputDeviceID: currentViewState.inputDeviceID)
                 }
             }
         }
@@ -555,7 +540,7 @@ struct ContentView: View {
         }
 
         if currentViewState.isRunning {
-            audioLevel = transcriptionEngine?.audioLevel ?? 0
+            audioLevel = coordinator.transcriptionEngine?.audioLevel ?? 0
         } else if audioLevel != 0 {
             audioLevel = 0
         }
@@ -571,7 +556,7 @@ struct ContentView: View {
                 startSession()
             }
         case .confirmDownload:
-            transcriptionEngine?.downloadConfirmed = true
+            coordinator.transcriptionEngine?.downloadConfirmed = true
             startSession()
         }
     }

--- a/OpenOats/Tests/OpenOatsTests/MeetingStateTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MeetingStateTests.swift
@@ -1,0 +1,542 @@
+import XCTest
+@testable import OpenOats
+
+final class MeetingStateTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeMetadata(
+        title: String? = nil,
+        startedAt: Date = Date(timeIntervalSince1970: 1_000_000)
+    ) -> MeetingMetadata {
+        MeetingMetadata(
+            detectionContext: nil,
+            calendarEvent: nil,
+            title: title,
+            startedAt: startedAt,
+            endedAt: nil
+        )
+    }
+
+    private func makeMetadataWithApp(
+        bundleID: String = "us.zoom.xos",
+        name: String = "Zoom"
+    ) -> MeetingMetadata {
+        let app = MeetingApp(bundleID: bundleID, name: name)
+        let signal = DetectionSignal.appLaunched(app)
+        let ctx = DetectionContext(
+            signal: signal,
+            detectedAt: Date(timeIntervalSince1970: 1_000_000),
+            meetingApp: app,
+            calendarEvent: nil
+        )
+        return MeetingMetadata(
+            detectionContext: ctx,
+            calendarEvent: nil,
+            title: nil,
+            startedAt: Date(timeIntervalSince1970: 1_000_000),
+            endedAt: nil
+        )
+    }
+
+    private func makeCalendarEvent(
+        id: String = "evt-1",
+        title: String = "Sprint Planning",
+        startDate: Date = Date(timeIntervalSince1970: 1_000_000),
+        endDate: Date = Date(timeIntervalSince1970: 1_003_600)
+    ) -> CalendarEvent {
+        CalendarEvent(
+            id: id,
+            title: title,
+            startDate: startDate,
+            endDate: endDate,
+            organizer: "alice@example.com",
+            participants: [
+                Participant(name: "Alice", email: "alice@example.com"),
+                Participant(name: "Bob", email: "bob@example.com"),
+            ],
+            isOnlineMeeting: true,
+            meetingURL: URL(string: "https://meet.example.com/abc")
+        )
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: - Idle State Tests
+    // -------------------------------------------------------------------------
+
+    func testIdleIsDefault() {
+        let state: MeetingState = .idle
+        XCTAssertEqual(state, .idle)
+    }
+
+    func testIdleUserStartedTransitionsToRecording() {
+        let meta = makeMetadata(title: "Standup")
+        let next = transition(from: .idle, on: .userStarted(meta))
+        if case .recording(let m) = next {
+            XCTAssertEqual(m.title, "Standup")
+        } else {
+            XCTFail("Expected .recording, got \(next)")
+        }
+    }
+
+    func testIdleUserStoppedIsNoOp() {
+        let next = transition(from: .idle, on: .userStopped)
+        XCTAssertEqual(next, .idle)
+    }
+
+    func testIdleUserDiscardedIsNoOp() {
+        let next = transition(from: .idle, on: .userDiscarded)
+        XCTAssertEqual(next, .idle)
+    }
+
+    func testIdleFinalizationCompleteIsNoOp() {
+        let next = transition(from: .idle, on: .finalizationComplete)
+        XCTAssertEqual(next, .idle)
+    }
+
+    func testIdleFinalizationTimeoutIsNoOp() {
+        let next = transition(from: .idle, on: .finalizationTimeout)
+        XCTAssertEqual(next, .idle)
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: - Recording State Tests
+    // -------------------------------------------------------------------------
+
+    func testRecordingUserStoppedTransitionsToEnding() {
+        let meta = makeMetadata()
+        let state = MeetingState.recording(meta)
+        let next = transition(from: state, on: .userStopped)
+        if case .ending = next {
+            // pass
+        } else {
+            XCTFail("Expected .ending, got \(next)")
+        }
+    }
+
+    func testRecordingUserDiscardedTransitionsToIdle() {
+        let meta = makeMetadata()
+        let state = MeetingState.recording(meta)
+        let next = transition(from: state, on: .userDiscarded)
+        XCTAssertEqual(next, .idle)
+    }
+
+    func testRecordingDoubleStartIsNoOp() {
+        let meta = makeMetadata(title: "First")
+        let state = MeetingState.recording(meta)
+        let meta2 = makeMetadata(title: "Second")
+        let next = transition(from: state, on: .userStarted(meta2))
+        if case .recording(let m) = next {
+            XCTAssertEqual(m.title, "First", "Double start should keep original metadata")
+        } else {
+            XCTFail("Expected .recording, got \(next)")
+        }
+    }
+
+    func testRecordingFinalizationCompleteIsNoOp() {
+        let meta = makeMetadata()
+        let state = MeetingState.recording(meta)
+        let next = transition(from: state, on: .finalizationComplete)
+        if case .recording = next {
+            // pass
+        } else {
+            XCTFail("Expected .recording, got \(next)")
+        }
+    }
+
+    func testRecordingFinalizationTimeoutIsNoOp() {
+        let meta = makeMetadata()
+        let state = MeetingState.recording(meta)
+        let next = transition(from: state, on: .finalizationTimeout)
+        if case .recording = next {
+            // pass
+        } else {
+            XCTFail("Expected .recording, got \(next)")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: - Ending State Tests
+    // -------------------------------------------------------------------------
+
+    func testEndingFinalizationCompleteTransitionsToIdle() {
+        let meta = makeMetadata()
+        let state = MeetingState.ending(meta)
+        let next = transition(from: state, on: .finalizationComplete)
+        XCTAssertEqual(next, .idle)
+    }
+
+    func testEndingFinalizationTimeoutTransitionsToIdle() {
+        let meta = makeMetadata()
+        let state = MeetingState.ending(meta)
+        let next = transition(from: state, on: .finalizationTimeout)
+        XCTAssertEqual(next, .idle)
+    }
+
+    func testEndingUserStartedIsNoOp() {
+        let meta = makeMetadata(title: "Ending")
+        let state = MeetingState.ending(meta)
+        let meta2 = makeMetadata(title: "New")
+        let next = transition(from: state, on: .userStarted(meta2))
+        if case .ending(let m) = next {
+            XCTAssertEqual(m.title, "Ending", "Should not start new session while ending")
+        } else {
+            XCTFail("Expected .ending, got \(next)")
+        }
+    }
+
+    func testEndingUserStoppedIsNoOp() {
+        let meta = makeMetadata()
+        let state = MeetingState.ending(meta)
+        let next = transition(from: state, on: .userStopped)
+        if case .ending = next {
+            // pass
+        } else {
+            XCTFail("Expected .ending, got \(next)")
+        }
+    }
+
+    func testEndingUserDiscardedIsNoOp() {
+        let meta = makeMetadata()
+        let state = MeetingState.ending(meta)
+        let next = transition(from: state, on: .userDiscarded)
+        if case .ending = next {
+            // pass
+        } else {
+            XCTFail("Expected .ending, got \(next)")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: - Full Lifecycle Tests
+    // -------------------------------------------------------------------------
+
+    func testFullHappyPath() {
+        var state: MeetingState = .idle
+        let meta = makeMetadata(title: "1:1")
+
+        // Start
+        state = transition(from: state, on: .userStarted(meta))
+        if case .recording = state {} else { XCTFail("Expected .recording") }
+
+        // Stop
+        state = transition(from: state, on: .userStopped)
+        if case .ending = state {} else { XCTFail("Expected .ending") }
+
+        // Finalize
+        state = transition(from: state, on: .finalizationComplete)
+        XCTAssertEqual(state, .idle)
+    }
+
+    func testDiscardPath() {
+        var state: MeetingState = .idle
+        let meta = makeMetadata()
+
+        state = transition(from: state, on: .userStarted(meta))
+        if case .recording = state {} else { XCTFail("Expected .recording") }
+
+        state = transition(from: state, on: .userDiscarded)
+        XCTAssertEqual(state, .idle)
+    }
+
+    func testTimeoutPath() {
+        var state: MeetingState = .idle
+        let meta = makeMetadata()
+
+        state = transition(from: state, on: .userStarted(meta))
+        state = transition(from: state, on: .userStopped)
+        if case .ending = state {} else { XCTFail("Expected .ending") }
+
+        state = transition(from: state, on: .finalizationTimeout)
+        XCTAssertEqual(state, .idle)
+    }
+
+    func testMultipleSessionsSequentially() {
+        var state: MeetingState = .idle
+
+        for i in 1...3 {
+            let meta = makeMetadata(title: "Session \(i)")
+            state = transition(from: state, on: .userStarted(meta))
+            if case .recording(let m) = state {
+                XCTAssertEqual(m.title, "Session \(i)")
+            } else {
+                XCTFail("Expected .recording for session \(i)")
+            }
+            state = transition(from: state, on: .userStopped)
+            state = transition(from: state, on: .finalizationComplete)
+            XCTAssertEqual(state, .idle)
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: - Metadata Preservation Tests
+    // -------------------------------------------------------------------------
+
+    func testMetadataPreservedFromRecordingToEnding() {
+        let meta = makeMetadata(title: "Planning", startedAt: Date(timeIntervalSince1970: 999))
+        let state = MeetingState.recording(meta)
+        let next = transition(from: state, on: .userStopped)
+        if case .ending(let m) = next {
+            XCTAssertEqual(m.title, "Planning")
+            XCTAssertEqual(m.startedAt, Date(timeIntervalSince1970: 999))
+        } else {
+            XCTFail("Expected .ending with metadata")
+        }
+    }
+
+    func testDetectionContextPreservedInMetadata() {
+        let meta = makeMetadataWithApp()
+        let state = transition(from: .idle, on: .userStarted(meta))
+        if case .recording(let m) = state {
+            XCTAssertNotNil(m.detectionContext)
+            XCTAssertEqual(m.detectionContext?.meetingApp?.bundleID, "us.zoom.xos")
+        } else {
+            XCTFail("Expected .recording")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: - MeetingTypes Tests
+    // -------------------------------------------------------------------------
+
+    func testMeetingAppEquality() {
+        let a = MeetingApp(bundleID: "us.zoom.xos", name: "Zoom")
+        let b = MeetingApp(bundleID: "us.zoom.xos", name: "Zoom")
+        XCTAssertEqual(a, b)
+    }
+
+    func testMeetingAppInequality() {
+        let a = MeetingApp(bundleID: "us.zoom.xos", name: "Zoom")
+        let b = MeetingApp(bundleID: "com.microsoft.teams2", name: "Teams")
+        XCTAssertNotEqual(a, b)
+    }
+
+    func testCalendarEventIdentifiable() {
+        let event = makeCalendarEvent()
+        XCTAssertEqual(event.id, "evt-1")
+        XCTAssertEqual(event.title, "Sprint Planning")
+        XCTAssertTrue(event.isOnlineMeeting)
+        XCTAssertEqual(event.participants.count, 2)
+    }
+
+    func testParticipantFields() {
+        let p = Participant(name: "Alice", email: "alice@example.com")
+        XCTAssertEqual(p.name, "Alice")
+        XCTAssertEqual(p.email, "alice@example.com")
+    }
+
+    func testParticipantOptionalFields() {
+        let p = Participant(name: nil, email: nil)
+        XCTAssertNil(p.name)
+        XCTAssertNil(p.email)
+    }
+
+    func testDetectionSignalManual() {
+        let signal = DetectionSignal.manual
+        XCTAssertEqual(signal, .manual)
+    }
+
+    func testDetectionSignalAppLaunched() {
+        let app = MeetingApp(bundleID: "us.zoom.xos", name: "Zoom")
+        let signal = DetectionSignal.appLaunched(app)
+        if case .appLaunched(let a) = signal {
+            XCTAssertEqual(a.bundleID, "us.zoom.xos")
+        } else {
+            XCTFail("Expected .appLaunched")
+        }
+    }
+
+    func testDetectionSignalCalendarEvent() {
+        let event = makeCalendarEvent()
+        let signal = DetectionSignal.calendarEvent(event)
+        if case .calendarEvent(let e) = signal {
+            XCTAssertEqual(e.title, "Sprint Planning")
+        } else {
+            XCTFail("Expected .calendarEvent")
+        }
+    }
+
+    func testDetectionSignalAudioActivity() {
+        let signal = DetectionSignal.audioActivity
+        XCTAssertEqual(signal, .audioActivity)
+    }
+
+    func testDetectionContext() {
+        let app = MeetingApp(bundleID: "us.zoom.xos", name: "Zoom")
+        let ctx = DetectionContext(
+            signal: .appLaunched(app),
+            detectedAt: Date(timeIntervalSince1970: 1_000_000),
+            meetingApp: app,
+            calendarEvent: nil
+        )
+        XCTAssertNotNil(ctx.meetingApp)
+        XCTAssertNil(ctx.calendarEvent)
+    }
+
+    func testMeetingMetadataBasic() {
+        let meta = makeMetadata(title: "Retro")
+        XCTAssertEqual(meta.title, "Retro")
+        XCTAssertNil(meta.endedAt)
+        XCTAssertNil(meta.detectionContext)
+    }
+
+    func testMeetingMetadataWithEndDate() {
+        var meta = makeMetadata()
+        meta.endedAt = Date(timeIntervalSince1970: 2_000_000)
+        XCTAssertNotNil(meta.endedAt)
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: - Encoding / Decoding Tests
+    // -------------------------------------------------------------------------
+
+    func testMeetingAppCodable() throws {
+        let app = MeetingApp(bundleID: "us.zoom.xos", name: "Zoom")
+        let data = try JSONEncoder().encode(app)
+        let decoded = try JSONDecoder().decode(MeetingApp.self, from: data)
+        XCTAssertEqual(decoded, app)
+    }
+
+    func testCalendarEventCodable() throws {
+        let event = makeCalendarEvent()
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(event)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(CalendarEvent.self, from: data)
+        XCTAssertEqual(decoded.id, event.id)
+        XCTAssertEqual(decoded.title, event.title)
+        XCTAssertEqual(decoded.participants.count, event.participants.count)
+    }
+
+    func testDetectionSignalManualCodable() throws {
+        let signal = DetectionSignal.manual
+        let data = try JSONEncoder().encode(signal)
+        let decoded = try JSONDecoder().decode(DetectionSignal.self, from: data)
+        XCTAssertEqual(decoded, signal)
+    }
+
+    func testDetectionSignalAppLaunchedCodable() throws {
+        let app = MeetingApp(bundleID: "us.zoom.xos", name: "Zoom")
+        let signal = DetectionSignal.appLaunched(app)
+        let data = try JSONEncoder().encode(signal)
+        let decoded = try JSONDecoder().decode(DetectionSignal.self, from: data)
+        XCTAssertEqual(decoded, signal)
+    }
+
+    func testMeetingMetadataCodable() throws {
+        let meta = makeMetadataWithApp()
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(meta)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(MeetingMetadata.self, from: data)
+        XCTAssertEqual(decoded.detectionContext?.meetingApp?.bundleID, "us.zoom.xos")
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: - Edge Cases
+    // -------------------------------------------------------------------------
+
+    func testRapidStartStop() {
+        var state: MeetingState = .idle
+        let meta = makeMetadata()
+        state = transition(from: state, on: .userStarted(meta))
+        state = transition(from: state, on: .userStopped)
+        state = transition(from: state, on: .finalizationComplete)
+        XCTAssertEqual(state, .idle)
+    }
+
+    func testStopWhileIdleIsHarmless() {
+        let state: MeetingState = .idle
+        let next = transition(from: state, on: .userStopped)
+        XCTAssertEqual(next, .idle)
+    }
+
+    func testDiscardWhileIdleIsHarmless() {
+        let state: MeetingState = .idle
+        let next = transition(from: state, on: .userDiscarded)
+        XCTAssertEqual(next, .idle)
+    }
+
+    func testDoubleFinalizationIsHarmless() {
+        let meta = makeMetadata()
+        var state = MeetingState.ending(meta)
+        state = transition(from: state, on: .finalizationComplete)
+        XCTAssertEqual(state, .idle)
+        // Second finalization on idle is a no-op
+        state = transition(from: state, on: .finalizationComplete)
+        XCTAssertEqual(state, .idle)
+    }
+
+    func testDiscardWhileEndingIsNoOp() {
+        let meta = makeMetadata()
+        let state = MeetingState.ending(meta)
+        let next = transition(from: state, on: .userDiscarded)
+        if case .ending = next {
+            // Discard during finalization is ignored
+        } else {
+            XCTFail("Expected .ending, got \(next)")
+        }
+    }
+
+    func testStartWhileEndingIsNoOp() {
+        let meta = makeMetadata(title: "Old")
+        let state = MeetingState.ending(meta)
+        let newMeta = makeMetadata(title: "New")
+        let next = transition(from: state, on: .userStarted(newMeta))
+        if case .ending(let m) = next {
+            XCTAssertEqual(m.title, "Old")
+        } else {
+            XCTFail("Expected .ending with old metadata")
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: - MeetingState Equatable
+    // -------------------------------------------------------------------------
+
+    func testIdleEqualsIdle() {
+        XCTAssertEqual(MeetingState.idle, MeetingState.idle)
+    }
+
+    func testRecordingNotEqualToIdle() {
+        let meta = makeMetadata()
+        XCTAssertNotEqual(MeetingState.recording(meta), MeetingState.idle)
+    }
+
+    func testEndingNotEqualToRecording() {
+        let meta = makeMetadata()
+        XCTAssertNotEqual(MeetingState.ending(meta), MeetingState.recording(meta))
+    }
+
+    func testEndingNotEqualToIdle() {
+        let meta = makeMetadata()
+        XCTAssertNotEqual(MeetingState.ending(meta), MeetingState.idle)
+    }
+
+    // -------------------------------------------------------------------------
+    // MARK: - MeetingAppEntry Tests
+    // -------------------------------------------------------------------------
+
+    func testMeetingAppEntryFields() {
+        let entry = MeetingAppEntry(bundleID: "com.apple.FaceTime", displayName: "FaceTime")
+        XCTAssertEqual(entry.bundleID, "com.apple.FaceTime")
+        XCTAssertEqual(entry.displayName, "FaceTime")
+    }
+
+    func testMeetingAppEntryEquality() {
+        let a = MeetingAppEntry(bundleID: "com.slack.Slack", displayName: "Slack")
+        let b = MeetingAppEntry(bundleID: "com.slack.Slack", displayName: "Slack")
+        XCTAssertEqual(a, b)
+    }
+
+    func testMeetingAppEntryCodable() throws {
+        let entry = MeetingAppEntry(bundleID: "us.zoom.xos", displayName: "Zoom")
+        let data = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(MeetingAppEntry.self, from: data)
+        XCTAssertEqual(decoded, entry)
+    }
+}


### PR DESCRIPTION
Part of #26.

## What this does

Moves session lifecycle management (start, stop, finalize) out of ContentView and into AppCoordinator behind a state machine. Separates UI rendering from business logic.

## Changes

- Add `MeetingState` enum (idle / recording / ending) with validated transitions
- Add `MeetingTypes` with session metadata structures
- Move TranscriptStore, Logger, and TranscriptionEngine ownership from ContentView to AppCoordinator
- Add recently-deleted session management to SessionStore
- Simplify ContentView to observe coordinator state rather than manage it directly
- Add 52 tests covering state transitions, invalid transition rejection, and edge cases

## Why

Moving lifecycle management to a coordinator with a validated state machine makes the app's recording logic reusable and testable independent of the UI. This is useful for any new trigger for starting/stopping recording: keyboard shortcuts, menu bar actions, automation, or the meeting detection proposed in #33.

Zero user-facing behavior change. Same UI, same flows, same settings.

## Testing

- `swift test` passes (52 tests, 0 failures)
- Manual test of start/stop/finalize recording flow
- Verified transcript saving, model selection, and folder separation all work as before

Happy to adjust based on your feedback.