### PR TITLE
Fix meeting detection settings to use nonisolated(unsafe) pattern

### DIFF
--- a/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
+++ b/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
@@ -399,33 +399,75 @@ final class AppSettings {
     // MARK: - Meeting Detection
 
     /// Whether automatic meeting detection is enabled.
+    @ObservationIgnored nonisolated(unsafe) private var _meetingAutoDetectEnabled: Bool
     var meetingAutoDetectEnabled: Bool {
-        didSet { UserDefaults.standard.set(meetingAutoDetectEnabled, forKey: "meetingAutoDetectEnabled") }
+        get { access(keyPath: \.meetingAutoDetectEnabled); return _meetingAutoDetectEnabled }
+        set {
+            withMutation(keyPath: \.meetingAutoDetectEnabled) {
+                _meetingAutoDetectEnabled = newValue
+                UserDefaults.standard.set(newValue, forKey: "meetingAutoDetectEnabled")
+            }
+        }
     }
 
     /// Whether the explanation sheet for auto-detect has been shown.
+    @ObservationIgnored nonisolated(unsafe) private var _hasShownAutoDetectExplanation: Bool
     var hasShownAutoDetectExplanation: Bool {
-        didSet { UserDefaults.standard.set(hasShownAutoDetectExplanation, forKey: "hasShownAutoDetectExplanation") }
+        get { access(keyPath: \.hasShownAutoDetectExplanation); return _hasShownAutoDetectExplanation }
+        set {
+            withMutation(keyPath: \.hasShownAutoDetectExplanation) {
+                _hasShownAutoDetectExplanation = newValue
+                UserDefaults.standard.set(newValue, forKey: "hasShownAutoDetectExplanation")
+            }
+        }
     }
 
     /// Whether the user has seen the suggestion to enable Launch at Login.
+    @ObservationIgnored nonisolated(unsafe) private var _hasSeenLaunchAtLoginSuggestion: Bool
     var hasSeenLaunchAtLoginSuggestion: Bool {
-        didSet { UserDefaults.standard.set(hasSeenLaunchAtLoginSuggestion, forKey: "hasSeenLaunchAtLoginSuggestion") }
+        get { access(keyPath: \.hasSeenLaunchAtLoginSuggestion); return _hasSeenLaunchAtLoginSuggestion }
+        set {
+            withMutation(keyPath: \.hasSeenLaunchAtLoginSuggestion) {
+                _hasSeenLaunchAtLoginSuggestion = newValue
+                UserDefaults.standard.set(newValue, forKey: "hasSeenLaunchAtLoginSuggestion")
+            }
+        }
     }
 
     /// Minutes of mic silence before auto-stopping a detected session.
+    @ObservationIgnored nonisolated(unsafe) private var _silenceTimeoutMinutes: Int
     var silenceTimeoutMinutes: Int {
-        didSet { UserDefaults.standard.set(silenceTimeoutMinutes, forKey: "silenceTimeoutMinutes") }
+        get { access(keyPath: \.silenceTimeoutMinutes); return _silenceTimeoutMinutes }
+        set {
+            withMutation(keyPath: \.silenceTimeoutMinutes) {
+                _silenceTimeoutMinutes = newValue
+                UserDefaults.standard.set(newValue, forKey: "silenceTimeoutMinutes")
+            }
+        }
     }
 
     /// User-added meeting app bundle IDs beyond the built-in list.
+    @ObservationIgnored nonisolated(unsafe) private var _customMeetingAppBundleIDs: [String]
     var customMeetingAppBundleIDs: [String] {
-        didSet { UserDefaults.standard.set(customMeetingAppBundleIDs, forKey: "customMeetingAppBundleIDs") }
+        get { access(keyPath: \.customMeetingAppBundleIDs); return _customMeetingAppBundleIDs }
+        set {
+            withMutation(keyPath: \.customMeetingAppBundleIDs) {
+                _customMeetingAppBundleIDs = newValue
+                UserDefaults.standard.set(newValue, forKey: "customMeetingAppBundleIDs")
+            }
+        }
     }
 
     /// When true, detection events are logged to the console.
+    @ObservationIgnored nonisolated(unsafe) private var _detectionLogEnabled: Bool
     var detectionLogEnabled: Bool {
-        didSet { UserDefaults.standard.set(detectionLogEnabled, forKey: "detectionLogEnabled") }
+        get { access(keyPath: \.detectionLogEnabled); return _detectionLogEnabled }
+        set {
+            withMutation(keyPath: \.detectionLogEnabled) {
+                _detectionLogEnabled = newValue
+                UserDefaults.standard.set(newValue, forKey: "detectionLogEnabled")
+            }
+        }
     }
 
     init() {
@@ -473,16 +515,16 @@ final class AppSettings {
 
         // Meeting detection — default to enabled
         if defaults.object(forKey: "meetingAutoDetectEnabled") == nil {
-            self.meetingAutoDetectEnabled = true
+            self._meetingAutoDetectEnabled = true
         } else {
-            self.meetingAutoDetectEnabled = defaults.bool(forKey: "meetingAutoDetectEnabled")
+            self._meetingAutoDetectEnabled = defaults.bool(forKey: "meetingAutoDetectEnabled")
         }
-        self.hasShownAutoDetectExplanation = defaults.bool(forKey: "hasShownAutoDetectExplanation")
-        self.hasSeenLaunchAtLoginSuggestion = defaults.bool(forKey: "hasSeenLaunchAtLoginSuggestion")
-        self.silenceTimeoutMinutes = defaults.object(forKey: "silenceTimeoutMinutes") != nil
+        self._hasShownAutoDetectExplanation = defaults.bool(forKey: "hasShownAutoDetectExplanation")
+        self._hasSeenLaunchAtLoginSuggestion = defaults.bool(forKey: "hasSeenLaunchAtLoginSuggestion")
+        self._silenceTimeoutMinutes = defaults.object(forKey: "silenceTimeoutMinutes") != nil
             ? defaults.integer(forKey: "silenceTimeoutMinutes") : 15
-        self.customMeetingAppBundleIDs = defaults.stringArray(forKey: "customMeetingAppBundleIDs") ?? []
-        self.detectionLogEnabled = defaults.bool(forKey: "detectionLogEnabled")
+        self._customMeetingAppBundleIDs = defaults.stringArray(forKey: "customMeetingAppBundleIDs") ?? []
+        self._detectionLogEnabled = defaults.bool(forKey: "detectionLogEnabled")
 
         // Default to true (hidden) if key has never been set
         if defaults.object(forKey: "hideFromScreenShare") == nil {


### PR DESCRIPTION
The 6 meeting detection properties added in v1.12.0 use plain `didSet` instead of the `nonisolated(unsafe)` + `access`/`withMutation` pattern that every other property in `AppSettings` uses.

The file's own comment at line 115 explains why this pattern is required:

> SwiftUI can evaluate view bodies outside a MainActor executor context in Swift 6.2. Use nonisolated backing storage plus manual observation tracking so bound settings remain safe to read during those updates.

## Changes

Migrates these 6 properties to match the established pattern:

- `meetingAutoDetectEnabled`
- `hasShownAutoDetectExplanation`
- `hasSeenLaunchAtLoginSuggestion`
- `silenceTimeoutMinutes`
- `customMeetingAppBundleIDs`
- `detectionLogEnabled`

Default values preserved (`meetingAutoDetectEnabled` defaults to `true` on fresh install, `silenceTimeoutMinutes` defaults to `15`). Single file changed, all existing tests pass.

---

Also noticed a couple of other small improvements while working on the detection feature. Happy to send separately if useful:

- `isRecording` could be derived from `MeetingState` instead of manually synced via polling
- `purgeRecentlyDeleted()` deletes everything unconditionally despite the soft-delete design; an age-based check would provide a recovery window

🤖 Generated with [Claude Code](https://claude.com/claude-code)