### PR TITLE
Update Homebrew cask for 1.18.1

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.12.7"
-  sha256 "0e044389281a2043760591cc91c6c6ac8d1aacde22dac51001bab66ce0378df8"
+  version "1.18.1"
+  sha256 "9c175ae16375bd2789fd7c9555c9d868d73db3d5540546501a07d963deead25a"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary

- Updates `Casks/openoats.rb` from v1.12.7 to v1.18.1 with correct SHA256

Automated branch from the release workflow — branch protection blocked direct push, and the `GITHUB_TOKEN` lacked permission to create PRs automatically.