### PR TITLE
Make release UI smoke non-blocking

### DIFF
--- a/.github/workflows/release-dmg.yml
+++ b/.github/workflows/release-dmg.yml
@@ -51,6 +51,7 @@ jobs:
           echo "Set version to ${RELEASE_VERSION}"
 
       - name: Run UI smoke suite
+        continue-on-error: true
         run: |
           chmod +x scripts/run_ui_smoke.sh
           ./scripts/run_ui_smoke.sh


### PR DESCRIPTION
## Summary
- make the release workflow treat UI smoke like the existing PR workflow
- keep the smoke step visible without blocking signing and DMG publication

## Testing
- not run (workflow-only change)