### PR TITLE
Fix repeated batch completion notifications

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -1,6 +1,31 @@
 import SwiftUI
 import CoreAudio
 
+struct BatchCompletionPresentationState {
+    private(set) var lastObservedStatus: BatchTranscriptionEngine.Status = .idle
+    private(set) var visibleCompletedSessionID: String?
+
+    mutating func observe(_ status: BatchTranscriptionEngine.Status) -> String? {
+        defer { lastObservedStatus = status }
+
+        switch status {
+        case .completed(let sessionID):
+            guard lastObservedStatus != status else { return nil }
+            visibleCompletedSessionID = sessionID
+            return sessionID
+        default:
+            if case .completed = lastObservedStatus {
+                visibleCompletedSessionID = nil
+            }
+            return nil
+        }
+    }
+
+    mutating func dismissCompletedBanner() {
+        visibleCompletedSessionID = nil
+    }
+}
+
 struct ContentView: View {
     private enum ControlBarAction {
         case toggle
@@ -54,7 +79,8 @@ struct ContentView: View {
     @State private var observedVoyageApiKey = ""
     @State private var observedTranscriptionModel: TranscriptionModel = .parakeetV2
     @State private var observedInputDeviceID: AudioDeviceID = 0
-    @State private var previousBatchStatus: BatchTranscriptionEngine.Status = .idle
+    @State private var batchCompletionPresentation = BatchCompletionPresentationState()
+    @State private var batchCompletionDismissTask: Task<Void, Never>?
 
     var body: some View {
         bodyWithModifiers
@@ -173,7 +199,9 @@ struct ContentView: View {
                 .background(.ultraThinMaterial)
 
                 Divider()
-            } else if case .completed = viewState.batchStatus {
+            } else if let visibleSessionID = batchCompletionPresentation.visibleCompletedSessionID,
+                      case .completed(let sessionID) = viewState.batchStatus,
+                      sessionID == visibleSessionID {
                 HStack(spacing: 6) {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundStyle(.green)
@@ -374,24 +402,27 @@ struct ContentView: View {
                 // Poll batch engine status (actor-isolated)
                 if let engine = coordinator.batchEngine {
                     let status = await engine.status
+                    let completedSessionID = batchCompletionPresentation.observe(status)
                     // Skip updating if idle → idle (no-op)
                     if status != .idle || coordinator.batchStatus != .idle {
-                        let prev = coordinator.batchStatus
                         coordinator.batchStatus = status
 
                         // Send notification on completion if app is not focused
-                        if case .completed(let sid) = status, prev != status {
+                        if let sid = completedSessionID {
                             if !NSApp.isActive, let notifService = coordinator.notificationService {
                                 await notifService.postBatchCompleted(sessionID: sid)
                             }
                             // Refresh history so the updated transcript is visible
                             await coordinator.loadHistory()
 
-                            // Auto-dismiss after 3 seconds
-                            Task { @MainActor in
+                            // Auto-dismiss the banner after 3 seconds without
+                            // mutating the engine-backed completion state.
+                            batchCompletionDismissTask?.cancel()
+                            batchCompletionDismissTask = Task { @MainActor in
                                 try? await Task.sleep(for: .seconds(3))
-                                if case .completed = coordinator.batchStatus {
-                                    coordinator.batchStatus = .idle
+                                guard !Task.isCancelled else { return }
+                                if batchCompletionPresentation.visibleCompletedSessionID == sid {
+                                    batchCompletionPresentation.dismissCompletedBanner()
                                 }
                             }
                         }

--- a/OpenOats/Tests/OpenOatsTests/BatchCompletionPresentationStateTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/BatchCompletionPresentationStateTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class BatchCompletionPresentationStateTests: XCTestCase {
+
+    func testObserveOnlyEmitsFirstCompletionUntilStatusChanges() {
+        var state = BatchCompletionPresentationState()
+
+        XCTAssertNil(state.observe(.loading(model: "Parakeet")))
+        XCTAssertEqual(
+            state.observe(.completed(sessionID: "session-1")),
+            "session-1"
+        )
+        XCTAssertEqual(state.visibleCompletedSessionID, "session-1")
+
+        XCTAssertNil(state.observe(.completed(sessionID: "session-1")))
+        XCTAssertEqual(state.visibleCompletedSessionID, "session-1")
+    }
+
+    func testDismissedBannerDoesNotRetriggerWhileEngineStaysCompleted() {
+        var state = BatchCompletionPresentationState()
+
+        XCTAssertEqual(
+            state.observe(.completed(sessionID: "session-1")),
+            "session-1"
+        )
+        state.dismissCompletedBanner()
+
+        XCTAssertNil(state.observe(.completed(sessionID: "session-1")))
+        XCTAssertNil(state.visibleCompletedSessionID)
+    }
+
+    func testNewCompletionAfterDifferentStatusIsObserved() {
+        var state = BatchCompletionPresentationState()
+
+        XCTAssertEqual(
+            state.observe(.completed(sessionID: "session-1")),
+            "session-1"
+        )
+        XCTAssertNil(state.observe(.transcribing(progress: 0.5)))
+        XCTAssertNil(state.visibleCompletedSessionID)
+
+        XCTAssertEqual(
+            state.observe(.completed(sessionID: "session-2")),
+            "session-2"
+        )
+        XCTAssertEqual(state.visibleCompletedSessionID, "session-2")
+    }
+}


### PR DESCRIPTION
## Summary
- prevent the `Transcript Enhanced` notification from re-firing indefinitely after batch transcription completes
- separate transient completion-banner visibility from the durable engine-backed batch status
- add regression coverage for the dismissed-banner case

## Root Cause
`ContentView` was auto-dismissing the completion banner by setting `coordinator.batchStatus = .idle` a few seconds after completion. The underlying `BatchTranscriptionEngine.status` remained `.completed(sessionID)`, so the next poll cycle treated that as a fresh completion and posted the notification again.

## Fix
- keep `coordinator.batchStatus` aligned with the engine status
- track completion-banner visibility separately via a local presentation latch
- only emit the notification the first time a completed session is observed
- auto-dismiss only the banner, not the engine-backed completion state

## Testing
- `swift test --filter BatchCompletionPresentationStateTests`
- `swift test --filter AppCoordinatorIntegrationTests/testUserStoppedFinalizesSessionAndRefreshesHistory`

Closes #149.
