### PR TITLE
Update Homebrew cask to v1.23.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.22.1"
-  sha256 "850d2456e2532f72a3ac91c8c07511e630035bc6b920a448694cb93fda03ac05"
+  version "1.23.0"
+  sha256 "69fa931a28d0ca6211008b982007d384b0b0b7d4b3b311736ebf98bf64042f4e"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary

Automated cask update from the release workflow.

- Updates `Casks/openoats.rb` version from 1.22.1 → 1.23.0
- Updates SHA256 to match the v1.23.0 DMG

No code changes — version string and hash only.