### PR TITLE
Update Homebrew cask for 1.20.2

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.20.1"
-  sha256 "fc1b081ca77f193426410ddaeec4dbc7228a031fe1b6939617c724030e8640b3"
+  version "1.20.2"
+  sha256 "cdb72db600c83de9ea3cf19a762a2bbbbd25c1925efe6120a8e31f5ad325d94a"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- update the Homebrew cask to OpenOats 1.20.2
- set the released DMG sha256 from the published artifact

## Testing
- derived from the successful release workflow artifact