### PR TITLE
Fix crash-on-disconnect in AudioRecorder by removing force unwrap

### DIFF
--- a/OpenOats/Sources/OpenOats/Audio/AudioRecorder.swift
+++ b/OpenOats/Sources/OpenOats/Audio/AudioRecorder.swift
@@ -46,11 +46,19 @@ final class AudioRecorder: @unchecked Sendable {
 
             // Lazily create file as mono at the source sample rate
             if micFile == nil, let url = micTempURL {
-                let monoFormat = AVAudioFormat(
+                guard let monoFormat = AVAudioFormat(
                     standardFormatWithSampleRate: buffer.format.sampleRate, channels: 1
-                )!
-                micFile = try? AVAudioFile(forWriting: url, settings: monoFormat.settings)
-                diagLog("[RECORDER] mic file created: \(url.lastPathComponent) mono at \(buffer.format.sampleRate)Hz")
+                ) else {
+                    diagLog("[RECORDER] mic file SKIP: cannot create mono format at \(buffer.format.sampleRate)Hz")
+                    return
+                }
+                do {
+                    micFile = try AVAudioFile(forWriting: url, settings: monoFormat.settings)
+                    diagLog("[RECORDER] mic file created: \(url.lastPathComponent) mono at \(buffer.format.sampleRate)Hz")
+                } catch {
+                    diagLog("[RECORDER] mic file creation FAILED: \(error)")
+                    return
+                }
             }
 
             // Downmix to mono inline — handle float32, int16, and int32 formats
@@ -144,14 +152,23 @@ final class AudioRecorder: @unchecked Sendable {
         lock.withLock {
             guard buffer.frameLength > 0 else { return }
             if sysFile == nil, let url = sysTempURL {
-                sysFile = try? AVAudioFile(
-                    forWriting: url,
-                    settings: buffer.format.settings,
-                    commonFormat: buffer.format.commonFormat,
-                    interleaved: buffer.format.isInterleaved
-                )
+                do {
+                    sysFile = try AVAudioFile(
+                        forWriting: url,
+                        settings: buffer.format.settings,
+                        commonFormat: buffer.format.commonFormat,
+                        interleaved: buffer.format.isInterleaved
+                    )
+                } catch {
+                    diagLog("[RECORDER] sys file creation FAILED: \(error)")
+                    return
+                }
             }
-            try? sysFile?.write(from: buffer)
+            do {
+                try sysFile?.write(from: buffer)
+            } catch {
+                diagLog("[RECORDER] sys write ERROR: \(error)")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace a force unwrap (`!`) on `AVAudioFormat` init in `writeMicBuffer` with a `guard let` that logs and gracefully skips the buffer. This prevents a hard crash when the audio format returns `nil` during mic hot-swap, Bluetooth disconnects, or virtual audio device quirks.
- Convert four `try?` calls across `writeMicBuffer` and `writeSysBuffer` to `do/catch` blocks with `diagLog` messages, so file creation and write failures are no longer silently swallowed.

## Problem

Line 51 on `main` has `AVAudioFormat(...)!`. If a user unplugs a USB mic or a Bluetooth headset disconnects mid-recording, the format initializer can return `nil` and the app crashes immediately. Because the old code also used `try?` for file I/O, any recording failures before the crash were invisible in logs, making the issue very difficult to diagnose from user reports.

## Solution

The four changes in this PR all follow the same pattern: fail gracefully and log diagnostically.

1. **`writeMicBuffer` format init** - `!` to `guard let` + `diagLog` warning. On failure, the single buffer (~100ms of audio) is dropped instead of crashing the entire app.
2. **`writeMicBuffer` file creation** - `try?` to `do/catch` + `diagLog` error.
3. **`writeSysBuffer` file creation** - `try?` to `do/catch` + `diagLog` error.
4. **`writeSysBuffer` write** - `try?` to `do/catch` + `diagLog` error.

The transcription pipeline is unaffected since it receives audio buffers on a separate path. Dropping a single buffer means at most a ~100ms gap in the recording, which is imperceptible compared to losing the entire session to a crash.

## Build

Builds cleanly with no new warnings on Xcode 16 / macOS 15.

## Test plan

- [ ] Build and run the app, verify recording works normally with default audio device
- [ ] If possible, disconnect a Bluetooth or USB mic mid-recording and confirm the app stays alive (previously would crash)
- [ ] Check diagnostic logs for the new `[RECORDER]` messages when errors occur