### PR TITLE
Fix hover executor crash on macOS 26 / Swift 6.2

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -51,8 +51,6 @@ struct ContentView: View {
     @State private var observedVoyageApiKey = ""
     @State private var observedTranscriptionModel: TranscriptionModel = .parakeetV2
     @State private var observedInputDeviceID: AudioDeviceID = 0
-    @State private var isHoveringNotes = false
-    @State private var isHoveringCopy = false
 
     var body: some View {
         bodyWithModifiers
@@ -88,12 +86,15 @@ struct ContentView: View {
                     }
                     .padding(.horizontal, 6)
                     .padding(.vertical, 3)
-                    .background(isHoveringNotes ? Color.primary.opacity(0.06) : Color.clear)
                     .clipShape(RoundedRectangle(cornerRadius: 5))
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(.secondary)
-                .onHover { hovering in isHoveringNotes = hovering }
+                // Avoid hover-driven local state here. On macOS 26 / Swift 6.2,
+                // the onHover closure triggers a view body re-evaluation outside
+                // the MainActor executor context, which crashes in
+                // swift_getObjectType when checking @Observable actor isolation.
+                // Same class of bug fixed in ControlBar (b9625e7).
                 .help("View past meeting notes")
             }
             .padding(.horizontal, 16)
@@ -179,11 +180,12 @@ struct ContentView: View {
                                     .font(.system(size: 11))
                                     .foregroundStyle(.secondary)
                                     .padding(4)
-                                    .background(isHoveringCopy ? Color.primary.opacity(0.06) : Color.clear)
                                     .clipShape(RoundedRectangle(cornerRadius: 4))
                             }
                             .buttonStyle(.plain)
-                            .onHover { hovering in isHoveringCopy = hovering }
+                            // Same hover executor crash as the Past Meetings button
+                            // and ControlBar toggle (b9625e7). Remove onHover to
+                            // avoid EXC_BAD_ACCESS in swift_getObjectType.
                             .help("Copy transcript")
                         }
                     }


### PR DESCRIPTION
## Summary

Removes `.onHover` closures from two buttons in `ContentView.rootContent` that cause `EXC_BAD_ACCESS (SIGSEGV)` on macOS 26 with Swift 6.2.

This is the same class of bug already fixed in ControlBar (`b9625e7` / #60). The two remaining `.onHover` handlers on the **Past Meetings** button and the **copy-transcript** button were missed in that fix.

## Crash mechanism

1. Mouse hovers over button, `.onHover` closure mutates `@State` (`isHoveringNotes` / `isHoveringCopy`)
2. SwiftUI re-evaluates `rootContent` body to reflect the state change
3. On macOS 26 / Swift 6.2, `ViewBodyAccessor` runs **outside the MainActor executor context**
4. Body re-evaluation accesses `@Observable @MainActor` objects (e.g. `AppCoordinator`) through the observation system
5. Observation registrar's executor check calls `swift_getObjectType` on a stale executor reference
6. **SIGSEGV** at `swift_getObjectType+40`

**Crash signature:**
```
closure #3 in closure #1 in closure #1 in ContentView.rootContent.getter
  → HoverResponder.updatePhase(_:)
  → swift_task_isCurrentExecutorWithFlagsImpl
  → swift_getObjectType (KERN_INVALID_ADDRESS at 0x2e3f000b339a0068)
```

## Changes

- Remove `.onHover` + hover background from "Past Meetings" button (line 91-96)
- Remove `.onHover` + hover background from copy-transcript button (line 182-186)
- Remove unused `@State` properties `isHoveringNotes` and `isHoveringCopy`
- Add comments explaining the workaround, referencing ControlBar precedent

## Note

`SuggestionsView.BulletRow` also has an `.onHover` but is **not affected** - it's an isolated child struct with no `@Observable @MainActor` dependencies, so its hover re-evaluation stays scoped to value types only.