### PR TITLE
Persist transcription locale end-to-end

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -307,6 +307,10 @@ final class LiveSessionController {
         }
 
         let engineName = settings?.transcriptionModel.rawValue
+        let transcriptionLanguage: String? = {
+            guard let locale = settings?.transcriptionLocale, !locale.isEmpty else { return nil }
+            return locale
+        }()
 
         // 4. Finalize: closes file handle, backfills refined text, writes session.json
         await coordinator.sessionRepository.finalizeSession(
@@ -315,6 +319,7 @@ final class LiveSessionController {
                 endedAt: Date(),
                 utteranceCount: utteranceCount,
                 title: title,
+                language: transcriptionLanguage,
                 meetingApp: meetingAppName,
                 engine: engineName,
                 templateSnapshot: coordinator.sessionTemplateSnapshot,
@@ -331,6 +336,7 @@ final class LiveSessionController {
             title: title,
             utteranceCount: utteranceCount,
             hasNotes: false,
+            language: transcriptionLanguage,
             meetingApp: meetingAppName,
             engine: engineName
         )

--- a/OpenOats/Sources/OpenOats/Intelligence/MarkdownMeetingWriter.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/MarkdownMeetingWriter.swift
@@ -18,6 +18,7 @@ enum MarkdownMeetingWriter {
         let title: String?
         let startedAt: Date
         let endedAt: Date?
+        let language: String?
         let meetingApp: String?
         let engine: String?
 
@@ -26,6 +27,7 @@ enum MarkdownMeetingWriter {
             self.title = index.title
             self.startedAt = index.startedAt
             self.endedAt = index.endedAt
+            self.language = index.language
             self.meetingApp = index.meetingApp
             self.engine = index.engine
         }
@@ -120,6 +122,11 @@ enum MarkdownMeetingWriter {
         // Engine
         if let engine = metadata.engine, !engine.isEmpty {
             lines.append("engine: \(engine)")
+        }
+
+        // Language (BCP 47)
+        if let language = metadata.language, !language.isEmpty {
+            lines.append("language: \(language)")
         }
 
         // Meeting app (lowercase per spec)

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -180,6 +180,8 @@ struct SessionIndex: Identifiable, Codable, Sendable {
     var title: String?
     var utteranceCount: Int
     var hasNotes: Bool
+    /// BCP 47 language/locale used for transcription (e.g. "en-US", "fr-FR").
+    var language: String?
     /// The detected meeting application name (e.g. "Zoom", "Microsoft Teams").
     var meetingApp: String?
     /// The ASR engine used for transcription (e.g. "parakeetV2").

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -118,12 +118,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
     }
 
     var supportsExplicitLanguageHint: Bool {
-        switch self {
-        case .qwen3ASR06B:
-            true
-        case .parakeetV2, .parakeetV3, .whisperBase, .whisperSmall, .whisperLargeV3Turbo:
-            false
-        }
+        true
     }
 
     var localeFieldTitle: String {
@@ -138,15 +133,15 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
     var localeHelpText: String {
         switch self {
         case .parakeetV2:
-            "Parakeet TDT v2 is English-only. Locale changes do not affect this model."
+            "Parakeet TDT v2 is English-only. Use en-US. This language value is still saved with the session and markdown export."
         case .parakeetV3:
-            "Parakeet TDT v3 auto-detects among its supported languages. Locale changes do not affect this model."
+            "Parakeet TDT v3 auto-detects speech language. Use this field to set your expected meeting language for metadata and export."
         case .qwen3ASR06B:
-            "Optional. Used as a language hint for Qwen3 ASR. Enter a locale such as en-US, fr-FR, or ja-JP. Applies when a new session starts."
+            "Used as a language hint for Qwen3 ASR and saved with the session. Enter a locale such as en-US, fr-FR, or ja-JP."
         case .whisperBase, .whisperSmall:
-            "Whisper auto-detects the spoken language. Locale changes do not affect this model."
+            "Whisper auto-detects speech language. This setting is still saved with the session and markdown export."
         case .whisperLargeV3Turbo:
-            "Whisper Large v3 Turbo auto-detects the spoken language. Best multilingual batch model."
+            "Whisper Large v3 Turbo auto-detects speech language. This setting is saved with session metadata and markdown export."
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -51,6 +51,7 @@ struct SessionFinalizeMetadata: Sendable {
     let endedAt: Date
     let utteranceCount: Int
     let title: String?
+    let language: String?
     let meetingApp: String?
     let engine: String?
     let templateSnapshot: TemplateSnapshot?
@@ -83,6 +84,7 @@ struct SessionMetadata: Codable, Sendable {
     var title: String?
     var utteranceCount: Int
     var hasNotes: Bool
+    var language: String?
     var meetingApp: String?
     var engine: String?
     var tags: [String]?
@@ -324,6 +326,7 @@ actor SessionRepository {
             title: metadata.title,
             utteranceCount: metadata.utteranceCount,
             hasNotes: false,
+            language: metadata.language,
             meetingApp: metadata.meetingApp,
             engine: metadata.engine
         )
@@ -449,6 +452,7 @@ actor SessionRepository {
                         title: meta.title,
                         utteranceCount: meta.utteranceCount,
                         hasNotes: meta.hasNotes,
+                        language: meta.language,
                         meetingApp: meta.meetingApp,
                         engine: meta.engine,
                         tags: meta.tags
@@ -484,6 +488,7 @@ actor SessionRepository {
                 title: meta.title,
                 utteranceCount: meta.utteranceCount,
                 hasNotes: meta.hasNotes,
+                language: meta.language,
                 meetingApp: meta.meetingApp,
                 engine: meta.engine,
                 tags: meta.tags
@@ -580,6 +585,7 @@ actor SessionRepository {
             title: index.title,
             utteranceCount: index.utteranceCount,
             hasNotes: index.hasNotes,
+            language: index.language,
             meetingApp: index.meetingApp,
             engine: index.engine,
             tags: normalized.isEmpty ? nil : normalized
@@ -983,6 +989,7 @@ actor SessionRepository {
             title: meta?.title,
             utteranceCount: meta?.utteranceCount ?? records.count,
             hasNotes: meta?.hasNotes ?? false,
+            language: meta?.language,
             meetingApp: meta?.meetingApp,
             engine: meta?.engine,
             tags: meta?.tags

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -188,13 +188,11 @@ struct SettingsView: View {
                 .font(.system(size: 12))
                 .accessibilityIdentifier("settings.transcriptionModelPicker")
 
-                if settings.transcriptionModel.supportsExplicitLanguageHint {
-                    TextField(
-                        "\(settings.transcriptionModel.localeFieldTitle) (e.g. en-US)",
-                        text: $settings.transcriptionLocale
-                    )
-                    .font(.system(size: 12, design: .monospaced))
-                }
+                TextField(
+                    "\(settings.transcriptionModel.localeFieldTitle) (e.g. en-US)",
+                    text: $settings.transcriptionLocale
+                )
+                .font(.system(size: 12, design: .monospaced))
 
                 Text(settings.transcriptionModel.localeHelpText)
                     .font(.system(size: 11))

--- a/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
@@ -65,10 +65,11 @@ final class AppSettingsTests: XCTestCase {
 
     func testTranscriptionModelSupportsExplicitLanguageHint() {
         XCTAssertTrue(TranscriptionModel.qwen3ASR06B.supportsExplicitLanguageHint)
-        XCTAssertFalse(TranscriptionModel.parakeetV2.supportsExplicitLanguageHint)
-        XCTAssertFalse(TranscriptionModel.parakeetV3.supportsExplicitLanguageHint)
-        XCTAssertFalse(TranscriptionModel.whisperBase.supportsExplicitLanguageHint)
-        XCTAssertFalse(TranscriptionModel.whisperSmall.supportsExplicitLanguageHint)
+        XCTAssertTrue(TranscriptionModel.parakeetV2.supportsExplicitLanguageHint)
+        XCTAssertTrue(TranscriptionModel.parakeetV3.supportsExplicitLanguageHint)
+        XCTAssertTrue(TranscriptionModel.whisperBase.supportsExplicitLanguageHint)
+        XCTAssertTrue(TranscriptionModel.whisperSmall.supportsExplicitLanguageHint)
+        XCTAssertTrue(TranscriptionModel.whisperLargeV3Turbo.supportsExplicitLanguageHint)
     }
 
     func testTranscriptionModelWhisperVariant() {

--- a/OpenOats/Tests/OpenOatsTests/MarkdownMeetingWriterTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MarkdownMeetingWriterTests.swift
@@ -169,6 +169,7 @@ final class MarkdownMeetingWriterTests: XCTestCase {
                 endedAt: start.addingTimeInterval(1920), // 32 minutes
                 utteranceCount: 10,
                 hasNotes: false,
+                language: "de-DE",
                 engine: "parakeetV2"
             )
         )
@@ -191,6 +192,7 @@ final class MarkdownMeetingWriterTests: XCTestCase {
         XCTAssertTrue(frontmatter.contains("  - You"))
         XCTAssertTrue(frontmatter.contains("  - Them"))
         XCTAssertTrue(frontmatter.contains("engine: parakeetV2"))
+        XCTAssertTrue(frontmatter.contains("language: de-DE"))
     }
 
     func testFrontmatterIncludesMeetingApp() {

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -107,6 +107,7 @@ final class SessionRepositoryTests: XCTestCase {
                 endedAt: Date(),
                 utteranceCount: 1,
                 title: "Test Meeting",
+                language: "fr-FR",
                 meetingApp: "Zoom",
                 engine: "parakeetV2",
                 templateSnapshot: nil,
@@ -118,6 +119,7 @@ final class SessionRepositoryTests: XCTestCase {
         let found = sessions.first(where: { $0.id == sessionID })
         XCTAssertNotNil(found)
         XCTAssertEqual(found?.title, "Test Meeting")
+        XCTAssertEqual(found?.language, "fr-FR")
         XCTAssertEqual(found?.meetingApp, "Zoom")
         XCTAssertEqual(found?.engine, "parakeetV2")
         XCTAssertEqual(found?.utteranceCount, 1)


### PR DESCRIPTION
## Summary

- Always show the locale/language field in settings for all transcription models (not just Qwen3 ASR)
- Persist the transcription locale in `session.json` via new `language` field on `SessionMetadata`, `SessionIndex`, and `SessionFinalizeMetadata`
- Emit `language:` (BCP 47) in the markdown frontmatter export
- Update help text to reflect that locale is saved as session metadata regardless of model

Reimplements the approach from #146 by @mono1982 cleanly against the current codebase architecture (no merge conflicts).

Closes #146

## Test plan

- [x] All 289 existing tests pass
- [x] `testFinalizeSessionWritesMetadata` now verifies `language` round-trip
- [x] `testFrontmatterContainsRequiredFields` verifies `language: de-DE` in frontmatter
- [x] `testTranscriptionModelSupportsExplicitLanguageHint` updated for all models returning `true`