### PR TITLE
Add WhatsApp, Google Meet PWA, and classic Teams to meeting auto-detection

### DIFF
--- a/OpenOats/Sources/OpenOats/Meeting/MeetingDetector.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/MeetingDetector.swift
@@ -283,6 +283,7 @@ actor MeetingDetector {
 
     private static let defaultMeetingApps: [MeetingAppEntry] = [
         MeetingAppEntry(bundleID: "us.zoom.xos", displayName: "Zoom"),
+        MeetingAppEntry(bundleID: "com.microsoft.teams", displayName: "Microsoft Teams (classic)"),
         MeetingAppEntry(bundleID: "com.microsoft.teams2", displayName: "Microsoft Teams"),
         MeetingAppEntry(bundleID: "com.apple.FaceTime", displayName: "FaceTime"),
         MeetingAppEntry(bundleID: "com.cisco.webexmeetingsapp", displayName: "Webex"),
@@ -290,5 +291,7 @@ actor MeetingDetector {
         MeetingAppEntry(bundleID: "co.around.Around", displayName: "Around"),
         MeetingAppEntry(bundleID: "com.slack.Slack", displayName: "Slack"),
         MeetingAppEntry(bundleID: "com.hnc.Discord", displayName: "Discord"),
+        MeetingAppEntry(bundleID: "net.whatsapp.WhatsApp", displayName: "WhatsApp"),
+        MeetingAppEntry(bundleID: "com.google.Chrome.app.kjgfgldnnfobanmcafgkdilakhehfkbm", displayName: "Google Meet (PWA)"),
     ]
 }


### PR DESCRIPTION
## Summary
- Adds WhatsApp Desktop (`net.whatsapp.WhatsApp`) to the known meeting apps list
- Adds Google Meet PWA (`com.google.Chrome.app.kjgfgldnnfobanmcafgkdilakhehfkbm`) to the known meeting apps list
- Adds legacy Microsoft Teams (`com.microsoft.teams`) alongside the existing new Teams entry

Closes #75 — meeting auto-detection failed for WhatsApp Desktop (not in list) and potentially for users running the classic Teams app (different bundle ID from Teams 2.0).

## Test plan
- [ ] `validate-swift` CI passes
- [ ] Manual: launch WhatsApp Desktop call → verify auto-detection triggers
- [ ] Manual: launch Teams call → verify auto-detection triggers