### PR TITLE
Add OpenOats deeplinks for session controls

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -2,6 +2,22 @@ import Foundation
 import Observation
 import SwiftUI
 
+enum ExternalCommand: Equatable {
+    case startSession
+    case stopSession
+    case openNotes(sessionID: String?)
+}
+
+struct ExternalCommandRequest: Identifiable, Equatable {
+    let id: UUID
+    let command: ExternalCommand
+
+    init(command: ExternalCommand) {
+        self.id = UUID()
+        self.command = command
+    }
+}
+
 /// Shared state coordinator injected into all window scenes.
 /// Bridges the main window (transcription) and Notes window (history + generation).
 @Observable
@@ -13,6 +29,8 @@ final class AppCoordinator {
 
     var selectedTemplate: MeetingTemplate?
     var lastEndedSession: SessionIndex?
+    var pendingExternalCommand: ExternalCommandRequest?
+    var requestedSessionSelectionID: String?
     private(set) var sessionHistory: [SessionIndex] = []
 
     /// The template snapshot frozen at session start (not stop).
@@ -85,5 +103,23 @@ final class AppCoordinator {
     /// Load session history from sidecars (lightweight index only).
     func loadHistory() async {
         sessionHistory = await sessionStore.loadSessionIndex()
+    }
+
+    func queueExternalCommand(_ command: ExternalCommand) {
+        pendingExternalCommand = ExternalCommandRequest(command: command)
+    }
+
+    func completeExternalCommand(_ requestID: UUID) {
+        guard pendingExternalCommand?.id == requestID else { return }
+        pendingExternalCommand = nil
+    }
+
+    func queueSessionSelection(_ sessionID: String?) {
+        requestedSessionSelectionID = sessionID
+    }
+
+    func consumeRequestedSessionSelection() -> String? {
+        defer { requestedSessionSelectionID = nil }
+        return requestedSessionSelectionID
     }
 }

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -16,6 +16,10 @@ struct OpenOatsApp: App {
                 .onAppear {
                     settings.applyScreenShareVisibility()
                 }
+                .onOpenURL { url in
+                    guard let command = OpenOatsDeepLink.parse(url) else { return }
+                    coordinator.queueExternalCommand(command)
+                }
         }
         .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)

--- a/OpenOats/Sources/OpenOats/App/OpenOatsDeepLink.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsDeepLink.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+enum OpenOatsDeepLink {
+    static func parse(_ url: URL) -> ExternalCommand? {
+        guard let scheme = url.scheme?.lowercased(), scheme == "openoats" else {
+            return nil
+        }
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let host = url.host?.lowercased() ?? ""
+        let sessionID = queryValue(named: "sessionID", in: components)
+            ?? queryValue(named: "sessionId", in: components)
+            ?? queryValue(named: "id", in: components)
+            ?? pathSessionID(from: url)
+
+        switch host {
+        case "start":
+            return .startSession
+        case "stop":
+            return .stopSession
+        case "notes":
+            return .openNotes(sessionID: sessionID)
+        default:
+            return nil
+        }
+    }
+
+    private static func queryValue(named name: String, in components: URLComponents?) -> String? {
+        components?.queryItems?.first(where: { $0.name == name })?.value
+    }
+
+    private static func pathSessionID(from url: URL) -> String? {
+        let trimmedPath = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        return trimmedPath.isEmpty ? nil : trimmedPath
+    }
+}

--- a/OpenOats/Sources/OpenOats/Info.plist
+++ b/OpenOats/Sources/OpenOats/Info.plist
@@ -16,6 +16,17 @@
     <string>OpenOats</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>com.opengranola.app</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>openoats</string>
