### PR TITLE
Fix: refined transcript text never persisted to session files

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -228,6 +228,13 @@ final class AppCoordinator {
         // 2. Drain delayed JSONL writes
         await sessionStore.awaitPendingWrites()
 
+        // 2b. Backfill refined text into JSONL from TranscriptStore
+        // The 5-second delayed writes often miss refinedText because LLM calls take longer.
+        // By now both the refinement engine and pending writes have drained, so the
+        // TranscriptStore has the final refined text for all utterances.
+        let utterancesSnapshot = transcriptStore.utterances
+        await sessionStore.backfillRefinedText(from: utterancesSnapshot)
+
         // 3. Build sidecar from this session's transcript data
         let sessionID = await sessionStore.currentSessionID ?? "unknown"
         let utteranceCount = transcriptStore.utterances.count

--- a/OpenOats/Sources/OpenOats/Storage/SessionStore.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionStore.swift
@@ -122,6 +122,89 @@ actor SessionStore {
         }
     }
 
+    /// Rewrite the current JSONL file, backfilling `refinedText` from the in-memory TranscriptStore.
+    ///
+    /// The 5-second delayed write often captures `refinedText` as nil because the LLM refinement
+    /// call hasn't finished yet. This method is called after both the refinement engine and pending
+    /// writes have drained, so the TranscriptStore now has the final refined text for all utterances.
+    func backfillRefinedText(from utterances: [Utterance]) {
+        guard let currentFile else { return }
+
+        // Close the file handle so we can read/rewrite the file safely
+        try? fileHandle?.close()
+        fileHandle = nil
+
+        guard let content = try? String(contentsOf: currentFile, encoding: .utf8) else { return }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let lines = content.components(separatedBy: "\n").filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return }
+
+        // Build a lookup from (timestamp, speaker) -> refinedText
+        // Uses ISO8601 string representation of the date for reliable matching
+        let iso8601Formatter = ISO8601DateFormatter()
+        iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var refinedLookup: [String: String] = [:]
+        for utterance in utterances {
+            guard let refined = utterance.refinedText else { continue }
+            let key = "\(iso8601Formatter.string(from: utterance.timestamp))|\(utterance.speaker.rawValue)"
+            refinedLookup[key] = refined
+        }
+
+        guard !refinedLookup.isEmpty else {
+            // No refined text to backfill; reopen file handle and return
+            fileHandle = try? FileHandle(forWritingTo: currentFile)
+            return
+        }
+
+        var updatedLines: [String] = []
+        var anyUpdated = false
+
+        for line in lines {
+            guard let data = line.data(using: .utf8),
+                  var record = try? decoder.decode(SessionRecord.self, from: data) else {
+                updatedLines.append(line)
+                continue
+            }
+
+            // Only backfill if the record doesn't already have refinedText
+            if record.refinedText == nil {
+                let key = "\(iso8601Formatter.string(from: record.timestamp))|\(record.speaker.rawValue)"
+                if let refined = refinedLookup[key] {
+                    record = SessionRecord(
+                        speaker: record.speaker,
+                        text: record.text,
+                        timestamp: record.timestamp,
+                        suggestions: record.suggestions,
+                        kbHits: record.kbHits,
+                        suggestionDecision: record.suggestionDecision,
+                        surfacedSuggestionText: record.surfacedSuggestionText,
+                        conversationStateSummary: record.conversationStateSummary,
+                        refinedText: refined
+                    )
+                    anyUpdated = true
+                }
+            }
+
+            if let encoded = try? encoder.encode(record),
+               let jsonString = String(data: encoded, encoding: .utf8) {
+                updatedLines.append(jsonString)
+            } else {
+                updatedLines.append(line)
+            }
+        }
+
+        if anyUpdated {
+            let newContent = updatedLines.joined(separator: "\n") + "\n"
+            try? newContent.write(to: currentFile, atomically: true, encoding: .utf8)
+        }
+
+        // Reopen file handle for any subsequent writes before endSession()
+        fileHandle = try? FileHandle(forWritingTo: currentFile)
+    }
+
     func endSession() {
         try? fileHandle?.close()
         fileHandle = nil


### PR DESCRIPTION
## Bug

`refinedText` is always `nil` in persisted session JSONL files. The `appendRecordDelayed()` method captures `refinedText` from the TranscriptStore after a 5-second delay, but LLM refinement calls typically take longer than that. By the time the record is written to disk, refinement hasn't finished yet.

**Impact**: Every session recorded since the refinement feature was added has zero refined text on disk. The Refined tab in Past Meetings always shows raw text.

**Evidence**: 0 out of ~1,500 records across all stored sessions contain `refinedText`.

## Fix

Backfill refined text into the JSONL when the session ends. At that point both the refinement engine and pending writes have drained, so the TranscriptStore has the final refined text for all utterances.

Two files changed:

- **`SessionStore.swift`** - Added `backfillRefinedText(from:)`: closes the file handle, reads the JSONL back, builds a lookup from TranscriptStore utterances keyed by `(timestamp, speaker)`, patches records missing `refinedText`, and atomically rewrites the file. Skips rewrite if nothing needs updating.
- **`AppCoordinator.swift`** - Calls `backfillRefinedText` in `finalizeCurrentSession()` after step 2 (pending writes drained) but before the sidecar write and `endSession()`.

## Test plan

- [ ] Record a meeting with refinement enabled
- [ ] End the session
- [ ] Inspect the JSONL file in `~/Library/Application Support/OpenOats/sessions/` - verify `refinedText` fields are populated
- [ ] Open Past Meetings, select the session, switch to Refined tab - verify cleaned-up text appears