### PR TITLE
Update Homebrew cask for 1.12.7

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.11.1"
-  sha256 "7d519a4e4a02756f3234577b709706791aee1a689f74bbae0d9f01af30f22431"
+  version "1.12.7"
+  sha256 "0e044389281a2043760591cc91c6c6ac8d1aacde22dac51001bab66ce0378df8"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Automated follow-up from the v1.12.7 release workflow. The workflow pushed the Homebrew cask update branch but could not open the PR automatically.