### PR TITLE
Fix ui-smoke test for 2-tab NotesView

### DIFF
--- a/UITests/OpenOatsUITests/SmokeTests.swift
+++ b/UITests/OpenOatsUITests/SmokeTests.swift
@@ -43,6 +43,13 @@ final class SmokeTests: XCTestCase {
         let deepLink = URL(string: "openoats://notes?sessionID=session_ui_test_notes")!
         openDeepLink(deepLink)
 
+        // The 2-tab NotesView defaults to the Transcript tab.
+        // Switch to the Notes tab before asserting on the generate button.
+        let notesTab = app.buttons["Notes"]
+        if notesTab.waitForExistence(timeout: 3) {
+            notesTab.click()
+        }
+
         XCTAssertTrue(element(in: app, identifier: "notes.generateButton").waitForExistence(timeout: 5))
         element(in: app, identifier: "notes.generateButton").click()
         XCTAssertTrue(element(in: app, identifier: "notes.renderedMarkdown").waitForExistence(timeout: 5))


### PR DESCRIPTION
## Summary
- The `testNotesSmokeSupportsDeepLinkAndGeneration` smoke test fails on PRs #82 and #83 because `NotesView` now defaults to the Transcript tab
- Adds a tab switch to "Notes" before asserting on `notes.generateButton`

## Test plan
- [ ] `ui-smoke` CI check passes on this PR
- [ ] Rebase PRs #82 and #83 on top of this to unblock them

🤖 Generated with [Claude Code](https://claude.com/claude-code)