### PR TITLE
Fix MainActor observation crash and harden mic routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@ OpenOats/.build/
 data/
 CLAUDE.md
 AGENTS.md
+
+# Local OS/editor artifacts
+.DS_Store
+.cursor/*.log
+
+# Local crash and package artifacts
+*.ips
+*.dmg

--- a/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
@@ -9,10 +9,12 @@ private let micLog = Logger(subsystem: "com.openoats", category: "MicCapture")
 final class MicCapture: @unchecked Sendable {
     private let engine = AVAudioEngine()
     private let _audioLevel = AudioLevel()
+    private let _hasCapturedFrames = SyncBool()
     private let _error = SyncString()
     private let _streamContinuation = OSAllocatedUnfairLock<AsyncStream<AVAudioPCMBuffer>.Continuation?>(uncheckedState: nil)
 
     var audioLevel: Float { _audioLevel.value }
+    var hasCapturedFrames: Bool { _hasCapturedFrames.value }
     var captureError: String? { _error.value }
 
     /// Set a specific input device by its AudioDeviceID. Pass nil to use system default.
@@ -31,34 +33,89 @@ final class MicCapture: @unchecked Sendable {
     }
 
     func bufferStream(deviceID: AudioDeviceID? = nil) -> AsyncStream<AVAudioPCMBuffer> {
+        // Defensive cleanup of any prior state
+        _streamContinuation.withLock { $0?.finish(); $0 = nil }
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+
         let level = _audioLevel
         let errorHolder = _error
 
         return AsyncStream { continuation in
             self._streamContinuation.withLock { $0 = continuation }
             errorHolder.value = nil
+            self._hasCapturedFrames.value = false
 
             diagLog("[MIC-1] bufferStream called, deviceID=\(String(describing: deviceID))")
 
-            // Set input device before accessing inputNode format
+            // Resolve the target device ID (explicit or system default)
+            let targetDevID: AudioDeviceID
             if let id = deviceID {
-                let inputNode = self.engine.inputNode
-                let audioUnit = inputNode.audioUnit!
-                var devID = id
-                let status = AudioUnitSetProperty(
-                    audioUnit,
+                targetDevID = id
+            } else if let defaultID = Self.defaultInputDeviceID() {
+                targetDevID = defaultID
+            } else {
+                let msg = "No input device available"
+                diagLog("[MIC-2-FAIL] \(msg)")
+                errorHolder.value = msg
+                continuation.finish()
+                return
+            }
+
+            // Prepare the engine first so audioUnit properties are available.
+            // reset() destroys audio units, so we must prepare() before
+            // accessing .audioUnit on any node.
+            self.engine.reset()
+            self.engine.prepare()
+
+            let inputNode = self.engine.inputNode
+
+            // Set input device before accessing inputNode format
+            guard let inAU = inputNode.audioUnit else {
+                let msg = "inputNode has no audio unit after prepare"
+                diagLog("[MIC-2-FAIL] \(msg)")
+                errorHolder.value = msg
+                continuation.finish()
+                return
+            }
+
+            var devID = targetDevID
+            let outputChannels = Self.channelCount(for: targetDevID, scope: kAudioDevicePropertyScopeOutput)
+            // For input-only devices, explicit AU device binding is fragile and
+            // repeatedly fails at engine.start (-10875 / !dev). Let AVAudioEngine
+            // negotiate routing itself instead of forcing CurrentDevice.
+            let shouldBindDevices = outputChannels > 0
+            if shouldBindDevices {
+                let inStatus = AudioUnitSetProperty(
+                    inAU,
                     kAudioOutputUnitProperty_CurrentDevice,
                     kAudioUnitScope_Global,
                     0,
                     &devID,
                     UInt32(MemoryLayout<AudioDeviceID>.size)
                 )
-                diagLog("[MIC-2] setInputDevice status=\(status) (0=ok)")
+                diagLog("[MIC-2] setInputDevice status=\(inStatus) (0=ok)")
             } else {
-                diagLog("[MIC-2] no deviceID, using system default")
+                diagLog("[MIC-2] skipping explicit input device set for input-only target")
             }
 
-            let inputNode = self.engine.inputNode
+            // Only force outputNode device when the selected mic device can output.
+            // Input-only devices trigger engine.start failures if assigned to output.
+            if shouldBindDevices, let outAU = self.engine.outputNode.audioUnit {
+                devID = targetDevID
+                let outStatus = AudioUnitSetProperty(
+                    outAU,
+                    kAudioOutputUnitProperty_CurrentDevice,
+                    kAudioUnitScope_Global,
+                    0,
+                    &devID,
+                    UInt32(MemoryLayout<AudioDeviceID>.size)
+                )
+                diagLog("[MIC-2b] setOutputDevice status=\(outStatus) (0=ok)")
+            } else {
+                diagLog("[MIC-2b] skipping output device set (outputChannels=\(outputChannels))")
+            }
+
             let format = inputNode.outputFormat(forBus: 0)
 
             diagLog("[MIC-3] inputNode format: sr=\(format.sampleRate) ch=\(format.channelCount) interleaved=\(format.isInterleaved) commonFormat=\(format.commonFormat.rawValue)")
@@ -84,9 +141,21 @@ final class MicCapture: @unchecked Sendable {
 
             diagLog("[MIC-4] tapFormat: sr=\(tapFormat.sampleRate) ch=\(tapFormat.channelCount)")
 
+            if shouldBindDevices {
+                // Connect inputNode → mainMixerNode to establish the audio pull chain.
+                // Use nil format so CoreAudio negotiates the hardware-native stream format.
+                let mixer = self.engine.mainMixerNode
+                self.engine.connect(inputNode, to: mixer, format: nil)
+                mixer.volume = 0   // Don't play mic input through speakers
+                diagLog("[MIC-4b] connected inputNode → mainMixer (volume=0)")
+            } else {
+                diagLog("[MIC-4b] skipping inputNode → mainMixer connect for input-only routing")
+            }
+
             var tapCallCount = 0
-            inputNode.installTap(onBus: 0, bufferSize: 4096, format: tapFormat) { buffer, _ in
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: nil) { buffer, _ in
                 tapCallCount += 1
+                self._hasCapturedFrames.value = true
                 let rms = Self.normalizedRMS(from: buffer)
                 level.value = min(rms * 25, 1.0)
 
@@ -106,8 +175,7 @@ final class MicCapture: @unchecked Sendable {
             }
 
             do {
-                self.engine.prepare()
-                diagLog("[MIC-7] engine prepared, starting...")
+                diagLog("[MIC-7] starting engine...")
                 try self.engine.start()
                 diagLog("[MIC-8] engine started successfully, isRunning=\(self.engine.isRunning)")
             } catch {
@@ -126,9 +194,12 @@ final class MicCapture: @unchecked Sendable {
     }
 
     func stop() {
+        finishStream()
         engine.inputNode.removeTap(onBus: 0)
         engine.stop()
+        engine.reset()
         _audioLevel.value = 0
+        _hasCapturedFrames.value = false
     }
 
     private static func normalizedRMS(from buffer: AVAudioPCMBuffer) -> Float {
@@ -256,12 +327,12 @@ final class MicCapture: @unchecked Sendable {
                 mScope: kAudioObjectPropertyScopeGlobal,
                 mElement: kAudioObjectPropertyElementMain
             )
-            var name: CFString = "" as CFString
-            var nameSize = UInt32(MemoryLayout<CFString>.size)
-            status = AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, &name)
-            guard status == noErr else { continue }
+            var nameRef: Unmanaged<CFString>?
+            var nameSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+            status = AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, &nameRef)
+            guard status == noErr, let nameVal = nameRef?.takeUnretainedValue() else { continue }
 
-            result.append((id: deviceID, name: name as String))
+            result.append((id: deviceID, name: nameVal as String))
         }
 
         return result
@@ -274,10 +345,10 @@ final class MicCapture: @unchecked Sendable {
             mScope: kAudioObjectPropertyScopeGlobal,
             mElement: kAudioObjectPropertyElementMain
         )
-        var uid: CFString = "" as CFString
-        var size = UInt32(MemoryLayout<CFString>.size)
-        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &uid)
-        return status == noErr ? uid as String : nil
+        var uidRef: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &uidRef)
+        return status == noErr ? uidRef?.takeUnretainedValue() as String? : nil
     }
 
     static func defaultInputDeviceID() -> AudioDeviceID? {
@@ -296,6 +367,27 @@ final class MicCapture: @unchecked Sendable {
             &deviceID
         )
         return status == noErr ? deviceID : nil
+    }
+
+    private static func channelCount(for deviceID: AudioDeviceID, scope: AudioObjectPropertyScope) -> Int {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: scope,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var bufferListSize: UInt32 = 0
+        let sizeStatus = AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &bufferListSize)
+        guard sizeStatus == noErr, bufferListSize > 0 else { return 0 }
+
+        let bufferListPtr = UnsafeMutablePointer<AudioBufferList>.allocate(capacity: 1)
+        defer { bufferListPtr.deallocate() }
+
+        var mutableSize = bufferListSize
+        let dataStatus = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &mutableSize, bufferListPtr)
+        guard dataStatus == noErr else { return 0 }
+
+        let bufferList = UnsafeMutableAudioBufferListPointer(bufferListPtr)
+        return bufferList.reduce(0) { $0 + Int($1.mNumberChannels) }
     }
 }
 
@@ -316,6 +408,17 @@ final class SyncString: @unchecked Sendable {
     private let lock = NSLock()
 
     var value: String? {
+        get { lock.withLock { _value } }
+        set { lock.withLock { _value = newValue } }
+    }
+}
+
+/// Simple thread-safe bool holder.
+final class SyncBool: @unchecked Sendable {
+    private var _value = false
+    private let lock = NSLock()
+
+    var value: Bool {
         get { lock.withLock { _value } }
         set { lock.withLock { _value = newValue } }
     }

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
@@ -165,7 +165,7 @@ final class StreamingTranscriber: @unchecked Sendable {
         ) else { return nil }
 
         var error: NSError?
-        var consumed = false
+        nonisolated(unsafe) var consumed = false
         converter.convert(to: outputBuffer, error: &error) { _, outStatus in
             if consumed {
                 outStatus.pointee = .noDataNow

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -21,20 +21,52 @@ func diagLog(_ msg: String) {
 @Observable
 @MainActor
 final class TranscriptionEngine {
-    private(set) var isRunning = false
-    private(set) var assetStatus: String = "Ready"
-    private(set) var lastError: String?
-    private(set) var needsModelDownload = false
+    // These properties are read from SwiftUI body during view evaluation.
+    // SwiftUI's ViewBodyAccessor doesn't carry MainActor executor context
+    // in Swift 6.2, so @MainActor-isolated @Observable properties trigger
+    // a failing runtime check in SerialExecutor.isMainExecutor.getter
+    // (EXC_BAD_ACCESS / KERN_PROTECTION_FAILURE).
+    //
+    // We use @ObservationIgnored nonisolated(unsafe) backing storage with
+    // manual observation tracking to bypass the MainActor check while
+    // keeping SwiftUI reactivity. Mutations only happen on MainActor.
+    @ObservationIgnored nonisolated(unsafe) private var _isRunning = false
+    var isRunning: Bool {
+        get { access(keyPath: \.isRunning); return _isRunning }
+        set { withMutation(keyPath: \.isRunning) { _isRunning = newValue } }
+    }
 
-    /// Whether the user has confirmed they want to download models.
-    var downloadConfirmed = false
+    @ObservationIgnored nonisolated(unsafe) private var _assetStatus: String = "Ready"
+    var assetStatus: String {
+        get { access(keyPath: \.assetStatus); return _assetStatus }
+        set { withMutation(keyPath: \.assetStatus) { _assetStatus = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _lastError: String?
+    var lastError: String? {
+        get { access(keyPath: \.lastError); return _lastError }
+        set { withMutation(keyPath: \.lastError) { _lastError = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _needsModelDownload = false
+    var needsModelDownload: Bool {
+        get { access(keyPath: \.needsModelDownload); return _needsModelDownload }
+        set { withMutation(keyPath: \.needsModelDownload) { _needsModelDownload = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _downloadConfirmed = false
+    var downloadConfirmed: Bool {
+        get { access(keyPath: \.downloadConfirmed); return _downloadConfirmed }
+        set { withMutation(keyPath: \.downloadConfirmed) { _downloadConfirmed = newValue } }
+    }
 
     private let systemCapture = SystemAudioCapture()
     private let micCapture = MicCapture()
     private let transcriptStore: TranscriptStore
 
     /// Audio level from mic for the UI meter.
-    var audioLevel: Float { micCapture.audioLevel }
+    /// nonisolated is safe here — micCapture.audioLevel is thread-safe (NSLock).
+    nonisolated var audioLevel: Float { micCapture.audioLevel }
 
     private var micTask: Task<Void, Never>?
     private var sysTask: Task<Void, Never>?
@@ -112,6 +144,12 @@ final class TranscriptionEngine {
         diagLog("[ENGINE-3] starting mic capture, targetMicID=\(String(describing: targetMicID))")
         let micStream = micCapture.bufferStream(deviceID: targetMicID)
 
+        // Check for immediate mic capture failure
+        if let micError = micCapture.captureError {
+            diagLog("[ENGINE-3-FAIL] mic capture error: \(micError)")
+            lastError = micError
+        }
+
         // 3. Start system audio capture
         diagLog("[ENGINE-4] starting system audio capture...")
         let sysStreams: SystemAudioCapture.CaptureStreams?
@@ -145,6 +183,16 @@ final class TranscriptionEngine {
             await micTranscriber.run(stream: micStream)
         }
 
+        // Health check: warn if mic produces no audio within 5 seconds
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(5))
+            guard let self, self.isRunning else { return }
+            if !self.micCapture.hasCapturedFrames && self.micCapture.captureError == nil {
+                diagLog("[ENGINE-HEALTH] no mic audio after 5s")
+                self.lastError = "Microphone is not producing audio. Check your input device in System Settings."
+            }
+        }
+
         // 5. Start system audio transcription
         if let sysStream = sysStreams?.systemAudio {
             let sysTranscriber = StreamingTranscriber(
@@ -175,7 +223,7 @@ final class TranscriptionEngine {
 
     /// Restart only the mic capture with a new device, keeping system audio and models intact.
     /// Pass the raw setting value (0 = system default, or a specific AudioDeviceID).
-    func restartMic(inputDeviceID: AudioDeviceID) {
+    func restartMic(inputDeviceID: AudioDeviceID) async {
         guard isRunning, let asrManager, let vadManager else { return }
 
         // Only update user selection when explicitly changed (not from OS listener)
@@ -192,8 +240,9 @@ final class TranscriptionEngine {
 
         // Tear down old mic
         micTask?.cancel()
-        micTask = nil
         micCapture.stop()
+        await micTask?.value
+        micTask = nil
 
         currentMicDeviceID = targetMicID
 
@@ -237,7 +286,7 @@ final class TranscriptionEngine {
             Task { @MainActor in
                 guard self.isRunning, self.userSelectedDeviceID == 0 else { return }
                 // User has "System Default" selected — follow the OS default
-                self.restartMic(inputDeviceID: 0)
+                await self.restartMic(inputDeviceID: 0)
             }
         }
         defaultDeviceListenerBlock = block

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
-import Combine
 
+@MainActor
 struct ContentView: View {
     @Bindable var settings: AppSettings
     @Environment(AppCoordinator.self) private var coordinator
@@ -170,7 +170,9 @@ struct ContentView: View {
         }
         .onChange(of: settings.inputDeviceID) {
             if isRunning {
-                transcriptionEngine?.restartMic(inputDeviceID: settings.inputDeviceID)
+                Task {
+                    await transcriptionEngine?.restartMic(inputDeviceID: settings.inputDeviceID)
+                }
             }
         }
         .onChange(of: transcriptStore.utterances.count) {
@@ -180,15 +182,22 @@ struct ContentView: View {
             overlayManager.hide()
             return .handled
         }
-        .onReceive(Timer.publish(every: 0.1, on: .main, in: .common).autoconnect()) { _ in
-            guard let engine = transcriptionEngine else {
-                if audioLevel != 0 { audioLevel = 0 }
-                return
-            }
-            if engine.isRunning {
-                audioLevel = engine.audioLevel
-            } else if audioLevel != 0 {
-                audioLevel = 0
+        .task {
+            // Poll audio level in a proper MainActor Swift Task context.
+            // Using .onReceive(Timer.publish) runs in a Combine/GCD context that
+            // doesn't satisfy Swift's MainActor executor check when accessing
+            // @MainActor-isolated properties, causing EXC_BAD_ACCESS crashes.
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(100))
+                guard let engine = transcriptionEngine else {
+                    if audioLevel != 0 { audioLevel = 0 }
+                    continue
+                }
+                if engine.isRunning {
+                    audioLevel = engine.audioLevel
+                } else if audioLevel != 0 {
+                    audioLevel = 0
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem
Switching/using certain microphone devices could crash during view observation and could silently fail to capture mic audio after device routing changes.

## Root cause
- `@MainActor` + `@Observable` properties were being read during SwiftUI view evaluation in a context that does not always carry MainActor executor context in Swift 6.2, triggering a runtime executor check crash.
- Mic routing logic forced CoreAudio device binding in cases where input-only devices cannot safely be bound as output/current device, causing fragile startup/restart behavior.

## Fix
- Reworked `TranscriptionEngine` observable state with `@ObservationIgnored nonisolated(unsafe)` backing storage plus manual observation access/mutation so SwiftUI updates remain reactive without triggering MainActor executor crashes.
- Moved audio-level polling in `ContentView` from Combine timer to a MainActor task loop and updated mic restart flow to `async` with awaited task teardown.
- Hardened `MicCapture` lifecycle/routing: defensive stream cleanup, engine reset/prepare ordering, device capability checks, conditional device binding, tap/frame health tracking, and better error surfacing.
- Added local artifact ignore rules (`.DS_Store`, `.cursor/*.log`, `*.ips`, `*.dmg`) to prevent crash/debug artifacts from entering commits.

## Safety
- PR contains only source + ignore-rule changes; no crash reports, local logs, or packaged binaries included.

## Related issues
- Refs #15
- Related historical crash reports: #1, #25
- No new issue created because existing issues already cover this root-cause/fix area.

## Test plan
- [x] `swift build` in `OpenOats` succeeds.
- [ ] Manual: start recording with system default mic and verify transcript + level meter update.
- [ ] Manual: switch input devices while running and verify no crash; mic capture continues.
- [ ] Manual: choose an input-only device and verify app warns if mic has no frames after startup.

Made with [Cursor](https://cursor.com)