### PR TITLE
Update Homebrew cask for 1.20.1

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.19.0"
-  sha256 "d9a1ba8c71a58b5e415729e1d326ad2df732ed9a56fda173c86a2fc9edccef15"
+  version "1.20.1"
+  sha256 "fc1b081ca77f193426410ddaeec4dbc7228a031fe1b6939617c724030e8640b3"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- update the Homebrew cask to OpenOats 1.20.1
- set the released DMG sha256 from the published artifact

## Testing
- derived from the successful release workflow artifact