### PR TITLE
fix: update FluidAudio to 0.12.4 to fix Qwen3 ASR model download

### DIFF
--- a/OpenOats/Package.resolved
+++ b/OpenOats/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "a3d5441852186709698c02923d4f349c1a5ac93e0c7266aa2b6aa8fca0bf5d48",
+  "originHash" : "2af88f4909b3439889ba75e75f138d80600a6f0a057cb272d612f6bef1e3fcb3",
   "pins" : [
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "1cf23303df75df13e8dc92a0343c40006fbbe234",
-        "version" : "0.12.1"
+        "revision" : "9830ce835881c0d0d40f90aabfaae3a6da5bebfb",
+        "version" : "0.12.4"
       }
     },
     {


### PR DESCRIPTION
## Problem

Qwen3 ASR model download fails silently — clicking **"Download Now"** shows the error immediately without any actual download attempt:

```
Failed to load models: Model file not found: qwen3_asr_audio_encoder.mlmodelc
```

The `f32/` cache directory is created but remains **completely empty** (0 files downloaded).

Closes #47

### Root Cause

The issue is in **FluidAudio v0.12.1**, which OpenOats currently depends on.

In `ModelNames.swift`, the `Repo.qwen3Asr.subPath` was incorrectly set to `"qwen3-asr-0.6b-coreml-f32"` instead of `"f32"`. This caused the HuggingFace API tree listing to request a non-existent path:

```
❌ /api/models/FluidInference/qwen3-asr-0.6b-coreml/tree/main/qwen3-asr-0.6b-coreml-f32
✅ /api/models/FluidInference/qwen3-asr-0.6b-coreml/tree/main/f32
```

The download silently returned an empty result, creating the cache directory structure but never downloading any model files. Subsequent `modelsExist()` validation then failed with the "Model file not found" error.

### Why Parakeet downloads work fine

Parakeet models (v2/v3) have `subPath = nil` — their models sit at the repository root, so they bypass the subdirectory listing entirely and download correctly.

### How I found this

1. Checked the diagnostic log at `/tmp/openoats.log` — error appeared instantly with no download attempt
2. Inspected `~/Library/Application Support/FluidAudio/Models/qwen3-asr-0.6b-coreml/f32/` — directory existed but was empty
3. Verified HuggingFace API was reachable and manually downloaded `vocab.json` successfully via `curl`
4. Traced through FluidAudio's `DownloadUtils.downloadRepo()` → `Repo.subPath` → found the incorrect value
5. Confirmed the fix was already merged in FluidAudio v0.12.2+ ([FluidInference/FluidAudio#312](https://github.com/FluidInference/FluidAudio/pull/312))

## Fix

Update `Package.resolved` to use **FluidAudio 0.12.4** (latest), which contains the corrected `subPath = "f32"`.

No code changes needed — only the resolved dependency version.

## Testing

After updating:
1. Delete existing (broken) cache: `rm -rf ~/Library/Application\ Support/FluidAudio/Models/qwen3-asr-0.6b-coreml/`
2. Select **Qwen3 ASR 0.6B** in Settings → Transcription → Model
3. Click **"Download Now"** — model downloads successfully (~1.7 GB)
4. Transcription starts working with Qwen3 ASR

Tested on macOS 26.3.1 (Tahoe) / Apple M3 Max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)