### PR TITLE
Add acoustic echo cancellation (AEC) for mic input

### DIFF
--- a/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
@@ -33,7 +33,7 @@ final class MicCapture: @unchecked Sendable {
         )
     }
 
-    func bufferStream(deviceID: AudioDeviceID? = nil) -> AsyncStream<AVAudioPCMBuffer> {
+    func bufferStream(deviceID: AudioDeviceID? = nil, echoCancellation: Bool = false) -> AsyncStream<AVAudioPCMBuffer> {
         // Defensive cleanup of any prior state
         _streamContinuation.withLock { $0?.finish(); $0 = nil }
         engine.inputNode.removeTap(onBus: 0)
@@ -54,6 +54,16 @@ final class MicCapture: @unchecked Sendable {
 
             let inputNode = engine.inputNode
             diagLog("[MIC-1b] input node ready")
+
+            // Enable voice processing (AEC + noise suppression) if requested
+            if echoCancellation {
+                do {
+                    try inputNode.setVoiceProcessingEnabled(true)
+                    diagLog("[MIC-1c] voice processing (AEC) enabled")
+                } catch {
+                    diagLog("[MIC-1c] failed to enable voice processing: \(error.localizedDescription)")
+                }
+            }
 
             // Set input device before accessing inputNode format
             var resolvedDeviceID: AudioDeviceID?

--- a/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
+++ b/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
@@ -416,6 +416,19 @@ final class AppSettings {
         }
     }
 
+    /// When true, Apple's voice-processing IO is enabled on the mic input to cancel
+    /// speaker echo and reduce double-transcription when using built-in speakers + mic.
+    @ObservationIgnored nonisolated(unsafe) private var _enableEchoCancellation: Bool
+    var enableEchoCancellation: Bool {
+        get { access(keyPath: \.enableEchoCancellation); return _enableEchoCancellation }
+        set {
+            withMutation(keyPath: \.enableEchoCancellation) {
+                _enableEchoCancellation = newValue
+                defaults.set(newValue, forKey: "enableEchoCancellation")
+            }
+        }
+    }
+
     /// When true, uses the LLM to clean up filler words and fix punctuation in real-time.
     @ObservationIgnored nonisolated(unsafe) private var _enableTranscriptRefinement: Bool
     var enableTranscriptRefinement: Bool {
@@ -554,6 +567,13 @@ final class AppSettings {
         self._hasAcknowledgedRecordingConsent = defaults.bool(forKey: "hasAcknowledgedRecordingConsent")
         self._saveAudioRecording = defaults.bool(forKey: "saveAudioRecording")
         self._enableTranscriptRefinement = defaults.bool(forKey: "enableTranscriptRefinement")
+
+        // Echo cancellation — default to enabled
+        if defaults.object(forKey: "enableEchoCancellation") == nil {
+            self._enableEchoCancellation = true
+        } else {
+            self._enableEchoCancellation = defaults.bool(forKey: "enableEchoCancellation")
+        }
 
         // Default to true (shown) if key has never been set
         if defaults.object(forKey: "showLiveTranscript") == nil {

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -547,7 +547,7 @@ final class TranscriptionEngine {
         vadManager: VadManager,
         deviceID: AudioDeviceID
     ) {
-        var micStream = micCapture.bufferStream(deviceID: deviceID)
+        var micStream = micCapture.bufferStream(deviceID: deviceID, echoCancellation: settings.enableEchoCancellation)
         if let recorder = audioRecorder {
             micStream = Self.tappedStream(micStream) { buffer in
                 recorder.writeMicBuffer(buffer)

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -149,6 +149,12 @@ struct SettingsView: View {
                 Text("Save a local audio file (.m4a) alongside each transcript. Audio never leaves your device.")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
+
+                Toggle("Echo cancellation", isOn: $settings.enableEchoCancellation)
+                    .font(.system(size: 12))
+                Text("Reduces duplicate transcription when using speakers and microphone simultaneously. Takes effect on next session.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
             }
 
             Section("Transcription") {


### PR DESCRIPTION
## Summary
- Enables Apple's built-in voice processing (`setVoiceProcessingEnabled`) on the AVAudioEngine mic input to cancel speaker echo
- Adds `enableEchoCancellation` setting (default: on) with toggle in Settings > Recording
- Prevents duplicate transcription when using built-in speakers + mic simultaneously (common MacBook setup)

Closes #88

## Implementation
- **MicCapture**: `bufferStream()` accepts `echoCancellation` param; when true, calls `inputNode.setVoiceProcessingEnabled(true)` before starting capture
- **AppSettings**: New `enableEchoCancellation` bool, defaults to `true`
- **TranscriptionEngine**: Passes the setting through when starting the mic stream
- **SettingsView**: Toggle in Recording section with description

## Test plan
- [ ] `validate-swift` CI passes
- [ ] Manual: enable AEC, play audio through speakers while recording with built-in mic — verify reduced echo in transcription
- [ ] Manual: disable AEC in Settings, restart session — verify original behavior
- [ ] Manual: verify toggle persists across app restarts