### PR TITLE
feat: add Import Meeting Recording for offline audio transcription

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -84,6 +84,12 @@ final class AppCoordinator {
         set { withMutation(keyPath: \.batchStatus) { _batchStatus = newValue } }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _batchIsImporting: Bool = false
+    var batchIsImporting: Bool {
+        get { access(keyPath: \.batchIsImporting); return _batchIsImporting }
+        set { withMutation(keyPath: \.batchIsImporting) { _batchIsImporting = newValue } }
+    }
+
     var transcriptionEngine: TranscriptionEngine?
     var refinementEngine: TranscriptRefinementEngine?
     var audioRecorder: AudioRecorder?

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -14,6 +14,7 @@ struct LiveSessionState {
     var suggestions: [Suggestion] = []
     var isGeneratingSuggestions: Bool = false
     var batchStatus: BatchTranscriptionEngine.Status = .idle
+    var batchIsImporting: Bool = false
     var lastEndedSession: SessionIndex? = nil
     var lastSessionHasNotes: Bool = false
     var kbIndexingProgress: String = ""
@@ -78,8 +79,10 @@ final class LiveSessionController {
             // Poll batch engine status (actor-isolated)
             if let engine = coordinator.batchEngine {
                 let status = await engine.status
+                let importing = await engine.isImporting
                 if status != .idle || coordinator.batchStatus != .idle {
                     coordinator.batchStatus = status
+                    coordinator.batchIsImporting = importing
 
                     if case .completed(let sid) = status, lastNotifiedBatchSessionID != sid {
                         lastNotifiedBatchSessionID = sid
@@ -467,6 +470,7 @@ final class LiveSessionController {
         next.suggestions = coordinator.suggestionEngine?.suggestions ?? []
         next.isGeneratingSuggestions = coordinator.suggestionEngine?.isGenerating ?? false
         next.batchStatus = coordinator.batchStatus
+        next.batchIsImporting = coordinator.batchIsImporting
         next.lastEndedSession = lastEndedSession
         next.lastSessionHasNotes = lastSessionHasNotes
         next.kbIndexingProgress = coordinator.knowledgeBase?.indexingProgress ?? ""

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 import AppKit
+import AVFoundation
 import Sparkle
+import UniformTypeIdentifiers
 import UserNotifications
 
 public struct OpenOatsRootApp: App {
@@ -79,6 +81,12 @@ public struct OpenOatsRootApp: App {
                 }
                 .keyboardShortcut("m", modifiers: [.command, .shift])
 
+                Button("Import Meeting Recording...") {
+                    importMeetingRecording()
+                }
+                .keyboardShortcut("i", modifiers: [.command, .shift])
+                .disabled(coordinator.isRecording || isBatchEngineBusy)
+
                 Button("GitHub Repository...") {
                     if let url = URL(string: "https://github.com/yazinsai/OpenOats") {
                         NSWorkspace.shared.open(url)
@@ -117,6 +125,89 @@ extension OpenOatsRootApp {
 
     private func openNotesWindow() {
         openWindow(id: "notes")
+    }
+
+    private var isBatchEngineBusy: Bool {
+        switch coordinator.batchStatus {
+        case .idle, .completed, .failed, .cancelled: return false
+        default: return true
+        }
+    }
+
+    private func importMeetingRecording() {
+        let panel = NSOpenPanel()
+        panel.title = "Import Meeting Recording"
+        panel.allowedContentTypes = [
+            .audio,
+            .init(filenameExtension: "m4a")!,
+            .init(filenameExtension: "mp3")!,
+            .init(filenameExtension: "wav")!,
+            .init(filenameExtension: "caf")!,
+        ]
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+
+        guard panel.runModal() == .OK, let fileURL = panel.url else { return }
+
+        guard let batchEngine = coordinator.batchEngine else { return }
+
+        let model = settings.transcriptionModel
+        let locale = settings.locale
+        let repo = coordinator.sessionRepository
+
+        // Derive start date and duration from file
+        let fm = FileManager.default
+        let startDate: Date
+        if let attrs = try? fm.attributesOfItem(atPath: fileURL.path),
+           let creation = attrs[.creationDate] as? Date {
+            startDate = creation
+        } else {
+            startDate = Date()
+        }
+
+        // Estimate duration from audio file for endedAt
+        var estimatedEnd = startDate
+        if let audioFile = try? AVAudioFile(forReading: fileURL) {
+            let duration = Double(audioFile.length) / audioFile.processingFormat.sampleRate
+            estimatedEnd = startDate.addingTimeInterval(duration)
+        }
+
+        let title = fileURL.deletingPathExtension().lastPathComponent
+
+        Task {
+            let sessionID = await repo.createImportedSession(
+                config: .init(
+                    title: title,
+                    startedAt: startDate,
+                    endedAt: estimatedEnd,
+                    language: settings.transcriptionLocale,
+                    engine: model.rawValue
+                )
+            )
+
+            await batchEngine.importFile(
+                url: fileURL,
+                sessionID: sessionID,
+                model: model,
+                locale: locale,
+                sessionRepository: repo
+            )
+
+            // Check result
+            let status = await batchEngine.status
+            if case .completed = status {
+                coordinator.queueSessionSelection(sessionID)
+                openNotesWindow()
+                await coordinator.loadHistory()
+            } else if case .failed = status {
+                // Clean up the orphaned session
+                await repo.deleteSession(sessionID: sessionID)
+                await coordinator.loadHistory()
+            } else if case .cancelled = status {
+                await repo.deleteSession(sessionID: sessionID)
+                await coordinator.loadHistory()
+            }
+        }
     }
 
     private func showMainWindow() {

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -188,6 +188,8 @@ struct SessionIndex: Identifiable, Codable, Sendable {
     var engine: String?
     /// User-assigned tags for session organization.
     var tags: [String]?
+    /// How the session was created (nil for live sessions, "imported" for imported audio).
+    var source: String?
 }
 
 struct SessionSidecar: Codable, Sendable {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -88,6 +88,8 @@ struct SessionMetadata: Codable, Sendable {
     var meetingApp: String?
     var engine: String?
     var tags: [String]?
+    /// How the session was created (nil for live sessions, "imported" for imported audio).
+    var source: String?
 }
 
 // MARK: - SessionRepository
@@ -341,6 +343,65 @@ actor SessionRepository {
         liveUtteranceCount = 0
     }
 
+    // MARK: - Imported Session
+
+    /// Configuration for creating an imported session (no live file handle needed).
+    struct ImportedSessionConfig: Sendable {
+        let title: String
+        let startedAt: Date
+        let endedAt: Date
+        let language: String?
+        let engine: String?
+    }
+
+    /// Create a session directory and initial metadata for an imported audio file.
+    /// Unlike `startSession`, this does not open a live file handle.
+    @discardableResult
+    func createImportedSession(config: ImportedSessionConfig) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        let sessionID = "session_\(formatter.string(from: config.startedAt))"
+
+        let sessionDir = sessionDirectory(for: sessionID)
+        try? FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+
+        // Create audio subdirectory
+        let audioDir = sessionDir.appendingPathComponent("audio", isDirectory: true)
+        try? FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+
+        let metadata = SessionMetadata(
+            id: sessionID,
+            startedAt: config.startedAt,
+            endedAt: config.endedAt,
+            title: config.title,
+            utteranceCount: 0,
+            hasNotes: false,
+            language: config.language,
+            engine: config.engine,
+            source: "imported"
+        )
+        writeSessionMetadata(metadata, sessionID: sessionID)
+
+        return sessionID
+    }
+
+    /// Update utterance count and endedAt for a finalized imported session.
+    func finalizeImportedSession(sessionID: String, utteranceCount: Int, endedAt: Date) {
+        guard var meta = loadSessionMetadataFile(sessionID: sessionID) else { return }
+        meta.utteranceCount = utteranceCount
+        meta.endedAt = endedAt
+        writeSessionMetadata(meta, sessionID: sessionID)
+    }
+
+    /// Copy an audio file into the session's audio directory.
+    func copyAudioFileToSession(sessionID: String, sourceURL: URL) {
+        let audioDir = sessionDirectory(for: sessionID)
+            .appendingPathComponent("audio", isDirectory: true)
+        try? FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+        let dest = audioDir.appendingPathComponent("imported.\(sourceURL.pathExtension)")
+        try? FileManager.default.copyItem(at: sourceURL, to: dest)
+    }
+
     // MARK: - Final Transcript
 
     func saveFinalTranscript(sessionID: String, records: [SessionRecord]) {
@@ -455,7 +516,8 @@ actor SessionRepository {
                         language: meta.language,
                         meetingApp: meta.meetingApp,
                         engine: meta.engine,
-                        tags: meta.tags
+                        tags: meta.tags,
+                        source: meta.source
                     ))
                     continue
                 }
@@ -491,7 +553,8 @@ actor SessionRepository {
                 language: meta.language,
                 meetingApp: meta.meetingApp,
                 engine: meta.engine,
-                tags: meta.tags
+                tags: meta.tags,
+                source: meta.source
             )
 
             let transcript = loadTranscript(sessionID: id)
@@ -992,7 +1055,8 @@ actor SessionRepository {
             language: meta?.language,
             meetingApp: meta?.meetingApp,
             engine: meta?.engine,
-            tags: meta?.tags
+            tags: meta?.tags,
+            source: meta?.source
         )
 
         // Write/update Markdown meeting notes

--- a/OpenOats/Sources/OpenOats/Transcription/BatchTranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/BatchTranscriptionEngine.swift
@@ -18,6 +18,8 @@ actor BatchTranscriptionEngine {
     }
 
     private(set) var status: Status = .idle
+    /// True when the current batch job is an audio file import (affects UI copy).
+    private(set) var isImporting: Bool = false
     private var currentTask: Task<Void, Never>?
 
     /// Process batch transcription for a completed session.
@@ -63,12 +65,133 @@ actor BatchTranscriptionEngine {
         task?.cancel()
         await task?.value
         status = .cancelled
+        isImporting = false
+    }
+
+    // MARK: - Audio Import
+
+    /// Import and transcribe an external audio file (meeting recording).
+    func importFile(
+        url: URL,
+        sessionID: String,
+        model: TranscriptionModel,
+        locale: Locale,
+        sessionRepository: SessionRepository
+    ) async {
+        currentTask?.cancel()
+        isImporting = true
+
+        let task = Task { [weak self] in
+            guard let self else { return }
+            do {
+                try await self.runImport(
+                    url: url,
+                    sessionID: sessionID,
+                    model: model,
+                    locale: locale,
+                    sessionRepository: sessionRepository
+                )
+            } catch is CancellationError {
+                await self.setStatus(.cancelled)
+                await self.setIsImporting(false)
+                batchLog.info("Audio import cancelled for \(sessionID)")
+            } catch {
+                await self.setStatus(.failed(error.localizedDescription))
+                await self.setIsImporting(false)
+                batchLog.error("Audio import failed: \(error.localizedDescription)")
+            }
+        }
+        currentTask = task
+        await task.value
+    }
+
+    private func runImport(
+        url: URL,
+        sessionID: String,
+        model: TranscriptionModel,
+        locale: Locale,
+        sessionRepository: SessionRepository
+    ) async throws {
+        batchLog.info("Starting audio import for \(sessionID) from \(url.lastPathComponent)")
+        status = .loading(model: model.displayName)
+
+        // Prepare backend and VAD
+        let backend = model.makeBackend()
+        try await backend.prepare { statusMsg in
+            batchLog.info("Backend: \(statusMsg)")
+        }
+
+        try Task.checkCancellation()
+
+        let vad = try await VadManager()
+
+        try Task.checkCancellation()
+
+        status = .transcribing(progress: 0)
+
+        // Derive start date from file attributes
+        let startDate: Date
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+           let creationDate = attrs[.creationDate] as? Date {
+            startDate = creationDate
+        } else if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+                  let modDate = attrs[.modificationDate] as? Date {
+            startDate = modDate
+        } else {
+            startDate = Date()
+        }
+
+        // Transcribe the file as a single speaker
+        let records = try await transcribeFile(
+            url: url,
+            speaker: .them,
+            startDate: startDate,
+            sampleRate: nil,
+            backend: backend,
+            vad: vad,
+            locale: locale,
+            progressBase: 0,
+            progressScale: 1.0
+        )
+
+        try Task.checkCancellation()
+
+        guard !records.isEmpty else {
+            batchLog.warning("Audio import produced no records for \(sessionID)")
+            status = .failed("No speech detected in the audio file")
+            isImporting = false
+            return
+        }
+
+        // Derive endedAt from last record timestamp
+        let endedAt = records.last?.timestamp ?? startDate
+
+        // Save final transcript atomically
+        await sessionRepository.saveFinalTranscript(sessionID: sessionID, records: records)
+
+        // Update session metadata with final counts
+        await sessionRepository.finalizeImportedSession(
+            sessionID: sessionID,
+            utteranceCount: records.count,
+            endedAt: endedAt
+        )
+
+        // Copy original audio file to session
+        await sessionRepository.copyAudioFileToSession(sessionID: sessionID, sourceURL: url)
+
+        status = .completed(sessionID: sessionID)
+        isImporting = false
+        batchLog.info("Audio import completed for \(sessionID): \(records.count) records")
     }
 
     // MARK: - Private
 
     private func setStatus(_ newStatus: Status) {
         status = newStatus
+    }
+
+    private func setIsImporting(_ value: Bool) {
+        isImporting = value
     }
 
     private func runTranscription(

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -102,13 +102,15 @@ struct ContentView: View {
                 Divider()
             }
 
-            // Batch transcription progress banner
+            // Batch transcription / import progress banner
             if case .transcribing(let progress) = controllerState.batchStatus {
                 HStack(spacing: 8) {
                     ProgressView(value: progress, total: 1.0)
                         .progressViewStyle(.linear)
                         .frame(maxWidth: .infinity)
-                    Text("Enhancing transcript... \(Int(progress * 100))%")
+                    Text(controllerState.batchIsImporting
+                         ? "Importing meeting recording… \(Int(progress * 100))%"
+                         : "Enhancing transcript... \(Int(progress * 100))%")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
@@ -122,7 +124,9 @@ struct ContentView: View {
                 HStack(spacing: 8) {
                     ProgressView()
                         .controlSize(.small)
-                    Text("Loading batch model...")
+                    Text(controllerState.batchIsImporting
+                         ? "Preparing to import…"
+                         : "Loading batch model...")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                 }
@@ -136,7 +140,9 @@ struct ContentView: View {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundStyle(.green)
                         .font(.system(size: 12))
-                    Text("Transcript enhanced")
+                    Text(controllerState.batchIsImporting
+                         ? "Meeting recording imported"
+                         : "Transcript enhanced")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                 }

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -41,7 +41,9 @@ struct NotesView: View {
             // transaction as session selection (matches pre-Phase 6 behavior).
             if let requested = coordinator.consumeRequestedSessionSelection() {
                 controller.selectSession(requested)
-                detailViewMode = .notes
+                // Show Transcript tab for imported sessions (no notes generated yet)
+                let isImported = controller.state.sessionHistory.first(where: { $0.id == requested })?.source == "imported"
+                detailViewMode = isImported ? .transcript : .notes
             } else if let last = coordinator.lastEndedSession {
                 controller.selectSession(last.id)
             }


### PR DESCRIPTION
## Summary

Closes #128

- Adds **File > Import Meeting Recording...** (Cmd+Shift+I) menu item to import audio files (M4A, MP3, WAV, CAF) as meeting sessions
- Reuses the existing `BatchTranscriptionEngine` pipeline for on-device transcription with VAD and proper timestamping
- Imported sessions appear in Past Meetings with `source: "imported"` metadata, preserving the original file's creation date as the session start time
- Progress is shown via the existing batch transcription banner in ContentView with import-specific copy
- On completion, Past Meetings opens to the Transcript tab for the new session
- Cancel/failure paths clean up the session directory via `SessionRepository.deleteSession()`

### Changes

| File | Change |
|------|--------|
| `BatchTranscriptionEngine.swift` | New `importFile()` method + `isImporting` flag |
| `SessionRepository.swift` | New `createImportedSession()`, `finalizeImportedSession()`, `copyAudioFileToSession()` helpers; `source` field on `SessionMetadata` |
| `Models.swift` | `source: String?` on `SessionIndex` |
| `AppCoordinator.swift` | `batchIsImporting` observable property |
| `LiveSessionController.swift` | `batchIsImporting` state projection from batch engine |
| `OpenOatsApp.swift` | Menu item + import orchestration |
| `ContentView.swift` | Import-aware progress banner copy |
| `NotesView.swift` | Open Transcript tab (not Notes) for imported sessions |

## Test plan

- [ ] Build passes (`swift build`)
- [ ] All 289 existing tests pass (`swift test`)
- [ ] Menu item appears under File, disabled during recording
- [ ] Selecting an M4A/MP3/WAV file starts import with progress banner
- [ ] Imported session appears in Past Meetings with correct title and date
- [ ] Cancelling during import cleans up the session
- [ ] Starting a meeting during import cancels the import gracefully