### PR TITLE
Fix session start state handling

### DIFF
--- a/OpenOats/Sources/OpenOats/App/MenuBarController.swift
+++ b/OpenOats/Sources/OpenOats/App/MenuBarController.swift
@@ -73,7 +73,7 @@ final class MenuBarController {
                 self.updateIcon()
                 await withCheckedContinuation { continuation in
                     withObservationTracking {
-                        _ = self.liveSessionController.state.isRunning
+                        _ = self.liveSessionController.state.hasActiveSession
                     } onChange: {
                         continuation.resume()
                     }
@@ -83,7 +83,7 @@ final class MenuBarController {
     }
 
     private func updateIcon() {
-        let symbolName = liveSessionController.state.isRunning
+        let symbolName = liveSessionController.state.hasActiveSession
             ? "waveform.circle.fill"
             : "waveform.circle"
         statusItem.button?.image = NSImage(

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -249,7 +249,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             return .terminateNow
         }
 
-        guard liveSessionController.state.isRunning else {
+        guard liveSessionController.state.hasActiveSession else {
             return .terminateNow
         }
 
@@ -346,6 +346,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func toggleMeeting() {
         guard let liveSessionController, let settings else { return }
         guard settings.hasAcknowledgedRecordingConsent else { return }
+        guard !liveSessionController.state.isStartingSession else { return }
 
         if liveSessionController.state.isRunning {
             liveSessionController.stopSession()

--- a/OpenOats/Sources/OpenOats/Models/TranscriptStore.swift
+++ b/OpenOats/Sources/OpenOats/Models/TranscriptStore.swift
@@ -40,6 +40,7 @@ final class TranscriptStore {
     func append(_ utterance: Utterance) -> Bool {
         guard !shouldSuppressAcousticEcho(utterance) else { return false }
         utterances.append(utterance)
+        diagLog("[TRANSCRIPT] appended \(utterance.speaker.storageKey) chars=\(utterance.text.count) total=\(utterances.count)")
         if utterance.speaker.isRemote {
             remoteUtterancesSinceStateUpdate += 1
         }

--- a/OpenOats/Sources/OpenOats/Runtime/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/Runtime/LiveSessionController.swift
@@ -8,6 +8,7 @@ import Observation
 final class LiveSessionController {
     struct State: Sendable {
         var sessionPhase: MeetingState = .idle
+        var isStartingSession = false
         var liveTranscript: [Utterance] = []
         var volatileYouText = ""
         var volatileThemText = ""
@@ -31,6 +32,15 @@ final class LiveSessionController {
         var isRunning: Bool {
             if case .recording = sessionPhase { return true }
             return false
+        }
+
+        var isEnding: Bool {
+            if case .ending = sessionPhase { return true }
+            return false
+        }
+
+        var hasActiveSession: Bool {
+            isStartingSession || isRunning || isEnding
         }
 
         var recordingStartedAt: Date? {
@@ -125,15 +135,11 @@ final class LiveSessionController {
     }
 
     func startManualSession() {
-        Task { @MainActor in
-            await self.startSession(metadata: .manual())
-        }
+        enqueueSessionStart(metadata: .manual())
     }
 
     func startDetectedSession(_ metadata: MeetingMetadata) {
-        Task { @MainActor in
-            await self.startSession(metadata: metadata)
-        }
+        enqueueSessionStart(metadata: metadata)
     }
 
     func confirmModelDownloadAndStart() {
@@ -254,7 +260,10 @@ final class LiveSessionController {
         next.suggestions = suggestionEngine.suggestions
         next.isGeneratingSuggestions = suggestionEngine.isGenerating
         next.currentError = transcriptionEngine.lastError ?? next.lastStorageError
-        next.statusMessage = transcriptionEngine.assetStatus
+        let engineStatus = transcriptionEngine.assetStatus
+        next.statusMessage = next.isStartingSession && engineStatus == "Ready"
+            ? "Starting..."
+            : engineStatus
         next.needsDownload = transcriptionEngine.needsModelDownload
         next.kbIndexingProgress = knowledgeBase.indexingProgress
         next.showLiveTranscript = settings.showLiveTranscript
@@ -415,8 +424,22 @@ final class LiveSessionController {
         }
     }
 
+    private func enqueueSessionStart(metadata: MeetingMetadata) {
+        guard !state.hasActiveSession else { return }
+        state.isStartingSession = true
+        refreshProjectedState()
+
+        Task { @MainActor [weak self] in
+            await self?.startSession(metadata: metadata)
+        }
+    }
+
     private func startSession(metadata: MeetingMetadata) async {
-        guard !state.isRunning else { return }
+        guard state.isStartingSession || !state.hasActiveSession else { return }
+        defer {
+            state.isStartingSession = false
+            refreshProjectedState()
+        }
 
         await batchEngine.cancel()
         finalizationTask?.cancel()
@@ -454,7 +477,6 @@ final class LiveSessionController {
 
         guard transcriptionEngine.isRunning else {
             await repository.deleteSession(sessionID: handle.id)
-            refreshProjectedState()
             return
         }
 

--- a/OpenOats/Sources/OpenOats/Runtime/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/Runtime/MeetingDetectionController.swift
@@ -174,7 +174,7 @@ final class MeetingDetectionController {
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                if self.liveSessionController.state.isRunning {
+                if self.liveSessionController.state.hasActiveSession {
                     self.liveSessionController.stopSession()
                 }
             }
@@ -214,7 +214,7 @@ final class MeetingDetectionController {
     }
 
     private func handleMeetingDetected(_ app: MeetingApp?) async {
-        guard !liveSessionController.state.isRunning else { return }
+        guard !liveSessionController.state.hasActiveSession else { return }
         if let bundleID = app?.bundleID, dismissedEvents.contains(bundleID) {
             return
         }
@@ -239,7 +239,7 @@ final class MeetingDetectionController {
     }
 
     private func handleDetectionAccepted() {
-        guard !liveSessionController.state.isRunning else { return }
+        guard !liveSessionController.state.hasActiveSession else { return }
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -274,7 +274,7 @@ final class MeetingDetectionController {
     }
 
     private func evaluateImmediate() async {
-        guard let meetingDetector, !liveSessionController.state.isRunning else { return }
+        guard let meetingDetector, !liveSessionController.state.hasActiveSession else { return }
         let (micActive, app) = await meetingDetector.queryCurrentState()
         if micActive, app != nil {
             await handleMeetingDetected(app)

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
@@ -153,6 +153,7 @@ final class StreamingTranscriber: @unchecked Sendable {
             let text = try await backend.transcribe(samples, locale: locale, previousContext: previousContext)
             guard !text.isEmpty else { return }
             log.info("[\(self.speaker.storageKey)] transcribed: \(text.prefix(80))")
+            diagLog("[\(speaker.storageKey)] transcribed chars=\(text.count)")
             // Store trailing words for cross-segment context
             let words = text.split(separator: " ")
             previousContext = words.suffix(Self.contextWordCount).joined(separator: " ")

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -17,7 +17,6 @@ struct ContentView: View {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @State private var showOnboarding = false
     @State private var showConsentSheet = false
-    @State private var pendingControlBarAction: ControlBarAction?
 
     var body: some View {
         let state = liveSessionController.state
@@ -72,6 +71,7 @@ struct ContentView: View {
 
             ControlBar(
                 isRunning: state.isRunning,
+                isStarting: state.isStartingSession,
                 audioLevel: state.audioLevel,
                 modelDisplayName: state.modelDisplayName,
                 transcriptionPrompt: state.transcriptionPrompt,
@@ -79,10 +79,10 @@ struct ContentView: View {
                 errorMessage: state.currentError,
                 needsDownload: state.needsDownload,
                 onToggle: {
-                    pendingControlBarAction = .toggle
+                    handleControlBarAction(.toggle)
                 },
                 onConfirmDownload: {
-                    pendingControlBarAction = .confirmDownload
+                    handleControlBarAction(.confirmDownload)
                 }
             )
         }
@@ -113,7 +113,7 @@ struct ContentView: View {
             }
         }
         .onChange(of: showConsentSheet) { _, isShowing in
-            if !isShowing && settings.hasAcknowledgedRecordingConsent && !liveSessionController.state.isRunning {
+            if !isShowing && settings.hasAcknowledgedRecordingConsent && !liveSessionController.state.hasActiveSession {
                 liveSessionController.startManualSession()
             }
         }
@@ -128,11 +128,6 @@ struct ContentView: View {
         }
         .onChange(of: liveSessionController.state.isGeneratingSuggestions) { _, _ in
             synchronizeMiniBar()
-        }
-        .onChange(of: pendingControlBarAction) { _, action in
-            guard let action else { return }
-            pendingControlBarAction = nil
-            handleControlBarAction(action)
         }
     }
 
@@ -322,7 +317,9 @@ struct ContentView: View {
     private func handleControlBarAction(_ action: ControlBarAction) {
         switch action {
         case .toggle:
-            if liveSessionController.state.isRunning {
+            if liveSessionController.state.isStartingSession {
+                return
+            } else if liveSessionController.state.isRunning {
                 liveSessionController.stopSession()
             } else if settings.hasAcknowledgedRecordingConsent {
                 liveSessionController.startManualSession()

--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ControlBar: View {
     let isRunning: Bool
+    let isStarting: Bool
     let audioLevel: Float
     let modelDisplayName: String
     let transcriptionPrompt: String
@@ -24,7 +25,7 @@ struct ControlBar: View {
             }
 
             // Download prompt
-            if needsDownload && !isRunning {
+            if needsDownload && !isRunning && !isStarting {
                 VStack(spacing: 6) {
                     Text(transcriptionPrompt)
                         .font(.system(size: 11))
@@ -71,6 +72,14 @@ struct ControlBar: View {
                                 .font(.system(size: 12, weight: .medium))
                                 .foregroundStyle(.primary)
                                 .accessibilityIdentifier("app.controlBar.toggle")
+                        } else if isStarting {
+                            ProgressView()
+                                .controlSize(.small)
+
+                            Text("Starting...")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.primary)
+                                .accessibilityIdentifier("app.controlBar.toggle")
                         } else {
                             Image(systemName: "mic.fill")
                                 .font(.system(size: 11))
@@ -87,10 +96,17 @@ struct ControlBar: View {
                     // Avoid hover-driven local state here. On macOS 26 / Swift 6.2,
                     // switching this button from Start to Live while the pointer is
                     // over it can trip a SwiftUI executor crash in onHover handling.
-                    .background(isRunning ? Color.green.opacity(0.1) : Color.accentColor)
+                    .background(
+                        isRunning
+                            ? Color.green.opacity(0.1)
+                            : isStarting
+                                ? Color.primary.opacity(0.08)
+                                : Color.accentColor
+                    )
                     .clipShape(Capsule())
                 }
                 .buttonStyle(.plain)
+                .disabled(isStarting)
 
                 // Audio level bars when running
                 if isRunning {

--- a/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
+++ b/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
@@ -81,7 +81,12 @@ struct MenuBarPopoverView: View {
         detectionState: MeetingDetectionController.State
     ) -> some View {
         HStack(spacing: 6) {
-            if liveState.isRunning {
+            if liveState.isStartingSession {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Starting…")
+                    .font(.system(size: 13, weight: .medium))
+            } else if liveState.isRunning {
                 Circle()
                     .fill(.red)
                     .frame(width: 8, height: 8)
@@ -108,6 +113,20 @@ struct MenuBarPopoverView: View {
 
     @ViewBuilder
     private func primaryAction(liveState: LiveSessionController.State) -> some View {
+        if liveState.isStartingSession {
+            Button(action: {}) {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Starting…")
+                        .font(.system(size: 13, weight: .medium))
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.regular)
+            .disabled(true)
+        } else
         if liveState.isRunning {
             Button(action: {
                 liveSessionController.stopSession()

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerIntegrationTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerIntegrationTests.swift
@@ -5,61 +5,12 @@ import XCTest
 final class LiveSessionControllerIntegrationTests: XCTestCase {
 
     func testManualStopFinalizesSessionAndPersistsCanonicalSession() async {
-        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-            .appendingPathComponent("OpenOatsLiveSessionTests", isDirectory: true)
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        let notesDirectory = root.appendingPathComponent("Notes", isDirectory: true)
-        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
-        try? FileManager.default.createDirectory(at: notesDirectory, withIntermediateDirectories: true)
-
-        let suiteName = "com.openoats.tests.live-session.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
-        defaults.removePersistentDomain(forName: suiteName)
-        defaults.set(notesDirectory.path, forKey: "notesFolderPath")
-        defaults.set(true, forKey: "hasAcknowledgedRecordingConsent")
-        defaults.set(false, forKey: "enableBatchRefinement")
-        defaults.set(false, forKey: "saveAudioRecording")
-        defaults.set(false, forKey: "enableTranscriptRefinement")
-
-        let storage = AppSettingsStorage(
-            defaults: defaults,
-            secretStore: .ephemeral,
-            defaultNotesDirectory: notesDirectory,
-            runMigrations: false
-        )
-        let settings = AppSettings(storage: storage)
-        let transcriptStore = TranscriptStore()
-        let repository = SessionRepository(rootDirectory: root)
-        let templateStore = TemplateStore(rootDirectory: root)
-        let knowledgeBase = KnowledgeBase(settings: settings)
-        let suggestionEngine = SuggestionEngine(
-            transcriptStore: transcriptStore,
-            knowledgeBase: knowledgeBase,
-            settings: settings
-        )
-        let transcriptionEngine = TranscriptionEngine(
-            transcriptStore: transcriptStore,
-            settings: settings,
-            mode: .scripted([
-                Utterance(text: "Let me walk through the rollout plan.", speaker: .you),
-                Utterance(text: "The pilot scope sounds good to me.", speaker: .them),
-            ])
-        )
-        let controller = LiveSessionController(
-            settings: settings,
-            repository: repository,
-            templateStore: templateStore,
-            transcriptStore: transcriptStore,
-            knowledgeBase: knowledgeBase,
-            suggestionEngine: suggestionEngine,
-            transcriptionEngine: transcriptionEngine,
-            refinementEngine: TranscriptRefinementEngine(
-                settings: settings,
-                transcriptStore: transcriptStore
-            ),
-            audioRecorder: AudioRecorder(outputDirectory: root),
-            batchEngine: BatchTranscriptionEngine()
-        )
+        let fixture = makeFixture(scriptedUtterances: [
+            Utterance(text: "Let me walk through the rollout plan.", speaker: .you),
+            Utterance(text: "The pilot scope sounds good to me.", speaker: .them),
+        ])
+        let controller = fixture.controller
+        let repository = fixture.repository
 
         await controller.activateIfNeeded()
         controller.startManualSession()
@@ -90,5 +41,185 @@ final class LiveSessionControllerIntegrationTests: XCTestCase {
         let session = await repository.loadSession(id: endedSession.id)
         XCTAssertEqual(session.liveTranscript.count, 2)
         XCTAssertEqual(session.liveTranscript.last?.speaker, .them)
+    }
+
+    func testRepeatedManualStartOnlyCreatesOneSession() async {
+        let fixture = makeFixture(scriptedUtterances: [
+            Utterance(text: "Kickoff is tomorrow morning.", speaker: .you)
+        ])
+        let controller = fixture.controller
+        let repository = fixture.repository
+
+        await controller.activateIfNeeded()
+        controller.startManualSession()
+        XCTAssertTrue(controller.state.isStartingSession)
+
+        controller.startManualSession()
+        controller.startManualSession()
+
+        for _ in 0..<20 where controller.state.isStartingSession {
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        let summaries = await repository.listSessions()
+        XCTAssertEqual(summaries.count, 1)
+        XCTAssertTrue(controller.state.isRunning)
+    }
+
+    func testFailedStartClearsStartingStateAndDoesNotPersistSession() async {
+        let fixture = makeFixture(
+            scriptedUtterances: [],
+            engineMode: .live,
+            configureSettings: { settings in
+                settings.transcriptionModel = .parakeetV2
+                settings.transcriptionLocale = "fr-FR"
+            }
+        )
+        let controller = fixture.controller
+        let repository = fixture.repository
+
+        await controller.activateIfNeeded()
+        controller.startManualSession()
+        XCTAssertTrue(controller.state.isStartingSession)
+
+        for _ in 0..<20 where controller.state.isStartingSession {
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        XCTAssertFalse(controller.state.isStartingSession)
+        XCTAssertFalse(controller.state.isRunning)
+        XCTAssertEqual(controller.state.sessionPhase, MeetingState.idle)
+        let summaries = await repository.listSessions()
+        XCTAssertEqual(summaries.count, 0)
+        XCTAssertEqual(
+            controller.state.currentError,
+            "Parakeet TDT v2 is English-only. Switch to Parakeet TDT v3 or Qwen3 ASR for fr-FR."
+        )
+    }
+
+    private func makeFixture(scriptedUtterances: [Utterance]) -> (
+        controller: LiveSessionController,
+        repository: SessionRepository
+    ) {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("OpenOatsLiveSessionTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let notesDirectory = root.appendingPathComponent("Notes", isDirectory: true)
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(at: notesDirectory, withIntermediateDirectories: true)
+
+        let suiteName = "com.openoats.tests.live-session.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(notesDirectory.path, forKey: "notesFolderPath")
+        defaults.set(true, forKey: "hasAcknowledgedRecordingConsent")
+        defaults.set(false, forKey: "enableBatchRefinement")
+        defaults.set(false, forKey: "saveAudioRecording")
+        defaults.set(false, forKey: "enableTranscriptRefinement")
+
+        let storage = AppSettingsStorage(
+            defaults: defaults,
+            secretStore: .ephemeral,
+            defaultNotesDirectory: notesDirectory,
+            runMigrations: false
+        )
+        let settings = AppSettings(storage: storage)
+        let engineMode = TranscriptionEngine.Mode.scripted(scriptedUtterances)
+        return makeFixture(
+            settings: settings,
+            root: root,
+            scriptedUtterances: scriptedUtterances,
+            engineMode: engineMode
+        )
+    }
+
+    private func makeFixture(
+        scriptedUtterances: [Utterance],
+        engineMode: TranscriptionEngine.Mode,
+        configureSettings: (AppSettings) -> Void
+    ) -> (
+        controller: LiveSessionController,
+        repository: SessionRepository
+    ) {
+        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("OpenOatsLiveSessionTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let notesDirectory = root.appendingPathComponent("Notes", isDirectory: true)
+        try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try? FileManager.default.createDirectory(at: notesDirectory, withIntermediateDirectories: true)
+
+        let suiteName = "com.openoats.tests.live-session.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(notesDirectory.path, forKey: "notesFolderPath")
+        defaults.set(true, forKey: "hasAcknowledgedRecordingConsent")
+        defaults.set(false, forKey: "enableBatchRefinement")
+        defaults.set(false, forKey: "saveAudioRecording")
+        defaults.set(false, forKey: "enableTranscriptRefinement")
+
+        let storage = AppSettingsStorage(
+            defaults: defaults,
+            secretStore: .ephemeral,
+            defaultNotesDirectory: notesDirectory,
+            runMigrations: false
+        )
+        let settings = AppSettings(storage: storage)
+        configureSettings(settings)
+        return makeFixture(
+            settings: settings,
+            root: root,
+            scriptedUtterances: scriptedUtterances,
+            engineMode: engineMode
+        )
+    }
+
+    private func makeFixture(
+        settings: AppSettings,
+        root: URL,
+        scriptedUtterances: [Utterance],
+        engineMode: TranscriptionEngine.Mode
+    ) -> (
+        controller: LiveSessionController,
+        repository: SessionRepository
+    ) {
+        let transcriptStore = TranscriptStore()
+        let repository = SessionRepository(rootDirectory: root)
+        let templateStore = TemplateStore(rootDirectory: root)
+        let knowledgeBase = KnowledgeBase(settings: settings)
+        let suggestionEngine = SuggestionEngine(
+            transcriptStore: transcriptStore,
+            knowledgeBase: knowledgeBase,
+            settings: settings
+        )
+        let transcriptionEngine = switch engineMode {
+        case .live:
+            TranscriptionEngine(
+                transcriptStore: transcriptStore,
+                settings: settings
+            )
+        case .scripted:
+            TranscriptionEngine(
+                transcriptStore: transcriptStore,
+                settings: settings,
+                mode: .scripted(scriptedUtterances)
+            )
+        }
+        let controller = LiveSessionController(
+            settings: settings,
+            repository: repository,
+            templateStore: templateStore,
+            transcriptStore: transcriptStore,
+            knowledgeBase: knowledgeBase,
+            suggestionEngine: suggestionEngine,
+            transcriptionEngine: transcriptionEngine,
+            refinementEngine: TranscriptRefinementEngine(
+                settings: settings,
+                transcriptStore: transcriptStore
+            ),
+            audioRecorder: AudioRecorder(outputDirectory: root),
+            batchEngine: BatchTranscriptionEngine()
+        )
+
+        return (controller, repository)
     }
 }


### PR DESCRIPTION
## Summary
- add an explicit starting state for live sessions so startup is visible and debounced
- block duplicate starts across the main window, menu bar, and meeting detection paths
- add regression tests for duplicate-start and failed-start cleanup

## Testing
- swift build
- swift test --filter LiveSessionControllerIntegrationTests
- ./scripts/build_swift_app.sh