### PR TITLE
Add custom keyword boosting for Parakeet transcription

### DIFF
--- a/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
+++ b/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
@@ -107,6 +107,15 @@ final class AppSettings {
         didSet { UserDefaults.standard.set(transcriptionLocale, forKey: "transcriptionLocale") }
     }
 
+    var transcriptionCustomVocabulary: String {
+        didSet {
+            UserDefaults.standard.set(
+                transcriptionCustomVocabulary,
+                forKey: "transcriptionCustomVocabulary"
+            )
+        }
+    }
+
     var transcriptionModel: TranscriptionModel {
         didSet { UserDefaults.standard.set(transcriptionModel.rawValue, forKey: "transcriptionModel") }
     }
@@ -183,6 +192,7 @@ final class AppSettings {
         self.notesFolderPath = defaults.string(forKey: "notesFolderPath") ?? defaultNotesPath
         self.selectedModel = defaults.string(forKey: "selectedModel") ?? "google/gemini-3-flash-preview"
         self.transcriptionLocale = defaults.string(forKey: "transcriptionLocale") ?? "en-US"
+        self.transcriptionCustomVocabulary = defaults.string(forKey: "transcriptionCustomVocabulary") ?? ""
         self.transcriptionModel = TranscriptionModel(
             rawValue: defaults.string(forKey: "transcriptionModel") ?? ""
         ) ?? .parakeetV2

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
@@ -165,6 +165,11 @@ final class StreamingTranscriber: @unchecked Sendable {
             switch backend {
             case .parakeet(let asrManager):
                 let result = try await asrManager.transcribe(samples)
+                if let appliedTerms = result.ctcAppliedTerms, !appliedTerms.isEmpty {
+                    let joinedTerms = appliedTerms.joined(separator: ", ")
+                    log.info("[\(self.speaker.rawValue)] custom keywords applied: \(joinedTerms)")
+                    diagLog("[\(self.speaker.rawValue)] custom keywords applied: \(joinedTerms)")
+                }
                 text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             case .qwen3(let qwen3Manager, let qwenLanguage):
                 text = try await qwen3Manager.transcribe(

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -114,6 +114,17 @@ final class TranscriptionEngine {
                 try await micAsr.initialize(models: models)
                 let systemAsr = AsrManager(config: .default)
                 try await systemAsr.initialize(models: models)
+                if let (customVocabulary, ctcModels) = try await loadCustomVocabularyBoosting() {
+                    assetStatus = "Loading custom keywords..."
+                    try await micAsr.configureVocabularyBoosting(
+                        vocabulary: customVocabulary,
+                        ctcModels: ctcModels
+                    )
+                    try await systemAsr.configureVocabularyBoosting(
+                        vocabulary: customVocabulary,
+                        ctcModels: ctcModels
+                    )
+                }
                 self.micAsrManager = micAsr
                 self.systemAsrManager = systemAsr
                 self.qwen3Manager = nil
@@ -124,6 +135,17 @@ final class TranscriptionEngine {
                 try await micAsr.initialize(models: models)
                 let systemAsr = AsrManager(config: .default)
                 try await systemAsr.initialize(models: models)
+                if let (customVocabulary, ctcModels) = try await loadCustomVocabularyBoosting() {
+                    assetStatus = "Loading custom keywords..."
+                    try await micAsr.configureVocabularyBoosting(
+                        vocabulary: customVocabulary,
+                        ctcModels: ctcModels
+                    )
+                    try await systemAsr.configureVocabularyBoosting(
+                        vocabulary: customVocabulary,
+                        ctcModels: ctcModels
+                    )
+                }
                 self.micAsrManager = micAsr
                 self.systemAsrManager = systemAsr
                 self.qwen3Manager = nil
@@ -522,5 +544,23 @@ final class TranscriptionEngine {
         let languageCode = normalizedLanguageCode(for: locale)
         guard let languageCode else { return nil }
         return Qwen3AsrConfig.Language(from: languageCode)
+    }
+
+    private func loadCustomVocabularyBoosting() async throws -> (CustomVocabularyContext, CtcModels)? {
+        let customVocabularyText = settings.transcriptionCustomVocabulary
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !customVocabularyText.isEmpty else { return nil }
+
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("openoats-custom-vocabulary-\(UUID().uuidString).txt")
+
+        try customVocabularyText.write(to: tempURL, atomically: true, encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        let (customVocabulary, ctcModels) = try await CustomVocabularyContext.loadWithCtcTokens(
+            from: tempURL.path
+        )
+        guard !customVocabulary.terms.isEmpty else { return nil }
+        return (customVocabulary, ctcModels)
     }
 }

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -150,6 +150,40 @@ struct SettingsView: View {
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Custom Keywords")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+
+                    ZStack(alignment: .topLeading) {
+                        if settings.transcriptionCustomVocabulary.isEmpty {
+                            Text("One term per line. Optional aliases: OpenOats: open oats")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.quaternary)
+                                .padding(.top, 6)
+                                .padding(.leading, 4)
+                                .allowsHitTesting(false)
+                        }
+
+                        TextEditor(text: $settings.transcriptionCustomVocabulary)
+                            .font(.system(size: 11, design: .monospaced))
+                            .frame(height: 90)
+                            .frame(maxWidth: .infinity)
+                            .scrollContentBackground(.hidden)
+                    }
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(.quaternary)
+                    )
+
+                    Text(
+                        "Optional. Boost meeting-specific jargon, names, and product terms for Parakeet TDT v2/v3. Enter one term per line, or use `Preferred Term: alias one, alias two`."
+                    )
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             Section("Privacy") {


### PR DESCRIPTION
## Summary
- add a persisted `Custom Keywords` transcription setting so users can enter meeting-specific terms and aliases in the app
- enable FluidAudio vocabulary boosting for Parakeet TDT v2/v3 sessions by loading the configured keyword list when transcription starts
- log applied keyword corrections so local feature validation is easier when testing real speech

## Test plan
- [x] `swift build`
- [x] `./scripts/build_swift_app.sh`
- [x] Launch `/Applications/OpenOats.app` and open `OpenOats -> Settings…`
- [x] In `Transcription`, select `Parakeet TDT v2` and add the following custom keywords:
  `OpenOats`
  `Granola`
  `Projekt DolFin: project dolphin`
  `Tekto: tech toe`
  `NVIDIA`
- [x] Start a live session and speak the terms aloud in the packaged app
- [x] Verify the transcript captured corrected custom terms locally, including:
  `OpenOats`
  `Granola`
  `Projekt DolFin Projekt DolFin`
  `Eck do, Tekto`
  `NVIDIA.`
- [x] Verify `/tmp/openoats.log` reported actual keyword applications during the run, including `OpenOats`, `Projekt DolFin`, and `Tekto`


Made with [Cursor](https://cursor.com)