### PR TITLE
Add Parakeet v2/v3 to batch refinement model picker

### DIFF
--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -172,9 +172,8 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
     }
 
     /// Models suitable for offline batch re-transcription.
-    /// Excludes Parakeet (English-focused streaming models).
     static var batchSuitableModels: [TranscriptionModel] {
-        [.whisperSmall, .whisperLargeV3Turbo, .qwen3ASR06B]
+        [.parakeetV2, .parakeetV3, .whisperSmall, .whisperLargeV3Turbo, .qwen3ASR06B]
     }
 }
 


### PR DESCRIPTION
## Summary
- Add Parakeet TDT v2 and v3 to the batch refinement model picker
- Remove inaccurate comment about Parakeet being "English-focused streaming models" (v3 is multilingual)

## Details
The Parakeet backend already implements the same `TranscriptionBackend.transcribe(_:locale:previousContext:)` interface that the batch engine uses. No backend adaptation is needed — the batch engine feeds 30-second chunks through VAD and passes detected speech segments to `backend.transcribe()`, which works identically for Parakeet.

## Test plan
- [ ] Open Settings > Batch Model and verify Parakeet TDT v2 and v3 appear in the picker
- [ ] Run batch refinement with Parakeet v3 on a recorded session and verify transcript output

Closes #145.