### PR TITLE
feat: add MiniMax as LLM provider

### DIFF
--- a/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
@@ -56,6 +56,10 @@ final class NotesEngine {
             }
             baseURL = ollamaURL
             model = settings.ollamaLLMModel
+        case .minimax:
+            apiKey = settings.minimaxApiKey.isEmpty ? nil : settings.minimaxApiKey
+            baseURL = URL(string: "https://api.minimax.io/v1/chat/completions")
+            model = settings.minimaxModel
         }
 
         let transcriptText = formatTranscript(transcript)

--- a/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
@@ -60,6 +60,7 @@ final class SuggestionEngine {
         switch settings.llmProvider {
         case .openRouter: settings.openRouterApiKey
         case .ollama: nil
+        case .minimax: settings.minimaxApiKey
         }
     }
 
@@ -75,6 +76,8 @@ final class SuggestionEngine {
                 return nil
             }
             return url
+        case .minimax:
+            return URL(string: "https://api.minimax.io/v1/chat/completions")
         }
     }
 
@@ -83,6 +86,7 @@ final class SuggestionEngine {
         switch settings.llmProvider {
         case .openRouter: settings.selectedModel
         case .ollama: settings.ollamaLLMModel
+        case .minimax: settings.minimaxModel
         }
     }
 
