### PR TITLE
Fix listen button hover crash on macOS 26

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -11,8 +11,6 @@ struct ControlBar: View {
     let onToggle: () -> Void
     let onConfirmDownload: () -> Void
 
-    @State private var isHoveringToggle = false
-
     var body: some View {
         VStack(spacing: 0) {
             // Error banner
@@ -83,13 +81,13 @@ struct ControlBar: View {
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 7)
-                    .background(isRunning
-                        ? Color.green.opacity(isHoveringToggle ? 0.18 : 0.1)
-                        : Color.accentColor.opacity(isHoveringToggle ? 0.85 : 1.0))
+                    // Avoid hover-driven local state here. On macOS 26 / Swift 6.2,
+                    // switching this button from Start to Live while the pointer is
+                    // over it can trip a SwiftUI executor crash in onHover handling.
+                    .background(isRunning ? Color.green.opacity(0.1) : Color.accentColor)
                     .clipShape(Capsule())
                 }
                 .buttonStyle(.plain)
-                .onHover { hovering in isHoveringToggle = hovering }
 
                 // Audio level bars when running
                 if isRunning {


### PR DESCRIPTION
## Summary
- remove hover-driven state from the Start/Live button in `ControlBar`
- keep the existing button visuals without `onHover`
- document why this path is avoided on macOS 26 / Swift 6.2

## Why
Crash reports point to SwiftUI hover handling on the listen button path:
- `HoverResponder.updatePhase(_:)`
- `ControlBar.body.getter`
- `swift_task_isCurrentExecutorWithFlagsImpl`

This appears to have regressed after commit `f0674b0` added hover state to interactive elements. The listen button is a particularly risky case because it swaps from `Start` to `Live` immediately after click while the pointer is still hovering the control.

## Verification
- `swift build -c debug -v`

Closes #59