+            </array>
+        </dict>
+    </array>
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>LSMinimumSystemVersion</key>

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -18,6 +18,10 @@ struct ContentView: View {
     @State private var audioLevel: Float = 0
 
     var body: some View {
+        bodyWithModifiers
+    }
+
+    private var rootContent: some View {
         VStack(spacing: 0) {
             // Compact header
             topBar
@@ -107,9 +111,20 @@ struct ContentView: View {
                 onConfirmDownload: confirmDownloadAndStart
             )
         }
-        .frame(minWidth: 360, maxWidth: 600, minHeight: 400)
-        .background(.ultraThinMaterial)
-        .overlay {
+    }
+
+    private var bodyWithModifiers: some View {
+        contentWithEventHandlers
+    }
+
+    private var sizedRootContent: some View {
+        rootContent
+            .frame(minWidth: 360, maxWidth: 600, minHeight: 400)
+            .background(.ultraThinMaterial)
+    }
+
+    private var contentWithOverlay: some View {
+        sizedRootContent.overlay {
             if showOnboarding {
                 OnboardingView(isPresented: $showOnboarding)
                     .transition(.opacity)
@@ -122,6 +137,10 @@ struct ContentView: View {
                 .transition(.opacity)
             }
         }
+    }
+
+    private var contentWithEventHandlers: some View {
+        contentWithOverlay
         .onChange(of: showOnboarding) {
             if !showOnboarding {
                 hasCompletedOnboarding = true
@@ -154,6 +173,10 @@ struct ContentView: View {
                 )
             }
             indexKBIfNeeded()
+            handlePendingExternalCommandIfPossible()
+        }
+        .onChange(of: coordinator.pendingExternalCommand?.id) {
+            handlePendingExternalCommandIfPossible()
         }
         .onChange(of: settings.kbFolderPath) {
             if settings.kbFolderPath.isEmpty {
@@ -397,6 +420,29 @@ struct ContentView: View {
         }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(lines.joined(separator: "\n"), forType: .string)
+    }
+
+    private func handlePendingExternalCommandIfPossible() {
+        guard let request = coordinator.pendingExternalCommand else { return }
+
+        switch request.command {
+        case .startSession:
+            guard transcriptionEngine != nil, suggestionEngine != nil, transcriptLogger != nil else {
+                return
+            }
+            if !isRunning {
+                startSession()
+            }
+        case .stopSession:
+            if isRunning {
+                stopSession()
+            }
+        case .openNotes(let sessionID):
+            coordinator.queueSessionSelection(sessionID)
+            openWindow(id: "notes")
+        }
+
+        coordinator.completeExternalCommand(request.id)
     }
 
     private func handleNewUtterance() {

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -16,7 +16,9 @@ struct NotesView: View {
         }
         .task {
             await coordinator.loadHistory()
-            if let last = coordinator.lastEndedSession {
+            if let requested = coordinator.consumeRequestedSessionSelection() {
+                selectedSessionID = requested
+            } else if let last = coordinator.lastEndedSession {
                 selectedSessionID = last.id
             }
         }
@@ -28,6 +30,11 @@ struct NotesView: View {
                     await coordinator.loadHistory()
                     selectedSessionID = last.id
                 }
+            }
+        }
+        .onChange(of: coordinator.requestedSessionSelectionID) {
+            if let requested = coordinator.consumeRequestedSessionSelection() {
+                selectedSessionID = requested
             }
         }
         .onChange(of: coordinator.sessionHistory.count) {


### PR DESCRIPTION
## Summary
- register an `openoats://` URL scheme for external automation entrypoints (like **Raycast**)
- add deeplink routing for starting/stopping sessions and opening the Notes window, including selecting a specific saved session
- queue deeplink commands in shared app state so they survive app startup timing and route cleanly into existing SwiftUI views

## Test plan
- [x] `swift build`
- [ ] Install/run the app and verify `openoats://start`
- [ ] Verify `openoats://stop`
- [ ] Verify `openoats://notes`
- [ ] Verify `openoats://notes?sessionID=<id>` opens the requested saved session

Made with [Cursor](https://cursor.com)