@@ -100,6 +104,8 @@ final class SuggestionEngine {
             guard !settings.openRouterApiKey.isEmpty else { return }
         case .ollama:
             guard llmBaseURL != nil else { return }
+        case .minimax:
+            guard !settings.minimaxApiKey.isEmpty else { return }
         }
 
         currentTask = Task {

--- a/OpenOats/Sources/OpenOats/Intelligence/TranscriptRefinementEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/TranscriptRefinementEngine.swift
@@ -99,6 +99,8 @@ actor TranscriptRefinementEngine {
         let openRouterKey = await MainActor.run { settings.openRouterApiKey }
         let ollamaURL = await MainActor.run { settings.ollamaBaseURL }
         let ollamaModel = await MainActor.run { settings.ollamaLLMModel }
+        let minimaxKey = await MainActor.run { settings.minimaxApiKey }
+        let minimaxModelName = await MainActor.run { settings.minimaxModel }
 
         switch provider {
         case .openRouter:
@@ -114,6 +116,10 @@ actor TranscriptRefinementEngine {
             }
             baseURL = url
             model = ollamaModel
+        case .minimax:
+            apiKey = minimaxKey.isEmpty ? nil : minimaxKey
+            baseURL = URL(string: "https://api.minimax.io/v1/chat/completions")
+            model = minimaxModelName
         }
 
         let messages: [OpenRouterClient.Message] = [

--- a/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
+++ b/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
@@ -7,6 +7,7 @@ import CoreAudio
 enum LLMProvider: String, CaseIterable, Identifiable {
     case openRouter
     case ollama
+    case minimax
 
     var id: String { rawValue }
 
@@ -14,6 +15,7 @@ enum LLMProvider: String, CaseIterable, Identifiable {
         switch self {
         case .openRouter: "OpenRouter"
         case .ollama: "Ollama"
+        case .minimax: "MiniMax"
         }
     }
 }
@@ -301,6 +303,28 @@ final class AppSettings {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _minimaxApiKey: String
+    var minimaxApiKey: String {
+        get { access(keyPath: \.minimaxApiKey); return _minimaxApiKey }
+        set {
+            withMutation(keyPath: \.minimaxApiKey) {
+                _minimaxApiKey = newValue
+                KeychainHelper.save(key: "minimaxApiKey", value: newValue)
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _minimaxModel: String
+    var minimaxModel: String {
+        get { access(keyPath: \.minimaxModel); return _minimaxModel }
+        set {
+            withMutation(keyPath: \.minimaxModel) {
+                _minimaxModel = newValue
+                UserDefaults.standard.set(newValue, forKey: "minimaxModel")
+            }
+        }
+    }
+
     /// Whether the user has acknowledged their obligation to comply with recording consent laws.
     @ObservationIgnored nonisolated(unsafe) private var _hasAcknowledgedRecordingConsent: Bool
     var hasAcknowledgedRecordingConsent: Bool {
@@ -392,6 +416,8 @@ final class AppSettings {
         self._openAIEmbedBaseURL = defaults.string(forKey: "openAIEmbedBaseURL") ?? "http://localhost:8080"
         self._openAIEmbedApiKey = KeychainHelper.load(key: "openAIEmbedApiKey") ?? ""
         self._openAIEmbedModel = defaults.string(forKey: "openAIEmbedModel") ?? "text-embedding-3-small"
+        self._minimaxApiKey = KeychainHelper.load(key: "minimaxApiKey") ?? ""
+        self._minimaxModel = defaults.string(forKey: "minimaxModel") ?? "MiniMax-M2.7"
         self._hasAcknowledgedRecordingConsent = defaults.bool(forKey: "hasAcknowledgedRecordingConsent")
         self._saveAudioRecording = defaults.bool(forKey: "saveAudioRecording")
         self._enableTranscriptRefinement = defaults.bool(forKey: "enableTranscriptRefinement")
@@ -621,6 +647,7 @@ final class AppSettings {
         switch llmProvider {
         case .openRouter: raw = selectedModel
         case .ollama: raw = ollamaLLMModel
+        case .minimax: raw = minimaxModel
         }
         return raw.split(separator: "/").last.map(String.init) ?? raw
     }

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -75,18 +75,28 @@ struct SettingsView: View {
                 }
                 .font(.system(size: 12))
 
-                if settings.llmProvider == .openRouter {
+                switch settings.llmProvider {
+                case .openRouter:
                     SecureField("API Key", text: $settings.openRouterApiKey)
                         .font(.system(size: 12, design: .monospaced))
 
                     TextField("Model", text: $settings.selectedModel, prompt: Text("e.g. google/gemini-3-flash-preview"))
                         .font(.system(size: 12, design: .monospaced))
-                } else {
+                case .ollama:
                     TextField("Ollama URL", text: $settings.ollamaBaseURL, prompt: Text("http://localhost:11434"))
                         .font(.system(size: 12, design: .monospaced))
 
                     TextField("Model", text: $settings.ollamaLLMModel, prompt: Text("e.g. qwen3:8b"))
                         .font(.system(size: 12, design: .monospaced))
+                case .minimax:
+                    SecureField("API Key", text: $settings.minimaxApiKey)
+                        .font(.system(size: 12, design: .monospaced))
+
+                    Picker("Model", selection: $settings.minimaxModel) {
+                        Text("MiniMax-M2.7").tag("MiniMax-M2.7")
+                        Text("MiniMax-M2.7-highspeed").tag("MiniMax-M2.7-highspeed")
+                    }
+                    .font(.system(size: 12))
                 }
             }
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OpenOats sits next to your call, transcribes both sides of the conversation in r
 - **Invisible to the other side** — the app window is hidden from screen sharing by default, so no one knows you're using it
 - **Fully offline transcription** — speech recognition runs entirely on your Mac; no audio ever leaves the device
 - **Runs 100% locally** — pair with [Ollama](https://ollama.com/) for LLM suggestions and local embeddings, and nothing touches the network at all
-- **Pick any LLM** — use [OpenRouter](https://openrouter.ai/) for cloud models (GPT-4o, Claude, Gemini) or Ollama for local ones (Llama, Qwen, Mistral)
+- **Pick any LLM** — use [OpenRouter](https://openrouter.ai/) for cloud models (GPT-4o, Claude, Gemini), [MiniMax](https://platform.minimax.io/) for MiniMax-M2.7, or Ollama for local ones (Llama, Qwen, Mistral)
 - **Live transcript** — see both sides of the conversation as it happens, copy the whole thing with one click
 - **Auto-saved sessions** — every conversation is automatically saved as a plain-text transcript and a structured session log, no manual export needed
 - **Knowledge base search** — point it at a folder of notes and it pulls in what's relevant using [Voyage AI](https://www.voyageai.com/) embeddings, local Ollama embeddings, or any OpenAI-compatible endpoint (llama.cpp, llamaswap, LiteLLM, vLLM, etc.)
@@ -73,7 +73,7 @@ Or build from source:
 1. Open the DMG and drag OpenOats to Applications
 2. Launch the app and grant microphone + system audio recording permissions
 3. Open Settings (`Cmd+,`) and pick your providers:
-   - **Cloud**: add your OpenRouter and Voyage AI API keys
+   - **Cloud**: add your OpenRouter and Voyage AI API keys, or select MiniMax and add your [MiniMax API key](https://platform.minimax.io/)
    - **Local**: select Ollama as your LLM and embedding provider (make sure Ollama is running)
    - **OpenAI-compatible**: select "OpenAI Compatible" as your embedding provider and point it at any `/v1/embeddings` endpoint
 4. Point it at a folder of `.md` or `.txt` files — that's your knowledge base
@@ -85,7 +85,7 @@ The first run downloads the local speech model (~600 MB).
 
 - Apple Silicon Mac, macOS 15+
 - Xcode 26 / Swift 6.2
-- **For cloud mode**: [OpenRouter](https://openrouter.ai/) API key + [Voyage AI](https://www.voyageai.com/) API key
+- **For cloud mode**: [OpenRouter](https://openrouter.ai/) API key + [Voyage AI](https://www.voyageai.com/) API key, or [MiniMax](https://platform.minimax.io/) API key
 - **For local mode**: [Ollama](https://ollama.com/) running locally with your preferred models (e.g. `qwen3:8b` for suggestions, `nomic-embed-text` for embeddings)
 - **For OpenAI-compatible embeddings**: any server implementing `/v1/embeddings` (llama.cpp, llamaswap, LiteLLM, vLLM, etc.)
 
@@ -99,7 +99,7 @@ Works well with meeting prep docs, research notes, pitch decks, competitive anal
 
 - Speech is transcribed locally — audio never leaves your Mac
 - **With Ollama**: everything stays on your machine. Zero network calls.
-- **With cloud providers**: KB chunks are sent to Voyage AI (or your chosen OpenAI-compatible endpoint) for embedding (text only, no audio), and conversation context is sent to OpenRouter for suggestions
+- **With cloud providers**: KB chunks are sent to Voyage AI (or your chosen OpenAI-compatible endpoint) for embedding (text only, no audio), and conversation context is sent to your chosen LLM provider (OpenRouter or MiniMax) for suggestions
 - API keys are stored in your Mac's Keychain
 - The app window is hidden from screen sharing by default
 - Transcripts are saved locally to `~/Documents/OpenOats/`

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""
+Integration tests for MiniMax LLM provider support in OpenOats.
+
+These tests verify the MiniMax OpenAI-compatible API endpoint works correctly
+with the same URL, auth, and model patterns used in the Swift implementation.
+
+Requirements:
+    - MINIMAX_API_KEY environment variable set
+
+Usage:
+    MINIMAX_API_KEY=your_key python3 tests/test_minimax_integration.py
+"""
+
+import json
+import os
+import sys
+import unittest
+import urllib.request
+import urllib.error
+
+
+MINIMAX_API_KEY = os.environ.get("MINIMAX_API_KEY", "")
+MINIMAX_BASE_URL = "https://api.minimax.io/v1/chat/completions"
+MODELS = ["MiniMax-M2.7", "MiniMax-M2.7-highspeed"]
+
+
+def skip_without_key(func):
+    """Skip test if MINIMAX_API_KEY is not set."""
+    def wrapper(*args, **kwargs):
+        if not MINIMAX_API_KEY:
+            raise unittest.SkipTest("MINIMAX_API_KEY not set")
+        return func(*args, **kwargs)
+    return wrapper
+
+
+class TestMiniMaxAPIEndpoint(unittest.TestCase):
+    """Test the MiniMax API endpoint used by OpenOats."""
+
+    @skip_without_key
+    def test_non_streaming_completion(self):
+        """Test non-streaming chat completion (used by SuggestionEngine gate/generation)."""
+        body = {
+            "model": "MiniMax-M2.7",
+            "messages": [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": "Say hello in one word."},
+            ],
+            "stream": False,
+            "max_tokens": 32,
+        }
+
+        req = urllib.request.Request(
+            MINIMAX_BASE_URL,
+            data=json.dumps(body).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {MINIMAX_API_KEY}",
+            },
+        )
+
+        resp = json.loads(urllib.request.urlopen(req, timeout=30).read())
+        self.assertIn("choices", resp)
+        self.assertGreater(len(resp["choices"]), 0)
+        content = resp["choices"][0]["message"]["content"]
+        self.assertIsInstance(content, str)
+        self.assertGreater(len(content), 0)
+
+    @skip_without_key
+    def test_streaming_completion(self):
+        """Test streaming chat completion (used by NotesEngine for live markdown)."""
+        body = {
+            "model": "MiniMax-M2.7",
+            "messages": [
+                {"role": "system", "content": "You are a meeting notes assistant."},
+                {"role": "user", "content": "Summarize: Alice said hello, Bob replied."},
+            ],
+            "stream": True,
+            "max_tokens": 64,
+        }
+
+        req = urllib.request.Request(
+            MINIMAX_BASE_URL,
+            data=json.dumps(body).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {MINIMAX_API_KEY}",
+            },
+        )
+
+        resp = urllib.request.urlopen(req, timeout=30)
+        chunks = []
+        for line in resp:
+            line = line.decode().strip()
+            if line.startswith("data: "):
+                payload = line[6:]
+                if payload == "[DONE]":
+                    break
+                chunk = json.loads(payload)
+                delta = chunk.get("choices", [{}])[0].get("delta", {})
+                if "content" in delta and delta["content"]:
+                    chunks.append(delta["content"])
+
+        full_text = "".join(chunks)
+        self.assertGreater(len(full_text), 0)
+
+    @skip_without_key
+    def test_highspeed_model(self):
+        """Test MiniMax-M2.7-highspeed model works."""
+        body = {
+            "model": "MiniMax-M2.7-highspeed",
+            "messages": [
+                {"role": "user", "content": "Reply with the word 'ok'."},
+            ],
+            "stream": False,
+            "max_tokens": 16,
+        }
+
+        req = urllib.request.Request(
+            MINIMAX_BASE_URL,
+            data=json.dumps(body).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {MINIMAX_API_KEY}",
+            },
+        )
+
+        resp = json.loads(urllib.request.urlopen(req, timeout=30).read())
+        self.assertIn("choices", resp)
+        content = resp["choices"][0]["message"]["content"]
+        self.assertGreater(len(content), 0)
+
+    @skip_without_key
+    def test_system_and_user_messages(self):
+        """Test system + user message pattern used by all engines."""
+        body = {
+            "model": "MiniMax-M2.7",
+            "messages": [
+                {"role": "system", "content": "Output JSON only: {\"topic\": \"string\"}"},
+                {"role": "user", "content": "The meeting is about product launch."},
+            ],
+            "stream": False,
+            "max_tokens": 128,
+        }
+
+        req = urllib.request.Request(
+            MINIMAX_BASE_URL,
+            data=json.dumps(body).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {MINIMAX_API_KEY}",
+            },
+        )
+
+        resp = json.loads(urllib.request.urlopen(req, timeout=30).read())
+        content = resp["choices"][0]["message"]["content"]
+        self.assertIn("topic", content.lower())
+
+    def test_invalid_api_key_rejected(self):
+        """Test that invalid API key returns error."""
+        body = {
+            "model": "MiniMax-M2.7",
+            "messages": [{"role": "user", "content": "test"}],
+            "stream": False,
+            "max_tokens": 8,
+        }
+
+        req = urllib.request.Request(
+            MINIMAX_BASE_URL,
+            data=json.dumps(body).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer invalid-key-12345",
+            },
+        )
+
+        with self.assertRaises(urllib.error.HTTPError) as ctx:
+            urllib.request.urlopen(req, timeout=15)
+        self.assertIn(ctx.exception.code, (401, 403))
+
+
+class TestMiniMaxConfig(unittest.TestCase):
+    """Test configuration values match what the Swift code expects."""
+
+    def test_base_url_format(self):
+        """Verify base URL matches OpenAI-compatible pattern."""
+        self.assertEqual(MINIMAX_BASE_URL, "https://api.minimax.io/v1/chat/completions")
+
+    def test_model_ids(self):
+        """Verify model IDs are the expected values."""
+        self.assertIn("MiniMax-M2.7", MODELS)
+        self.assertIn("MiniMax-M2.7-highspeed", MODELS)
+        self.assertEqual(len(MODELS), 2)
+
+    def test_auth_header_format(self):
+        """Verify auth uses Bearer token format."""
+        key = "test-key"
+        header = f"Bearer {key}"
+        self.assertTrue(header.startswith("Bearer "))
+
+
+class TestSwiftCodeConsistency(unittest.TestCase):
+    """Verify Swift source files have consistent MiniMax integration."""
+
+    def setUp(self):
+        self.base_dir = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "OpenOats", "Sources", "OpenOats",
+        )
+
+    def test_llm_provider_enum_has_minimax(self):
+        """LLMProvider enum should include miniMax case."""
+        path = os.path.join(self.base_dir, "Settings", "AppSettings.swift")
+        with open(path) as f:
+            content = f.read()
+        self.assertIn("case minimax", content)
+        self.assertIn('"MiniMax"', content)
+
+    def test_settings_has_minimax_api_key(self):
+        """AppSettings should have minimaxApiKey property."""
+        path = os.path.join(self.base_dir, "Settings", "AppSettings.swift")
+        with open(path) as f:
+            content = f.read()
+        self.assertIn("minimaxApiKey", content)
+        self.assertIn("minimaxModel", content)
+        self.assertIn('"MiniMax-M2.7"', content)
+
+    def test_notes_engine_handles_minimax(self):
+        """NotesEngine should route MiniMax provider."""
+        path = os.path.join(self.base_dir, "Intelligence", "NotesEngine.swift")
+        with open(path) as f:
+            content = f.read()
+        self.assertIn("case .minimax:", content)
+        self.assertIn("api.minimax.io", content)
+
+    def test_suggestion_engine_handles_minimax(self):
+        """SuggestionEngine should route MiniMax provider."""
+        path = os.path.join(self.base_dir, "Intelligence", "SuggestionEngine.swift")
+        with open(path) as f:
+            content = f.read()
+        self.assertIn("case .minimax:", content)
+        self.assertIn("api.minimax.io", content)
+        self.assertIn("settings.minimaxApiKey", content)
+        self.assertIn("settings.minimaxModel", content)
+
+    def test_refinement_engine_handles_minimax(self):
+        """TranscriptRefinementEngine should route MiniMax provider."""
+        path = os.path.join(self.base_dir, "Intelligence", "TranscriptRefinementEngine.swift")
+        with open(path) as f:
+            content = f.read()
+        self.assertIn("case .minimax:", content)
+        self.assertIn("api.minimax.io", content)
+
+    def test_settings_view_has_minimax_ui(self):
+        """SettingsView should have MiniMax provider UI."""
+        path = os.path.join(self.base_dir, "Views", "SettingsView.swift")
+        with open(path) as f:
+            content = f.read()
+        self.assertIn("case .minimax:", content)
+        self.assertIn("minimaxApiKey", content)
+        self.assertIn("MiniMax-M2.7", content)
+        self.assertIn("MiniMax-M2.7-highspeed", content)
+
+    def test_readme_mentions_minimax(self):
+        """README should mention MiniMax as a provider option."""
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "README.md",
+        )
+        with open(path) as f:
+            content = f.read()
+        self.assertIn("MiniMax", content)
+        self.assertIn("minimax", content.lower())
+
+    def test_all_switch_cases_exhaustive(self):
+        """All switch statements on llmProvider should handle .miniMax."""
+        files_to_check = [
+            ("Intelligence/NotesEngine.swift", 1),
+            ("Intelligence/SuggestionEngine.swift", 4),
+            ("Intelligence/TranscriptRefinementEngine.swift", 1),
+            ("Settings/AppSettings.swift", 1),
+        ]
+        for rel_path, expected_min in files_to_check:
+            path = os.path.join(self.base_dir, rel_path)
+            with open(path) as f:
+                content = f.read()
+            count = content.count("case .minimax")
+            self.assertGreaterEqual(
+                count, expected_min,
+                f"{rel_path} should have at least {expected_min} 'case .minimax' but has {count}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io/) as a third LLM provider option alongside OpenRouter and Ollama. MiniMax offers an OpenAI-compatible chat completions API, making it a drop-in cloud alternative with two models:

- **MiniMax-M2.7** — latest flagship model
- **MiniMax-M2.7-highspeed** — 204K context, optimized for speed

## Changes

- Add `minimax` case to `LLMProvider` enum with display name
- Add `minimaxApiKey` (Keychain-stored) and `minimaxModel` (UserDefaults) settings to `AppSettings`
- Route MiniMax provider in all three LLM engines:
  - `SuggestionEngine` — gate decisions, state updates, and suggestion generation
  - `NotesEngine` — streaming meeting notes
  - `TranscriptRefinementEngine` — filler word cleanup
- Add MiniMax section in `SettingsView` with API key field and model picker (static dropdown)
- Update `activeModelDisplay` computed property
- Update README to document MiniMax as a cloud provider option

## Test plan

- [x] 8 unit tests verify Swift code consistency (enum cases, settings properties, switch exhaustiveness)
- [x] 5 integration tests verify MiniMax API endpoint compatibility (streaming, non-streaming, auth)
- [x] 3 config tests verify URL/model/auth patterns
- [x] All 16 tests pass
- [ ] Manual: select MiniMax in Settings, enter API key, verify suggestions and notes generate correctly
