### PR TITLE
Add mic mute toggle to live session control bar

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -23,6 +23,7 @@ struct LiveSessionState {
     var transcriptionPrompt: String = ""
     var modelDisplayName: String = ""
     var showLiveTranscript: Bool = true
+    var isMicMuted: Bool = false
 }
 
 /// Owns all live session side effects: polling, utterance ingestion,
@@ -113,6 +114,11 @@ final class LiveSessionController {
     func confirmDownloadAndStart(settings: AppSettings) {
         coordinator.transcriptionEngine?.downloadConfirmed = true
         startSession(settings: settings)
+    }
+
+    func toggleMicMute() {
+        guard let engine = coordinator.transcriptionEngine, engine.isRunning else { return }
+        engine.isMicMuted.toggle()
     }
 
     // MARK: - KB Indexing
@@ -461,6 +467,7 @@ final class LiveSessionController {
         next.transcriptionPrompt = settings.transcriptionModel.downloadPrompt
         next.modelDisplayName = activeModelRaw.split(separator: "/").last.map(String.init) ?? activeModelRaw
         next.showLiveTranscript = settings.showLiveTranscript
+        next.isMicMuted = coordinator.transcriptionEngine?.isMicMuted ?? false
 
         state = next
     }

--- a/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
@@ -13,10 +13,17 @@ final class MicCapture: @unchecked Sendable {
     private let _hasCapturedFrames = SyncBool()
     private let _error = SyncString()
     private let _streamContinuation = OSAllocatedUnfairLock<AsyncStream<AVAudioPCMBuffer>.Continuation?>(uncheckedState: nil)
+    private let _muted = SyncBool()
 
-    var audioLevel: Float { _audioLevel.value }
+    var audioLevel: Float { _muted.value ? 0 : _audioLevel.value }
     var hasCapturedFrames: Bool { _hasCapturedFrames.value }
     var captureError: String? { _error.value }
+
+    /// When muted, buffers are not forwarded to the stream and audio level reads as 0.
+    var isMuted: Bool {
+        get { _muted.value }
+        set { _muted.value = newValue }
+    }
 
     /// Set a specific input device by its AudioDeviceID. Pass nil to use system default.
     func setInputDevice(_ deviceID: AudioDeviceID?) {
@@ -131,6 +138,7 @@ final class MicCapture: @unchecked Sendable {
 
             diagLog("[MIC-4] tapFormat: sr=\(tapFormat.sampleRate) ch=\(tapFormat.channelCount)")
 
+            let muted = self._muted
             var tapCallCount = 0
             inputNode.installTap(onBus: 0, bufferSize: 4096, format: tapFormat) { buffer, _ in
                 tapCallCount += 1
@@ -142,6 +150,7 @@ final class MicCapture: @unchecked Sendable {
                     diagLog("[MIC-6] tap #\(tapCallCount): frames=\(buffer.frameLength) rms=\(rms) level=\(level.value)")
                 }
 
+                guard !muted.value else { return }
                 continuation.yield(buffer)
             }
             self.hasTapInstalled = true

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -93,6 +93,13 @@ final class TranscriptionEngine {
         }
     }
 
+    /// Mute/unmute the microphone. When muted, mic audio is not transcribed
+    /// and the audio level reads as 0. System audio continues normally.
+    nonisolated var isMicMuted: Bool {
+        get { micCapture.isMuted }
+        set { micCapture.isMuted = newValue }
+    }
+
     private var micTask: Task<Void, Never>?
     private var sysTask: Task<Void, Never>?
     /// Keeps the mic stream alive for the audio level meter when transcription isn't running.

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -220,6 +220,7 @@ struct ContentView: View {
             ControlBar(
                 isRunning: controllerState.isRunning,
                 audioLevel: controllerState.audioLevel,
+                isMicMuted: controllerState.isMicMuted,
                 modelDisplayName: controllerState.modelDisplayName,
                 transcriptionPrompt: controllerState.transcriptionPrompt,
                 statusMessage: controllerState.statusMessage,
@@ -227,6 +228,9 @@ struct ContentView: View {
                 needsDownload: controllerState.needsDownload,
                 onToggle: {
                     pendingControlBarAction = .toggle
+                },
+                onMuteToggle: {
+                    liveSessionController?.toggleMicMute()
                 },
                 onConfirmDownload: {
                     pendingControlBarAction = .confirmDownload

--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -3,12 +3,14 @@ import SwiftUI
 struct ControlBar: View {
     let isRunning: Bool
     let audioLevel: Float
+    let isMicMuted: Bool
     let modelDisplayName: String
     let transcriptionPrompt: String
     let statusMessage: String?
     let errorMessage: String?
     let needsDownload: Bool
     let onToggle: () -> Void
+    let onMuteToggle: () -> Void
     let onConfirmDownload: () -> Void
 
     var body: some View {
@@ -60,16 +62,16 @@ struct ControlBar: View {
                 Button(action: onToggle) {
                     HStack(spacing: 6) {
                         if isRunning {
-                            // Pulsing dot when live
+                            // Pulsing dot when live, static when muted
                             Circle()
-                                .fill(Color.green)
+                                .fill(isMicMuted ? Color.red : Color.green)
                                 .frame(width: 8, height: 8)
-                                .scaleEffect(1.0 + CGFloat(audioLevel) * 0.5)
+                                .scaleEffect(isMicMuted ? 1.0 : 1.0 + CGFloat(audioLevel) * 0.5)
                                 .animation(.easeOut(duration: 0.1), value: audioLevel)
 
-                            Text("Live")
+                            Text(isMicMuted ? "Muted" : "Live")
                                 .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(.primary)
+                                .foregroundStyle(isMicMuted ? .red : .primary)
                         } else {
                             Image(systemName: "mic.fill")
                                 .font(.system(size: 11))
@@ -85,16 +87,27 @@ struct ControlBar: View {
                     // Avoid hover-driven local state here. On macOS 26 / Swift 6.2,
                     // switching this button from Start to Live while the pointer is
                     // over it can trip a SwiftUI executor crash in onHover handling.
-                    .background(isRunning ? Color.green.opacity(0.1) : Color.accentColor)
+                    .background(isRunning ? (isMicMuted ? Color.red.opacity(0.1) : Color.green.opacity(0.1)) : Color.accentColor)
                     .clipShape(Capsule())
                 }
                 .buttonStyle(.plain)
                 .accessibilityIdentifier("app.controlBar.toggle")
 
-                // Audio level bars when running
+                // Mute button + audio level bars when running
                 if isRunning {
+                    Button(action: onMuteToggle) {
+                        Image(systemName: isMicMuted ? "mic.slash.fill" : "mic.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(isMicMuted ? .red : .secondary)
+                            .frame(width: 20, height: 20)
+                    }
+                    .buttonStyle(.plain)
+                    .help(isMicMuted ? "Unmute microphone" : "Mute microphone")
+                    .accessibilityIdentifier("app.controlBar.muteToggle")
+
                     AudioLevelView(level: audioLevel)
                         .frame(width: 40, height: 14)
+                        .opacity(isMicMuted ? 0.3 : 1.0)
                 }
 
                 Spacer()


### PR DESCRIPTION
Closes #152

## Summary

Adds a mute/unmute button to the live session control bar that temporarily suppresses mic audio from being transcribed, while keeping the session alive and system audio capture running.

**Changes across 5 files:**

- **MicCapture** — new `isMuted` flag (thread-safe `SyncBool`); when muted, the audio tap still runs but buffers are not yielded to the stream, and `audioLevel` reads as 0
- **TranscriptionEngine** — exposes `isMicMuted` property that delegates to `MicCapture`
- **LiveSessionController** — adds `isMicMuted` to `LiveSessionState` and a `toggleMicMute()` action
- **ControlBar** — adds a mic mute button (mic.fill / mic.slash.fill) with visual feedback: red "Muted" label, red status dot, dimmed audio level bars
- **ContentView** — wires the `onMuteToggle` callback

**Behavior:**
- Mic mute only available during active sessions
- System audio (remote participants) continues unaffected
- Visual state: red dot + "Muted" text + mic.slash icon + dimmed level bars
- Unmuting resumes mic transcription immediately

## Test plan

- [ ] Start a live session, verify mute button appears
- [ ] Tap mute — verify "Live" changes to "Muted" with red indicator
- [ ] Speak while muted — verify no transcription appears for "You"
- [ ] Verify system audio ("Them") continues transcribing while mic is muted
- [ ] Tap unmute — verify "Muted" reverts to "Live" with green indicator
- [ ] Verify audio level bars dim when muted and restore when unmuted