### PR TITLE
Replace per-utterance transcript refinement with batch cleanup engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ REPO_POLICY.md
 # Local crash and package artifacts
 *.ips
 *.dmg
+
+# Local marketing video project
+video/
+docs/superpowers/

--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -37,6 +37,9 @@ final class AppCoordinator {
     @ObservationIgnored private let _notesEngine: NotesEngine
     nonisolated var notesEngine: NotesEngine { _notesEngine }
 
+    @ObservationIgnored private let _cleanupEngine = TranscriptCleanupEngine()
+    nonisolated var cleanupEngine: TranscriptCleanupEngine { _cleanupEngine }
+
     @ObservationIgnored private let _transcriptStore: TranscriptStore
     nonisolated var transcriptStore: TranscriptStore { _transcriptStore }
 

--- a/OpenOats/Sources/OpenOats/Intelligence/TranscriptCleanupEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/TranscriptCleanupEngine.swift
@@ -1,0 +1,285 @@
+import Foundation
+import Observation
+
+/// Batch transcript cleanup engine that sends transcript chunks to an LLM
+/// to remove filler words and fix punctuation, preserving meaning.
+@Observable
+@MainActor
+final class TranscriptCleanupEngine {
+    @ObservationIgnored nonisolated(unsafe) private var _isCleaningUp = false
+    private(set) var isCleaningUp: Bool {
+        get { access(keyPath: \.isCleaningUp); return _isCleaningUp }
+        set { withMutation(keyPath: \.isCleaningUp) { _isCleaningUp = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _chunksCompleted = 0
+    private(set) var chunksCompleted: Int {
+        get { access(keyPath: \.chunksCompleted); return _chunksCompleted }
+        set { withMutation(keyPath: \.chunksCompleted) { _chunksCompleted = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _totalChunks = 0
+    private(set) var totalChunks: Int {
+        get { access(keyPath: \.totalChunks); return _totalChunks }
+        set { withMutation(keyPath: \.totalChunks) { _totalChunks = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _error: String?
+    private(set) var error: String? {
+        get { access(keyPath: \.error); return _error }
+        set { withMutation(keyPath: \.error) { _error = newValue } }
+    }
+
+    private let client = OpenRouterClient()
+    private var currentTask: Task<[SessionRecord], Never>?
+
+    /// The system prompt instructing the LLM how to clean up transcripts.
+    private nonisolated static let systemPrompt = """
+        You are a transcript cleanup assistant. Your job is to clean up raw speech-to-text output.
+
+        Rules:
+        - Remove filler words (um, uh, like, you know, sort of, kind of, I mean, basically, actually, right, so, well) \
+        when they add no meaning.
+        - Fix punctuation and capitalization.
+        - Preserve the original meaning exactly. Do not rephrase, summarize, or add content.
+        - Keep the exact same number of lines in the same order.
+        - Each line starts with a timestamp and speaker prefix in the format: [HH:MM:SS] Speaker: text
+        - Return the cleaned lines in the same format, one per line.
+        - Do not add any commentary, explanation, or extra text.
+        """
+
+    /// Chunks records into time-based blocks and sends each to an LLM for cleanup.
+    /// Returns a new array of `SessionRecord` with `refinedText` populated.
+    func cleanup(records: [SessionRecord], settings: AppSettings) async -> [SessionRecord] {
+        currentTask?.cancel()
+        isCleaningUp = true
+        chunksCompleted = 0
+        error = nil
+
+        let apiKey: String?
+        let baseURL: URL?
+        let model: String
+
+        switch settings.llmProvider {
+        case .openRouter:
+            apiKey = settings.openRouterApiKey.isEmpty ? nil : settings.openRouterApiKey
+            baseURL = nil
+            model = "openai/gpt-4o-mini"
+        case .ollama:
+            apiKey = nil
+            let base = settings.ollamaBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            guard let ollamaURL = URL(string: base + "/v1/chat/completions") else {
+                error = "Invalid Ollama URL: \(settings.ollamaBaseURL)"
+                isCleaningUp = false
+                return records
+            }
+            baseURL = ollamaURL
+            model = settings.ollamaLLMModel
+        case .mlx:
+            apiKey = nil
+            let base = settings.mlxBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            guard let mlxURL = URL(string: base + "/v1/chat/completions") else {
+                error = "Invalid MLX URL: \(settings.mlxBaseURL)"
+                isCleaningUp = false
+                return records
+            }
+            baseURL = mlxURL
+            model = settings.mlxModel
+        }
+
+        let chunks = Self.chunkRecords(records)
+        totalChunks = chunks.count
+
+        let task = Task { [weak self, client, apiKey, baseURL, model] () -> [SessionRecord] in
+            // Process chunks concurrently (up to 3 at a time) off the main actor.
+            let results: [(index: Int, records: [SessionRecord]?)] = await withTaskGroup(
+                of: (Int, [SessionRecord]?).self,
+                returning: [(Int, [SessionRecord]?)].self
+            ) { group in
+                var submitted = 0
+                var collected: [(Int, [SessionRecord]?)] = []
+                collected.reserveCapacity(chunks.count)
+
+                for (chunkIndex, chunk) in chunks.enumerated() {
+                    if submitted >= 3 {
+                        if let result = await group.next() {
+                            collected.append(result)
+                            await self?.incrementCompleted()
+                        }
+                    }
+
+                    guard !Task.isCancelled else { break }
+
+                    group.addTask {
+                        let cleaned = await Self.processChunk(
+                            chunk,
+                            client: client,
+                            apiKey: apiKey,
+                            model: model,
+                            baseURL: baseURL
+                        )
+                        return (chunkIndex, cleaned)
+                    }
+                    submitted += 1
+                }
+
+                // Collect remaining results.
+                for await result in group {
+                    collected.append(result)
+                    await self?.incrementCompleted()
+                }
+
+                return collected
+            }
+
+            guard !Task.isCancelled else { return records }
+
+            // Reassemble records in original order, falling back to originals for failed chunks.
+            var assembled: [SessionRecord] = []
+            let sortedResults = results.sorted { $0.index < $1.index }
+            var failedCount = 0
+
+            for (chunkIndex, cleanedRecords) in sortedResults {
+                if let cleanedRecords {
+                    assembled.append(contentsOf: cleanedRecords)
+                } else {
+                    failedCount += 1
+                    assembled.append(contentsOf: chunks[chunkIndex])
+                }
+            }
+
+            if failedCount > chunks.count / 2 {
+                await self?.setError("Cleanup failed for \(failedCount) of \(chunks.count) chunks")
+            }
+
+            return assembled
+        }
+
+        currentTask = task
+        let result = await task.value
+        isCleaningUp = false
+        return result
+    }
+
+    func cancel() {
+        currentTask?.cancel()
+        currentTask = nil
+        isCleaningUp = false
+        chunksCompleted = 0
+        totalChunks = 0
+        error = nil
+    }
+
+    // MARK: - Private Helpers
+
+    private func incrementCompleted() {
+        chunksCompleted += 1
+    }
+
+    private func setError(_ message: String) {
+        error = message
+    }
+
+    /// Splits records into chunks of approximately 2.5 minutes based on timestamps.
+    private static func chunkRecords(_ records: [SessionRecord]) -> [[SessionRecord]] {
+        guard let first = records.first else { return [] }
+
+        let chunkDuration: TimeInterval = 150 // 2.5 minutes
+        var chunks: [[SessionRecord]] = []
+        var currentChunk: [SessionRecord] = []
+        var chunkStart = first.timestamp
+
+        for record in records {
+            let elapsed = record.timestamp.timeIntervalSince(chunkStart)
+            if elapsed >= chunkDuration && !currentChunk.isEmpty {
+                chunks.append(currentChunk)
+                currentChunk = [record]
+                chunkStart = record.timestamp
+            } else {
+                currentChunk.append(record)
+            }
+        }
+
+        if !currentChunk.isEmpty {
+            chunks.append(currentChunk)
+        }
+
+        return chunks
+    }
+
+    /// Processes a single chunk of records through the LLM. Runs off the main actor.
+    private nonisolated static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss"
+        return f
+    }()
+
+    private nonisolated static func processChunk(
+        _ records: [SessionRecord],
+        client: OpenRouterClient,
+        apiKey: String?,
+        model: String,
+        baseURL: URL?
+    ) async -> [SessionRecord]? {
+        let lines = records.map { record in
+            let label = record.speaker == .you ? "You" : "Them"
+            let text = record.refinedText ?? record.text
+            return "[\(timeFormatter.string(from: record.timestamp))] \(label): \(text)"
+        }
+
+        let prompt = lines.joined(separator: "\n")
+
+        let messages: [OpenRouterClient.Message] = [
+            .init(role: "system", content: systemPrompt),
+            .init(role: "user", content: prompt),
+        ]
+
+        do {
+            let response = try await client.complete(
+                apiKey: apiKey,
+                model: model,
+                messages: messages,
+                maxTokens: 4096,
+                baseURL: baseURL
+            )
+
+            return parseResponse(response, originalRecords: records)
+        } catch {
+            return nil
+        }
+    }
+
+    /// Parses the LLM response back into session records, stripping the
+    /// `[HH:MM:SS] Speaker: ` prefix from each line.
+    private nonisolated static func parseResponse(
+        _ response: String,
+        originalRecords: [SessionRecord]
+    ) -> [SessionRecord]? {
+        let responseLines = response
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map(String.init)
+
+        guard responseLines.count == originalRecords.count else {
+            // Line count mismatch - fall back to originals.
+            return nil
+        }
+
+        let prefixPattern = /^\[\d{2}:\d{2}:\d{2}\]\s+\w+:\s*/
+
+        var updated: [SessionRecord] = []
+        updated.reserveCapacity(originalRecords.count)
+
+        for (line, original) in zip(responseLines, originalRecords) {
+            let cleanedText: String
+            if let match = line.prefixMatch(of: prefixPattern) {
+                cleanedText = String(line[match.range.upperBound...])
+            } else {
+                cleanedText = line.trimmingCharacters(in: .whitespaces)
+            }
+
+            updated.append(original.withRefinedText(cleanedText.isEmpty ? original.text : cleanedText))
+        }
+
+        return updated
+    }
+}

--- a/OpenOats/Sources/OpenOats/Intelligence/TranscriptRefinementEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/TranscriptRefinementEngine.swift
@@ -42,22 +42,15 @@ actor TranscriptRefinementEngine {
     }
 
     /// Await all pending and in-flight refinements, with a timeout.
-    func drain(timeout: Duration = .seconds(5)) async {
-        guard inFlightCount > 0 || !pendingQueue.isEmpty else { return }
-
-        let tasks = activeTasks.values.map { $0 }
-        await withTaskGroup(of: Void.self) { group in
-            group.addTask {
-                for task in tasks {
-                    await task.value
-                }
+    func drain(timeout: Duration = .seconds(300)) async {
+        let deadline = ContinuousClock.now + timeout
+        while (inFlightCount > 0 || !pendingQueue.isEmpty) && ContinuousClock.now < deadline {
+            guard let anyTask = activeTasks.values.first else {
+                drainQueue()
+                try? await Task.sleep(for: .milliseconds(50))
+                continue
             }
-            group.addTask {
-                try? await Task.sleep(for: timeout)
-            }
-            // Return as soon as either completes
-            await group.next()
-            group.cancelAll()
+            await anyTask.value
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -213,6 +213,17 @@ struct SessionRecord: Codable {
         self.conversationStateSummary = conversationStateSummary
         self.refinedText = refinedText
     }
+
+    func withRefinedText(_ text: String?) -> SessionRecord {
+        SessionRecord(
+            speaker: speaker, text: self.text, timestamp: timestamp,
+            suggestions: suggestions, kbHits: kbHits,
+            suggestionDecision: suggestionDecision,
+            surfacedSuggestionText: surfacedSuggestionText,
+            conversationStateSummary: conversationStateSummary,
+            refinedText: text
+        )
+    }
 }
 
 // MARK: - Meeting Templates & Enhanced Notes

--- a/OpenOats/Sources/OpenOats/Storage/SessionStore.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionStore.swift
@@ -128,28 +128,34 @@ actor SessionStore {
         }
     }
 
-    /// Rewrite the current JSONL file, backfilling `refinedText` from the in-memory TranscriptStore.
-    ///
-    /// The 5-second delayed write often captures `refinedText` as nil because the LLM refinement
-    /// call hasn't finished yet. This method is called after both the refinement engine and pending
-    /// writes have drained, so the TranscriptStore now has the final refined text for all utterances.
+    /// Backfill refined text into the current session's JSONL from the in-memory TranscriptStore.
     func backfillRefinedText(from utterances: [Utterance]) {
         guard let currentFile else { return }
 
-        // Close the file handle so we can read/rewrite the file safely
         try? fileHandle?.close()
         fileHandle = nil
 
-        guard let content = try? String(contentsOf: currentFile, encoding: .utf8) else { return }
+        let updated = rewriteJSONLWithRefinedText(file: currentFile, utterances: utterances)
+        _ = updated
+
+        fileHandle = try? FileHandle(forWritingTo: currentFile)
+    }
+
+    /// Backfill refined text into a past session's JSONL.
+    func backfillRefinedText(sessionID: String, from utterances: [Utterance]) {
+        rewriteJSONLWithRefinedText(file: jsonlURL(for: sessionID), utterances: utterances)
+    }
+
+    @discardableResult
+    private func rewriteJSONLWithRefinedText(file: URL, utterances: [Utterance]) -> Bool {
+        guard let content = try? String(contentsOf: file, encoding: .utf8) else { return false }
 
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
 
         let lines = content.components(separatedBy: "\n").filter { !$0.isEmpty }
-        guard !lines.isEmpty else { return }
+        guard !lines.isEmpty else { return false }
 
-        // Build a lookup from (timestamp, speaker) -> refinedText
-        // Uses ISO8601 string representation of the date for reliable matching
         let iso8601Formatter = ISO8601DateFormatter()
         iso8601Formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         var refinedLookup: [String: String] = [:]
@@ -159,11 +165,7 @@ actor SessionStore {
             refinedLookup[key] = refined
         }
 
-        guard !refinedLookup.isEmpty else {
-            // No refined text to backfill; reopen file handle and return
-            fileHandle = try? FileHandle(forWritingTo: currentFile)
-            return
-        }
+        guard !refinedLookup.isEmpty else { return false }
 
         var updatedLines: [String] = []
         var anyUpdated = false
@@ -175,7 +177,6 @@ actor SessionStore {
                 continue
             }
 
-            // Only backfill if the record doesn't already have refinedText
             if record.refinedText == nil {
                 let key = "\(iso8601Formatter.string(from: record.timestamp))|\(record.speaker.rawValue)"
                 if let refined = refinedLookup[key] {
@@ -204,11 +205,10 @@ actor SessionStore {
 
         if anyUpdated {
             let newContent = updatedLines.joined(separator: "\n") + "\n"
-            try? newContent.write(to: currentFile, atomically: true, encoding: .utf8)
+            try? newContent.write(to: file, atomically: true, encoding: .utf8)
         }
 
-        // Reopen file handle for any subsequent writes before endSession()
-        fileHandle = try? FileHandle(forWritingTo: currentFile)
+        return anyUpdated
     }
 
     func endSession() {

--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -16,7 +16,7 @@ struct ControlBar: View {
             // Error banner
             if let error = errorMessage {
                 Text(error)
-                    .font(.system(size: 10))
+                    .font(.system(size: 12))
                     .foregroundStyle(.red)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 16)
@@ -45,9 +45,9 @@ struct ControlBar: View {
             if let status = statusMessage, status != "Ready" {
                 HStack(spacing: 6) {
                     ProgressView()
-                        .controlSize(.mini)
+                        .controlSize(.small)
                     Text(status)
-                        .font(.system(size: 11))
+                        .font(.system(size: 12))
                         .foregroundStyle(.secondary)
                         .accessibilityIdentifier("app.controlBar.status")
                 }

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -12,11 +12,21 @@ struct NotesView: View {
     @State private var sessionToDelete: String?
     @State private var showDeleteConfirmation = false
 
+    enum DetailViewMode: String, CaseIterable {
+        case transcript = "Transcript"
+        case notes = "Notes"
+    }
+
+    @State private var detailViewMode: DetailViewMode = .transcript
+    @State private var showingOriginal = false
+
     var body: some View {
-        NavigationSplitView {
+        HStack(spacing: 0) {
             sidebar
-        } detail: {
+                .frame(width: 250)
+            Divider()
             detailContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .task {
             await coordinator.loadHistory()
@@ -40,9 +50,6 @@ struct NotesView: View {
             if let requested = coordinator.consumeRequestedSessionSelection() {
                 selectedSessionID = requested
             }
-        }
-        .onChange(of: coordinator.sessionHistory.count) {
-            // Refresh sidebar when history changes
         }
     }
 
@@ -102,9 +109,8 @@ struct NotesView: View {
                 }
             }
         }
-        .navigationTitle("Sessions")
-        .frame(minWidth: 200)
-        .accessibilityIdentifier("notes.sessionList")
+        .listStyle(.sidebar)
+        .frame(maxHeight: .infinity)
         .onChange(of: selectedSessionID) {
             loadSelectedSession()
         }
@@ -126,16 +132,188 @@ struct NotesView: View {
     private var detailContent: some View {
         if let sessionID = selectedSessionID {
             VStack(spacing: 0) {
-                if coordinator.notesEngine.isGenerating {
-                    generatingView
-                } else if let notes = loadedNotes {
-                    notesReadyView(notes)
-                } else {
-                    noNotesView(sessionID: sessionID)
+                detailToolbar
+                Divider()
+                detailBody(sessionID: sessionID)
+            }
+            .background {
+                Group {
+                    Button("") { detailViewMode = .transcript }
+                        .keyboardShortcut("1", modifiers: .command)
+                    Button("") { detailViewMode = .notes }
+                        .keyboardShortcut("2", modifiers: .command)
                 }
+                .frame(width: 0, height: 0)
+                .opacity(0)
+                .accessibilityHidden(true)
             }
         } else {
             ContentUnavailableView("Select a Session", systemImage: "doc.text", description: Text("Choose a session from the sidebar to view or generate notes."))
+        }
+    }
+
+    private enum CleanupState {
+        case notCleaned
+        case inProgress
+        case partiallyCleaned
+        case cleaned
+    }
+
+    private var cleanupState: CleanupState {
+        if coordinator.cleanupEngine.isCleaningUp { return .inProgress }
+        guard !loadedTranscript.isEmpty else { return .notCleaned }
+        let hasAnyRefined = loadedTranscript.contains(where: { $0.refinedText != nil })
+        if !hasAnyRefined { return .notCleaned }
+        let allRefined = !loadedTranscript.contains(where: { $0.refinedText == nil })
+        return allRefined ? .cleaned : .partiallyCleaned
+    }
+
+    @ViewBuilder
+    private var detailToolbar: some View {
+        HStack(spacing: 8) {
+            Picker("View", selection: $detailViewMode) {
+                ForEach(DetailViewMode.allCases, id: \.self) { mode in
+                    Text(mode.rawValue).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(minWidth: 120, maxWidth: 220)
+            .layoutPriority(1)
+
+            Spacer(minLength: 4)
+
+            if detailViewMode == .transcript {
+                transcriptToolbarActions
+            } else if detailViewMode == .notes {
+                notesToolbarActions
+            }
+
+            Button {
+                copyCurrentContent()
+            } label: {
+                Label("Copy", systemImage: "doc.on.doc")
+                    .font(.system(size: 12))
+            }
+            .labelStyle(.iconOnly)
+            .buttonStyle(.bordered)
+            .disabled(copyContentIsEmpty)
+            .help("Copy to clipboard")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    @ViewBuilder
+    private var transcriptToolbarActions: some View {
+        switch cleanupState {
+        case .notCleaned:
+            Button {
+                cleanUpTranscript()
+            } label: {
+                Label("Clean Up", systemImage: "sparkles")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(loadedTranscript.isEmpty)
+            .help("Remove filler words and fix punctuation")
+
+        case .inProgress:
+            HStack(spacing: 6) {
+                Text("\(coordinator.cleanupEngine.chunksCompleted)/\(coordinator.cleanupEngine.totalChunks) cleaning...")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                Button("Cancel") {
+                    coordinator.cleanupEngine.cancel()
+                }
+                .buttonStyle(.bordered)
+                .font(.system(size: 11))
+                .controlSize(.small)
+            }
+
+        case .partiallyCleaned:
+            Button {
+                cleanUpTranscript()
+            } label: {
+                Label("Clean Up", systemImage: "sparkles")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.borderedProminent)
+            .help("Clean up remaining utterances")
+
+            Button {
+                showingOriginal.toggle()
+            } label: {
+                Label("Show Original", systemImage: showingOriginal ? "text.badge.checkmark" : "text.badge.minus")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.bordered)
+            .tint(showingOriginal ? .accentColor : nil)
+            .help(showingOriginal ? "Showing original transcript" : "Show original transcript")
+
+        case .cleaned:
+            Button {
+                showingOriginal.toggle()
+            } label: {
+                Label("Show Original", systemImage: showingOriginal ? "text.badge.checkmark" : "text.badge.minus")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.bordered)
+            .tint(showingOriginal ? .accentColor : nil)
+            .help(showingOriginal ? "Showing original transcript" : "Show original transcript")
+        }
+    }
+
+    @ViewBuilder
+    private var notesToolbarActions: some View {
+        if let notes = loadedNotes {
+            Menu {
+                ForEach(coordinator.templateStore.templates) { template in
+                    Button {
+                        regenerateNotes(with: template)
+                    } label: {
+                        Label(template.name, systemImage: template.icon)
+                    }
+                    .disabled(notes.template.id == template.id)
+                }
+            } label: {
+                Label(notes.template.name, systemImage: notes.template.icon)
+                    .font(.system(size: 12))
+            } primaryAction: {
+                regenerateNotes()
+            }
+            .menuStyle(.button)
+            .buttonStyle(.bordered)
+            .fixedSize()
+            .help("Click to regenerate, or pick a different template")
+        }
+    }
+
+    @ViewBuilder
+    private func detailBody(sessionID: String) -> some View {
+        ZStack {
+            transcriptView
+                .zIndex(detailViewMode == .transcript ? 1 : 0)
+                .opacity(detailViewMode == .transcript ? 1 : 0)
+                .allowsHitTesting(detailViewMode == .transcript)
+                .accessibilityHidden(detailViewMode != .transcript)
+
+            notesTab(sessionID: sessionID)
+                .zIndex(detailViewMode == .notes ? 1 : 0)
+                .opacity(detailViewMode == .notes ? 1 : 0)
+                .allowsHitTesting(detailViewMode == .notes)
+                .accessibilityHidden(detailViewMode != .notes)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private func notesTab(sessionID: String) -> some View {
+        if coordinator.notesEngine.isGenerating {
+            generatingView
+        } else if let notes = loadedNotes {
+            notesContentView(notes)
+        } else {
+            notesEmptyState(sessionID: sessionID)
         }
     }
 
@@ -144,125 +322,129 @@ struct NotesView: View {
             VStack(alignment: .leading, spacing: 12) {
                 HStack {
                     ProgressView()
-                        .scaleEffect(0.8)
+                        .controlSize(.small)
                     Text("Generating notes...")
-                        .font(.system(size: 13))
+                        .font(.system(size: 12))
                         .foregroundStyle(.secondary)
                         .accessibilityIdentifier("notes.generating")
                     Spacer()
                     Button("Cancel") {
                         coordinator.notesEngine.cancel()
                     }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(.red)
+                    .buttonStyle(.bordered)
+                    .font(.system(size: 11))
                 }
 
                 markdownContent(coordinator.notesEngine.generatedMarkdown)
             }
-            .padding(20)
+            .padding(16)
         }
     }
 
-    private func notesReadyView(_ notes: EnhancedNotes) -> some View {
-        VStack(spacing: 0) {
-            // Toolbar
-            HStack {
-                Label(notes.template.name, systemImage: notes.template.icon)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                Spacer()
-                Text("Generated \(notes.generatedAt, style: .relative) ago")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.tertiary)
-
-                Button {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(notes.markdown, forType: .string)
-                } label: {
-                    Label("Copy", systemImage: "doc.on.doc")
-                        .font(.system(size: 12))
-                }
-                .buttonStyle(.bordered)
-
-                Button {
-                    regenerateNotes()
-                } label: {
-                    Label("Regenerate", systemImage: "arrow.clockwise")
-                        .font(.system(size: 12))
-                }
-                .buttonStyle(.bordered)
-            }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 10)
-
-            Divider()
-
-            ScrollView {
-                markdownContent(notes.markdown)
-                    .padding(20)
-                    .accessibilityIdentifier("notes.renderedMarkdown")
-            }
+    private func notesContentView(_ notes: EnhancedNotes) -> some View {
+        ScrollView {
+            markdownContent(notes.markdown)
+                .padding(16)
         }
     }
 
-    private func noNotesView(sessionID: String) -> some View {
-        VStack(spacing: 16) {
+    private func notesEmptyState(sessionID: String) -> some View {
+        ContentUnavailableView {
+            Label("Generate Notes", systemImage: "sparkles")
+        } description: {
+            Text("Summarize this transcript into structured meeting notes.")
+        } actions: {
             if let error = coordinator.notesEngine.error {
                 Text(error)
                     .foregroundStyle(.red)
                     .font(.system(size: 12))
             }
 
-            if !loadedTranscript.isEmpty {
-                // Transcript preview
-                ScrollView {
-                    VStack(alignment: .leading, spacing: 4) {
-                        ForEach(Array(loadedTranscript.prefix(20).enumerated()), id: \.offset) { _, record in
-                            HStack(alignment: .top, spacing: 8) {
-                                Text(record.speaker == .you ? "You" : "Them")
-                                    .font(.system(size: 11, weight: .semibold, design: .monospaced))
-                                    .foregroundStyle(record.speaker == .you ? .blue : .green)
-                                    .frame(width: 35, alignment: .trailing)
-                                Text(record.text)
-                                    .font(.system(size: 12))
-                                    .foregroundStyle(.primary)
-                            }
-                        }
-                        if loadedTranscript.count > 20 {
-                            Text("... and \(loadedTranscript.count - 20) more utterances")
-                                .font(.system(size: 11))
-                                .foregroundStyle(.tertiary)
-                                .padding(.top, 4)
-                        }
-                    }
-                    .padding(16)
-                }
-                .frame(maxHeight: 300)
-                .background(.quaternary.opacity(0.3))
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+            Button {
+                generateNotes(sessionID: sessionID)
+            } label: {
+                Label("Generate Notes", systemImage: "sparkles")
             }
+            .buttonStyle(.borderedProminent)
+            .disabled(loadedTranscript.isEmpty)
+        }
+    }
 
-            // Template picker for generation
-            HStack {
-                Picker("Template", selection: $selectedTemplateForGeneration) {
-                    ForEach(coordinator.templateStore.templates) { template in
-                        Label(template.name, systemImage: template.icon).tag(Optional(template))
+    // MARK: - Transcript Views
+
+    @ViewBuilder
+    private var transcriptView: some View {
+        if loadedTranscript.isEmpty {
+            ContentUnavailableView("No Transcript", systemImage: "waveform", description: Text("This session has no recorded utterances."))
+        } else {
+            ScrollView {
+                if coordinator.cleanupEngine.isCleaningUp {
+                    cleanupProgressBanner
+                }
+                if let cleanupError = coordinator.cleanupEngine.error {
+                    Text(cleanupError)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.red)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 4)
+                }
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    let isCleaning = coordinator.cleanupEngine.isCleaningUp
+                    ForEach(Array(loadedTranscript.enumerated()), id: \.offset) { _, record in
+                        transcriptRow(record: record, isCleaning: isCleaning)
                     }
                 }
-                .frame(maxWidth: 200)
-
-                Button {
-                    generateNotes(sessionID: sessionID)
-                } label: {
-                    Label("Generate Notes", systemImage: "sparkles")
-                }
-                .buttonStyle(.borderedProminent)
-                .disabled(loadedTranscript.isEmpty)
-                .accessibilityIdentifier("notes.generateButton")
+                .padding(16)
             }
         }
-        .padding(20)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var cleanupProgressBanner: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+            Text("Cleaning up transcript... \(coordinator.cleanupEngine.chunksCompleted)/\(coordinator.cleanupEngine.totalChunks) sections")
+                .font(.system(size: 12))
+                .lineLimit(1)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button("Cancel") {
+                coordinator.cleanupEngine.cancel()
+            }
+            .buttonStyle(.bordered)
+            .font(.system(size: 11))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(.bar)
+    }
+
+    @ViewBuilder
+    private func transcriptRow(record: SessionRecord, isCleaning: Bool) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(record.speaker == .you ? "You" : "Them")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(record.speaker == .you ? Color.youColor : Color.themColor)
+                .frame(width: 36, alignment: .trailing)
+
+            let displayText = showingOriginal ? record.text : (record.refinedText ?? record.text)
+            Text(displayText)
+                .font(.system(size: 13))
+                .foregroundStyle(
+                    isCleaning && record.refinedText == nil ? .secondary : .primary
+                )
+                .textSelection(.enabled)
+        }
+    }
+
+    private var copyContentIsEmpty: Bool {
+        switch detailViewMode {
+        case .transcript:
+            return loadedTranscript.isEmpty
+        case .notes:
+            return loadedNotes == nil
+        }
     }
 
     // MARK: - Markdown Rendering
@@ -344,6 +526,23 @@ struct NotesView: View {
 
     // MARK: - Actions
 
+    private func copyCurrentContent() {
+        let text: String
+        switch detailViewMode {
+        case .transcript:
+            text = loadedTranscript.map { record in
+                let label = record.speaker == .you ? "You" : "Them"
+                let content = showingOriginal ? record.text : (record.refinedText ?? record.text)
+                return "[\(Self.transcriptTimeFormatter.string(from: record.timestamp))] \(label): \(content)"
+            }.joined(separator: "\n")
+        case .notes:
+            text = loadedNotes?.markdown ?? ""
+        }
+
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(text, forType: .string)
+    }
+
     private func loadSelectedSession() {
         guard let sessionID = selectedSessionID else {
             loadedNotes = nil
@@ -351,9 +550,22 @@ struct NotesView: View {
             return
         }
 
+        // Clear immediately to prevent stale content flash
+        loadedNotes = nil
+        loadedTranscript = []
+        showingOriginal = false
+        coordinator.cleanupEngine.cancel()
+
         Task {
-            loadedNotes = await coordinator.sessionStore.loadNotes(sessionID: sessionID)
-            loadedTranscript = await coordinator.sessionStore.loadTranscript(sessionID: sessionID)
+            let notes = await coordinator.sessionStore.loadNotes(sessionID: sessionID)
+            let transcript = await coordinator.sessionStore.loadTranscript(sessionID: sessionID)
+
+            // Guard against rapid session switching
+            guard selectedSessionID == sessionID else { return }
+
+            loadedNotes = notes
+            loadedTranscript = transcript
+            detailViewMode = notes != nil ? .notes : .transcript
 
             // Default template for generation
             let session = coordinator.sessionHistory.first { $0.id == sessionID }
@@ -413,9 +625,42 @@ struct NotesView: View {
         }
     }
 
-    private func regenerateNotes() {
+    private func regenerateNotes(with template: MeetingTemplate? = nil) {
         guard let sessionID = selectedSessionID else { return }
+        if let template {
+            selectedTemplateForGeneration = template
+        }
         loadedNotes = nil
         generateNotes(sessionID: sessionID)
+    }
+
+    private static let transcriptTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm:ss"
+        return f
+    }()
+
+    private func cleanUpTranscript() {
+        guard let sessionID = selectedSessionID, !loadedTranscript.isEmpty else { return }
+
+        Task {
+            let updated = await coordinator.cleanupEngine.cleanup(
+                records: loadedTranscript,
+                settings: settings
+            )
+
+            let utterances = updated.map { record in
+                Utterance(
+                    text: record.text,
+                    speaker: record.speaker,
+                    timestamp: record.timestamp,
+                    refinedText: record.refinedText
+                )
+            }
+            await coordinator.sessionStore.backfillRefinedText(sessionID: sessionID, from: utterances)
+
+            guard selectedSessionID == sessionID else { return }
+            loadedTranscript = await coordinator.sessionStore.loadTranscript(sessionID: sessionID)
+        }
     }
 }

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -179,9 +179,9 @@ struct SettingsView: View {
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
 
-                Toggle("Refine transcript", isOn: $settings.enableTranscriptRefinement)
+                Toggle("Clean up transcript during recording", isOn: $settings.enableTranscriptRefinement)
                     .font(.system(size: 12))
-                Text("Uses your LLM provider to clean up filler words and fix punctuation in real-time. Original text is preserved.")
+                Text("Automatically removes filler words and fixes punctuation as you record. You can always clean up past transcripts manually from the Notes window.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
 


### PR DESCRIPTION
## Bug

The existing transcript refinement flow has three compounding problems:

1. **Slow**: Per-utterance LLM calls process 300+ utterances individually. A 30-minute meeting takes minutes to refine.
2. **Silent failures**: No progress indicator, no error reporting. Users stare at a spinner with no feedback.
3. **Confusing UI**: The 3-tab model (Raw / Refined / Notes) forces users to choose between tabs they don't understand the difference between.

Additionally, `refinedText` never persists to session JSONL files (#69 scope) because `appendRecordDelayed()` captures the field before the LLM call finishes.

## Fix

### New `TranscriptCleanupEngine`

Batch processor that chunks the transcript into ~2.5-minute time blocks and runs 3 concurrent LLM calls via `TaskGroup`. A 300-utterance transcript finishes in seconds instead of minutes.

- `@Observable @MainActor` class following the same pattern as `NotesEngine`
- `nonisolated static` methods for off-main-actor LLM work
- Per-chunk fallback on failure (one bad chunk doesn't kill the whole run)
- `cancel()` resets all observable state immediately

### 2-tab NotesView redesign

| Before | After |
|--------|-------|
| 3 tabs: Raw / Refined / Notes | 2 tabs: Transcript / Notes |
| No progress feedback | Progress banner with chunk counter + cancel |
| No way to compare original vs cleaned | "Show Original" toggle |
| Separate regenerate + template picker | Split-button: click = regenerate, chevron = pick template |

The transcript tab uses a 4-state model (`notCleaned` / `inProgress` / `partiallyCleaned` / `cleaned`) to show the right controls at each stage. `ZStack` with opacity toggling preserves scroll position across tab switches.

### 8 UI consistency fixes

Design review caught these inconsistencies across the new and existing views:

| # | Issue | Fix |
|---|-------|-----|
| 1 | "Clean Up" `.bordered` but "Generate Notes" `.borderedProminent` | Both `.borderedProminent` |
| 2 | Three different error patterns (yellow icon / red text / red inline) | Unified: red text, size 12 |
| 3 | Spinner scale `0.8` vs `0.7` vs `.controlSize(.mini)` | All `.controlSize(.small)` |
| 4 | Progress text font 13 / 12 / 11 across contexts | All size 12 |
| 5 | Toolbar padding 20px vs content padding 16px (4px ledge) | All 16px |
| 6 | Menu `.button` style vs Button `.bordered` style | Menu gets `.buttonStyle(.bordered)` |
| 7 | No cancel button in toolbar progress counter | Added |
| 8 | Yellow warning icon vs red error text for same failure type | Consistent red text |

### Persistence fix

`backfillRefinedText()` rewrites the session JSONL at finalization, after the refinement engine has drained. This fixes the race condition where `appendRecordDelayed()` captured `refinedText` before the LLM finished.

## Changed files

| File | What changed |
|------|-------------|
| `TranscriptCleanupEngine.swift` | **New.** Batch cleanup engine (285 lines) |
| `NotesView.swift` | 2-tab redesign, cleanup UI, 8 consistency fixes |
| `ControlBar.swift` | Error font + spinner size consistency |
| `AppCoordinator.swift` | Expose `cleanupEngine` property |
| `SessionStore.swift` | `backfillRefinedText()` for persistence fix |
| `Models.swift` | `SessionRecord.withRefinedText()` copy helper |
| `SettingsView.swift` | Toggle wording: "Clean up transcript during recording" |
| `TranscriptRefinementEngine.swift` | Minor cleanup (kept for live during-recording use) |

## Test plan

- [ ] Open Notes window on a past session with 50+ utterances
- [ ] Tap "Clean Up" - progress banner appears with chunk counter and cancel
- [ ] Cleanup completes in seconds, not minutes
- [ ] "Show Original" toggle switches between raw and cleaned text
- [ ] Cancel mid-cleanup - partial results preserved, button reappears
- [ ] Trigger a cleanup error (e.g. invalid API key) - red error text, not yellow icon
- [ ] Switch to Notes tab - generate notes with streaming, try regenerate split-button
- [ ] Cmd+1 / Cmd+2 keyboard shortcuts switch tabs
- [ ] Kill and relaunch the app - refined text persists in the session
- [ ] Verify no 4px padding ledge between toolbar and content area