### PR TITLE
Fix batch completion notification repeating indefinitely

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -45,7 +45,9 @@ final class LiveSessionController {
     private var observedTranscriptionModel: TranscriptionModel = .parakeetV2
     private var observedInputDeviceID: AudioDeviceID = 0
     private var observedPendingExternalCommandID: UUID?
-    private var previousBatchStatus: BatchTranscriptionEngine.Status = .idle
+    /// Tracks the session ID we last handled a batch completion for,
+    /// preventing the auto-dismiss → re-poll cycle from re-triggering the notification.
+    private var lastNotifiedBatchSessionID: String?
 
     init(coordinator: AppCoordinator, container: AppContainer) {
         self.coordinator = coordinator
@@ -73,10 +75,10 @@ final class LiveSessionController {
             if let engine = coordinator.batchEngine {
                 let status = await engine.status
                 if status != .idle || coordinator.batchStatus != .idle {
-                    let prev = coordinator.batchStatus
                     coordinator.batchStatus = status
 
-                    if case .completed(let sid) = status, prev != status {
+                    if case .completed(let sid) = status, lastNotifiedBatchSessionID != sid {
+                        lastNotifiedBatchSessionID = sid
                         if !NSApp.isActive, let notifService = container.notificationService {
                             await notifService.postBatchCompleted(sessionID: sid)
                         }


### PR DESCRIPTION
Fixes #149 (also reported in #147)

## Summary

- The batch transcription completion notification fires once and then repeats indefinitely when OpenOats is not the active app
- Root cause: the 3-second auto-dismiss resets `coordinator.batchStatus` to `.idle`, but the engine stays at `.completed(sessionID)`, so the next 100ms poll sees a fresh transition and re-triggers
- Fix: track the last notified session ID so a completion is handled exactly once per session, regardless of the auto-dismiss cycle

## Changes

- Add `lastNotifiedBatchSessionID` to gate notification + history reload on a per-session basis
- Remove unused `previousBatchStatus` field

## Test plan

- [ ] Start a session with "Enhance transcript after meeting" enabled
- [ ] End the session and switch focus away from OpenOats
- [ ] Wait for batch transcription to complete
- [ ] Verify the notification fires exactly once
- [ ] Verify the "Transcript enhanced" banner appears and auto-dismisses after 3 seconds
- [ ] Start a second session and repeat — verify the notification fires once for the new session