### PR TITLE
Add user-configurable suggestion verbosity setting

### DIFF
--- a/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
@@ -33,17 +33,23 @@ final class SuggestionEngine {
 
     // MARK: - Thresholds
 
-    private let cooldownSeconds: TimeInterval = 90
+    private var cooldownSeconds: TimeInterval { settings.suggestionVerbosity.cooldownSeconds }
     private let minUtteranceWordCount = 8
     private let minUtteranceCharCount = 30
     private let minKBRelevanceScore: Double = 0.35
 
-    // Gate thresholds
-    private let minRelevanceScore: Double = 0.72
-    private let minHelpfulnessScore: Double = 0.75
-    private let minTimingScore: Double = 0.70
-    private let minNoveltyScore: Double = 0.65
-    private let minConfidenceScore: Double = 0.75
+    // Base gate thresholds, scaled by verbosity
+    private static let baseRelevanceScore: Double = 0.72
+    private static let baseHelpfulnessScore: Double = 0.75
+    private static let baseTimingScore: Double = 0.70
+    private static let baseNoveltyScore: Double = 0.65
+    private static let baseConfidenceScore: Double = 0.75
+
+    private var minRelevanceScore: Double { Self.baseRelevanceScore * settings.suggestionVerbosity.thresholdMultiplier }
+    private var minHelpfulnessScore: Double { Self.baseHelpfulnessScore * settings.suggestionVerbosity.thresholdMultiplier }
+    private var minTimingScore: Double { Self.baseTimingScore * settings.suggestionVerbosity.thresholdMultiplier }
+    private var minNoveltyScore: Double { Self.baseNoveltyScore * settings.suggestionVerbosity.thresholdMultiplier }
+    private var minConfidenceScore: Double { Self.baseConfidenceScore * settings.suggestionVerbosity.thresholdMultiplier }
 
     private let transcriptStore: TranscriptStore
     private let knowledgeBase: KnowledgeBase

--- a/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
+++ b/OpenOats/Sources/OpenOats/Settings/AppSettings.swift
@@ -4,6 +4,52 @@ import Observation
 import Security
 import CoreAudio
 
+/// Controls how eagerly the suggestion engine surfaces talking points.
+enum SuggestionVerbosity: String, CaseIterable, Identifiable {
+    /// Mostly silent — surfaces suggestions only when highly relevant (current default behavior).
+    case quiet
+    /// Balanced — moderate cooldown, slightly lower thresholds.
+    case balanced
+    /// Eager — short cooldown, lower thresholds for frequent fact-retrieval style use.
+    case eager
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .quiet: "Quiet"
+        case .balanced: "Balanced"
+        case .eager: "Eager"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .quiet: "Surfaces suggestions only when highly relevant"
+        case .balanced: "Moderate frequency, good for most meetings"
+        case .eager: "Frequent suggestions, good for fact retrieval"
+        }
+    }
+
+    /// Seconds between consecutive suggestions.
+    var cooldownSeconds: TimeInterval {
+        switch self {
+        case .quiet: 90
+        case .balanced: 45
+        case .eager: 15
+        }
+    }
+
+    /// Multiplier applied to gate score thresholds. Lower = easier to surface.
+    var thresholdMultiplier: Double {
+        switch self {
+        case .quiet: 1.0
+        case .balanced: 0.85
+        case .eager: 0.70
+        }
+    }
+}
+
 enum LLMProvider: String, CaseIterable, Identifiable {
     case openRouter
     case ollama
@@ -563,6 +609,20 @@ final class AppSettings {
         }
     }
 
+    // MARK: - Suggestions
+
+    /// How eagerly the suggestion engine surfaces talking points.
+    @ObservationIgnored nonisolated(unsafe) private var _suggestionVerbosity: SuggestionVerbosity
+    var suggestionVerbosity: SuggestionVerbosity {
+        get { access(keyPath: \.suggestionVerbosity); return _suggestionVerbosity }
+        set {
+            withMutation(keyPath: \.suggestionVerbosity) {
+                _suggestionVerbosity = newValue
+                defaults.set(newValue.rawValue, forKey: "suggestionVerbosity")
+            }
+        }
+    }
+
     init(storage: AppSettingsStorage = .live()) {
         self.defaults = storage.defaults
         self.secretStore = storage.secretStore
@@ -632,6 +692,9 @@ final class AppSettings {
             ? defaults.integer(forKey: "silenceTimeoutMinutes") : 15
         self._customMeetingAppBundleIDs = defaults.stringArray(forKey: "customMeetingAppBundleIDs") ?? []
         self._detectionLogEnabled = defaults.bool(forKey: "detectionLogEnabled")
+        self._suggestionVerbosity = SuggestionVerbosity(
+            rawValue: defaults.string(forKey: "suggestionVerbosity") ?? ""
+        ) ?? .quiet
 
         // Default to true (hidden) if key has never been set
         if defaults.object(forKey: "hideFromScreenShare") == nil {

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -141,6 +141,19 @@ struct SettingsView: View {
                 }
             }
 
+            Section("Suggestions") {
+                Picker("Verbosity", selection: $settings.suggestionVerbosity) {
+                    ForEach(SuggestionVerbosity.allCases) { level in
+                        Text(level.displayName).tag(level)
+                    }
+                }
+                .font(.system(size: 12))
+
+                Text(settings.suggestionVerbosity.description)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Audio Input") {
                 Picker("Microphone", selection: $settings.inputDeviceID) {
                     Text("System Default").tag(AudioDeviceID(0))


### PR DESCRIPTION
## Summary

- Adds a `SuggestionVerbosity` enum (Quiet / Balanced / Eager) that controls suggestion cooldown and gate score thresholds
- Adds a new "Suggestions" section in Settings with a verbosity picker
- `SuggestionEngine` now reads the verbosity setting dynamically instead of using hardcoded thresholds

**Quiet** preserves the current behavior (90s cooldown, full thresholds). **Balanced** halves the cooldown and lowers thresholds by 15%. **Eager** uses a 15s cooldown with 30% lower thresholds for users who want frequent fact-retrieval suggestions.

Closes #117

## Test plan

- [ ] Verify the app builds and launches with no regressions
- [ ] Open Settings → confirm "Suggestions" section appears with Quiet/Balanced/Eager picker
- [ ] Switch between levels and confirm the description text updates
- [ ] Start a meeting with Quiet mode → confirm suggestions behave as before (infrequent)
- [ ] Switch to Eager → confirm suggestions surface more frequently
- [ ] Quit and relaunch → confirm the setting persists