### PR TITLE
Fix Check for Updates unreachable in background mode

### DIFF
--- a/OpenOats/Sources/OpenOats/App/MenuBarController.swift
+++ b/OpenOats/Sources/OpenOats/App/MenuBarController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Observation
+import Sparkle
 import SwiftUI
 
 @MainActor
@@ -13,7 +14,7 @@ final class MenuBarController {
     var onShowMainWindow: (() -> Void)?
     var onQuitApp: (() -> Void)?
 
-    init(coordinator: AppCoordinator, settings: AppSettings) {
+    init(coordinator: AppCoordinator, settings: AppSettings, updater: SPUUpdater) {
         self.coordinator = coordinator
         self.settings = settings
 
@@ -26,6 +27,7 @@ final class MenuBarController {
         let popoverView = MenuBarPopoverView(
             coordinator: coordinator,
             settings: settings,
+            updater: updater,
             onShowMainWindow: { [weak self] in
                 self?.popover.performClose(nil)
                 self?.onShowMainWindow?()

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -36,6 +36,7 @@ public struct OpenOatsRootApp: App {
                         appDelegate.setupMenuBarIfNeeded(
                             coordinator: coordinator,
                             settings: settings,
+                            updater: updaterController.updater,
                             showMainWindow: { [self] in showMainWindow() }
                         )
                     }
@@ -129,6 +130,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func setupMenuBarIfNeeded(
         coordinator: AppCoordinator,
         settings: AppSettings,
+        updater: SPUUpdater,
         showMainWindow: @escaping () -> Void
     ) {
         guard menuBarController == nil else { return }
@@ -137,7 +139,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
 
         let controller = MenuBarController(
             coordinator: coordinator,
-            settings: settings
+            settings: settings,
+            updater: updater
         )
         controller.onShowMainWindow = showMainWindow
         controller.onQuitApp = { [weak self] in

--- a/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
+++ b/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
@@ -1,8 +1,10 @@
+import Sparkle
 import SwiftUI
 
 struct MenuBarPopoverView: View {
     let coordinator: AppCoordinator
     let settings: AppSettings
+    let updater: SPUUpdater
     let onShowMainWindow: () -> Void
     let onQuit: () -> Void
 
@@ -34,6 +36,16 @@ struct MenuBarPopoverView: View {
             Button(action: onShowMainWindow) {
                 HStack {
                     Text("Show OpenOats")
+                    Spacer()
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+
+            Button(action: { updater.checkForUpdates() }) {
+                HStack {
+                    Text("Check for Updates…")
                     Spacer()
                 }
             }


### PR DESCRIPTION
## Summary

- **Root cause**: When the main window is closed, the app switches to `NSApp.setActivationPolicy(.accessory)` (LSUIElement). This hides the app menu bar entirely — the only place "Check for Updates" existed. Users in background mode (menu bar only) had no way to trigger Sparkle update checks.
- **Fix**: Thread `SPUUpdater` through `MenuBarController` to `MenuBarPopoverView` and add a "Check for Updates…" button in the popover alongside "Show OpenOats" and "Quit OpenOats".

## Test plan

- [ ] Close the main window (app goes to background/menu bar mode)
- [ ] Click the menu bar icon → popover shows "Check for Updates…"
- [ ] Click it → Sparkle update dialog appears
- [ ] With main window open → app menu "Check for Updates…" still works