### PR TITLE
Fix deeplink stop handling and duplicate main windows

### DIFF
--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -11,7 +11,7 @@ struct OpenOatsApp: App {
     private let updaterController = AppUpdaterController()
 
     var body: some Scene {
-        WindowGroup {
+        Window("OpenOats", id: "main") {
             ContentView(settings: settings)
                 .environment(coordinator)
                 .onAppear {

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -377,6 +377,7 @@ struct ContentView: View {
 
     private func handlePendingExternalCommandIfPossible() {
         guard let request = coordinator.pendingExternalCommand else { return }
+        let handled: Bool
 
         switch request.command {
         case .startSession:
@@ -386,16 +387,20 @@ struct ContentView: View {
             if !viewState.isRunning {
                 startSession()
             }
+            handled = true
         case .stopSession:
-            if viewState.isRunning {
-                stopSession()
-            }
+            guard viewState.isRunning else { return }
+            stopSession()
+            handled = true
         case .openNotes(let sessionID):
             coordinator.queueSessionSelection(sessionID)
             openWindow(id: "notes")
+            handled = true
         }
 
-        coordinator.completeExternalCommand(request.id)
+        if handled {
+            coordinator.completeExternalCommand(request.id)
+        }
     }
 
     private func handleNewUtterance(_ last: Utterance) {


### PR DESCRIPTION
## Summary
- prevent non-recording windows from consuming queued external stop commands before the active recording window handles them
- switch the main app scene to a single `Window` so deeplink activation does not spawn an extra main OpenOats window
- keep deeplink-driven session controls working reliably from external tools like Raycast

## Test plan
- `cd OpenOats && swift build -c release`
- Install the patched app and verify `openoats://start` starts recording in the running app
- Verify `openoats://stop` stops the active recording without leaving the current session running
- Verify deeplink activation no longer opens an extra main OpenOats window during stop handling

Made with [Cursor](https://cursor.com)