### PR TITLE
Update Homebrew cask for 1.25.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.23.0"
-  sha256 "69fa931a28d0ca6211008b982007d384b0b0b7d4b3b311736ebf98bf64042f4e"
+  version "1.25.0"
+  sha256 "5bf47d9d167ef677eb6aaf9f726f22a54753b8f2c4792727a7ed12332ca1668b"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Update `Casks/openoats.rb` to v1.25.0 with the correct SHA256 for the release DMG.

Automated cask update from the release workflow.