### PR TITLE
Bump FluidAudio 0.12.1 → 0.12.5: fix Qwen3 ASR model download

### DIFF
--- a/OpenOats/Package.resolved
+++ b/OpenOats/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "1cf23303df75df13e8dc92a0343c40006fbbe234",
-        "version" : "0.12.1"
+        "revision" : "2d2979486bd7125558fe783741ef9a2757b3c1bb",
+        "version" : "0.12.5"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Bumps FluidAudio from 0.12.1 to 0.12.5 in `Package.resolved`
- Fixes Qwen3 ASR model download that silently fails on every install

## Root cause

FluidAudio 0.12.1's `Repo.qwen3Asr.subPath` returns `"qwen3-asr-0.6b-coreml-f32"` instead of `"f32"`, causing the HuggingFace directory listing API to 404. The error is silently swallowed (`guard let items = ... as? [[String: Any]]` fails on the JSON error object), so `DownloadUtils` finds 0 files, creates an empty directory, and the model load fails with "Failed to load models."

Fixed in FluidAudio 0.12.4 via FluidInference/FluidAudio#53.

## Impact

Every user selecting Qwen3 ASR on OpenOats 1.12.7–1.16.1 hits this — the Download button never works. Manual model installation is the only workaround.

## Note

I couldn't run `swift package resolve` locally (Swift 6.1 installed, Package.swift requires 6.2). The `originHash` in Package.resolved may need regeneration on your end. The revision and version for FluidAudio 0.12.5 are correct (tag `v0.12.5` → commit `2d2979486bd7125558fe783741ef9a2757b3c1bb`).

Refs: #102