### PR TITLE
Fix model download retry when cached files are corrupt

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/ParakeetBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/ParakeetBackend.swift
@@ -23,6 +23,11 @@ final class ParakeetBackend: TranscriptionBackend, @unchecked Sendable {
         return exists ? .ready : .needsDownload(prompt: "Transcription requires a one-time model download.")
     }
 
+    func clearModelCache() {
+        let cacheDir = AsrModels.defaultCacheDirectory(for: version)
+        try? FileManager.default.removeItem(at: cacheDir)
+    }
+
     func prepare(onStatus: @Sendable (String) -> Void) async throws {
         onStatus("Downloading \(displayName)...")
         let models = try await AsrModels.downloadAndLoad(version: version)

--- a/OpenOats/Sources/OpenOats/Transcription/Qwen3Backend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/Qwen3Backend.swift
@@ -12,6 +12,11 @@ final class Qwen3Backend: TranscriptionBackend, @unchecked Sendable {
         return exists ? .ready : .needsDownload(prompt: "Qwen3 ASR requires a one-time model download.")
     }
 
+    func clearModelCache() {
+        let cacheDir = Qwen3AsrModels.defaultCacheDirectory()
+        try? FileManager.default.removeItem(at: cacheDir)
+    }
+
     func prepare(onStatus: @Sendable (String) -> Void) async throws {
         onStatus("Downloading \(displayName)...")
         let modelsDirectory = try await Qwen3AsrModels.download()

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionBackend.swift
@@ -25,6 +25,13 @@ protocol TranscriptionBackend: Sendable {
     /// Transcribe a segment of Float32 audio samples at 16kHz mono.
     /// Returns the transcribed text, or empty string if no speech detected.
     func transcribe(_ samples: [Float], locale: Locale) async throws -> String
+
+    /// Remove cached model files so the next prepare() triggers a fresh download.
+    func clearModelCache()
+}
+
+extension TranscriptionBackend {
+    func clearModelCache() {}
 }
 
 enum TranscriptionBackendError: Error {

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -212,6 +212,11 @@ final class TranscriptionEngine {
             lastError = msg
             assetStatus = "Ready"
             isRunning = false
+            // Clear corrupt cache so the next attempt triggers a fresh download
+            settings.transcriptionModel.makeBackend().clearModelCache()
+            diagLog("[ENGINE-2-FAIL] cleared model cache for \(settings.transcriptionModel.rawValue)")
+            needsModelDownload = true
+            downloadConfirmed = false
             return
         }
 

--- a/OpenOats/Sources/OpenOats/Transcription/WhisperKitBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/WhisperKitBackend.swift
@@ -19,6 +19,20 @@ final class WhisperKitBackend: TranscriptionBackend, @unchecked Sendable {
         )
     }
 
+    func clearModelCache() {
+        let fm = FileManager.default
+        guard let documentsDir = fm.urls(for: .documentDirectory, in: .userDomainMask).first else { return }
+        let hfCacheDir = documentsDir
+            .appendingPathComponent("huggingface")
+            .appendingPathComponent("models")
+            .appendingPathComponent("argmaxinc")
+            .appendingPathComponent("whisperkit-coreml")
+        guard let contents = try? fm.contentsOfDirectory(atPath: hfCacheDir.path) else { return }
+        for entry in contents where entry.contains("whisper-\(variant.rawValue)") {
+            try? fm.removeItem(at: hfCacheDir.appendingPathComponent(entry))
+        }
+    }
+
     func prepare(onStatus: @Sendable (String) -> Void) async throws {
         onStatus("Downloading \(displayName)...")
         let manager = WhisperKitManager(variant: variant)


### PR DESCRIPTION
## Problem

When model files exist on disk but are invalid (incomplete download, corrupt CoreML bundle), clicking "Download Now" silently does nothing. The cycle:

1. `modelsExist()` checks file/directory presence, not validity
2. `download(force: false)` sees files exist, skips download
3. `prepare()` tries `MLModel.load()`, fails on corrupt data
4. Catch block sets `lastError` but leaves `needsModelDownload = false`
5. User sees error + "Download Now" button, but clicking it repeats the same cycle

## Solution

Add `clearModelCache()` to the `TranscriptionBackend` protocol with a default no-op. Each backend implements it to delete its specific cache directory. On model load failure, the engine now:

1. Calls `clearModelCache()` to remove the corrupt files
2. Sets `needsModelDownload = true` so the UI shows the download prompt
3. Resets `downloadConfirmed = false` so the download gate works correctly

The next "Download Now" click triggers a fresh download because the files are gone.

## Changed files

| File | What |
|------|------|
| `TranscriptionBackend.swift` | Add `clearModelCache()` to protocol with default no-op |
| `TranscriptionEngine.swift` | Call `clearModelCache()` and reset state on load failure |
| `Qwen3Backend.swift` | Implement cache clear for `~/Library/Application Support/FluidAudio/Models/` |
| `ParakeetBackend.swift` | Implement cache clear for versioned Parakeet cache |
| `WhisperKitBackend.swift` | Implement cache clear for `~/Documents/huggingface/models/` |

## Test plan

- [ ] Delete or corrupt a model file in `~/Library/Application Support/FluidAudio/Models/qwen3-asr-0.6b-coreml/f32/`
- [ ] Launch app, observe "Failed to load models" error with "Download Now" button
- [ ] Click "Download Now" - should trigger fresh download and succeed
- [ ] Verify diagnostic log shows `[ENGINE-2-FAIL] cleared model cache for ...`
- [ ] Repeat for Parakeet and WhisperKit backends


🤖 Generated with [Claude Code](https://claude.com/claude-code)