### PR TITLE
feat: add image insertion to meeting notes

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -16,6 +16,8 @@ struct NotesState {
     var streamingMarkdown: String = ""
     /// Active tag filter for sidebar (nil = show all).
     var tagFilter: String?
+    /// Directory for the currently selected session (used for image loading).
+    var selectedSessionDirectory: URL?
 }
 
 enum CleanupStatus: Equatable {
@@ -98,11 +100,14 @@ final class NotesController {
         guard let sessionID else {
             state.loadedNotes = nil
             state.loadedTranscript = []
+            state.selectedSessionDirectory = nil
             return
         }
 
         state.loadedNotes = nil
         state.loadedTranscript = []
+        state.selectedSessionDirectory = coordinator.sessionRepository.sessionsDirectoryURL
+            .appendingPathComponent(sessionID, isDirectory: true)
         state.showingOriginal = false
         coordinator.cleanupEngine.cancel()
         syncCleanupStatus()
@@ -174,6 +179,41 @@ final class NotesController {
         coordinator.notesEngine.cancel()
         state.notesGenerationStatus = .idle
         state.streamingMarkdown = ""
+    }
+
+    // MARK: - Image Insertion
+
+    func insertImage(imageData: Data) {
+        guard let sessionID = state.selectedSessionID else { return }
+
+        Task {
+            let filename = await coordinator.sessionRepository.saveImage(
+                sessionID: sessionID, imageData: imageData
+            )
+            let imageRef = "\n\n![](images/\(filename))\n"
+
+            if let existing = state.loadedNotes {
+                let updated = EnhancedNotes(
+                    template: existing.template,
+                    generatedAt: existing.generatedAt,
+                    markdown: existing.markdown + imageRef
+                )
+                await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: updated)
+                state.loadedNotes = updated
+            } else {
+                let template = state.selectedTemplate
+                    ?? coordinator.templateStore.template(for: TemplateStore.genericID)
+                    ?? TemplateStore.builtInTemplates.first!
+                let notes = EnhancedNotes(
+                    template: coordinator.templateStore.snapshot(of: template),
+                    generatedAt: Date(),
+                    markdown: "![](images/\(filename))"
+                )
+                await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
+                state.loadedNotes = notes
+                await loadHistory()
+            }
+        }
     }
 
     // MARK: - Transcript Cleanup

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -483,6 +483,18 @@ actor SessionRepository {
         )
     }
 
+    // MARK: - Images
+
+    func saveImage(sessionID: String, imageData: Data) -> String {
+        let dir = sessionDirectory(for: sessionID)
+            .appendingPathComponent("images", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let filename = "\(UUID().uuidString).png"
+        let url = dir.appendingPathComponent(filename)
+        try? imageData.write(to: url, options: .atomic)
+        return filename
+    }
+
     // MARK: - Listing & Loading
 
     func listSessions() -> [SessionIndex] {
@@ -929,7 +941,7 @@ actor SessionRepository {
 
     // MARK: - Accessors
 
-    var sessionsDirectoryURL: URL { sessionsDirectory }
+    nonisolated var sessionsDirectoryURL: URL { sessionsDirectory }
 
     func getCurrentSessionID() -> String? { currentSessionID }
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct NotesView: View {
     @Bindable var settings: AppSettings
@@ -544,6 +545,84 @@ struct NotesView: View {
             .fixedSize()
             .help("Click to regenerate, or pick a different template")
         }
+
+        imageInsertMenu(controller: controller, state: state)
+    }
+
+    @ViewBuilder
+    private func imageInsertMenu(controller: NotesController, state: NotesState) -> some View {
+        Menu {
+            Button {
+                insertImageFromFile(controller: controller)
+            } label: {
+                Label("From File\u{2026}", systemImage: "folder")
+            }
+            Button {
+                insertImageFromClipboard(controller: controller)
+            } label: {
+                Label("From Clipboard", systemImage: "doc.on.clipboard")
+            }
+            .disabled(!clipboardHasImage())
+            Button {
+                captureScreenshot(controller: controller)
+            } label: {
+                Label("Capture Screenshot", systemImage: "camera.viewfinder")
+            }
+        } label: {
+            Label("Insert Image", systemImage: "photo.badge.plus")
+                .font(.system(size: 12))
+        }
+        .menuStyle(.button)
+        .buttonStyle(.bordered)
+        .fixedSize()
+        .disabled(state.notesGenerationStatus == .generating || state.selectedSessionID == nil)
+        .help("Insert an image into notes")
+    }
+
+    private func clipboardHasImage() -> Bool {
+        let pb = NSPasteboard.general
+        return pb.canReadItem(withDataConformingToTypes: [UTType.png.identifier, UTType.tiff.identifier, UTType.jpeg.identifier])
+    }
+
+    private func insertImageFromFile(controller: NotesController) {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.image]
+        panel.allowsMultipleSelection = false
+        panel.message = "Choose an image to insert into notes"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        guard let nsImage = NSImage(contentsOf: url),
+              let tiff = nsImage.tiffRepresentation,
+              let rep = NSBitmapImageRep(data: tiff),
+              let pngData = rep.representation(using: .png, properties: [:]) else { return }
+        controller.insertImage(imageData: pngData)
+    }
+
+    private func insertImageFromClipboard(controller: NotesController) {
+        let pb = NSPasteboard.general
+        if let data = pb.data(forType: .png) {
+            controller.insertImage(imageData: data)
+        } else if let data = pb.data(forType: .tiff),
+                  let rep = NSBitmapImageRep(data: data),
+                  let pngData = rep.representation(using: .png, properties: [:]) {
+            controller.insertImage(imageData: pngData)
+        }
+    }
+
+    private func captureScreenshot(controller: NotesController) {
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).png")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/sbin/screencapture")
+        process.arguments = ["-i", tempURL.path]
+        process.terminationHandler = { proc in
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+            guard proc.terminationStatus == 0,
+                  let data = try? Data(contentsOf: tempURL) else { return }
+            Task { @MainActor in
+                controller.insertImage(imageData: data)
+            }
+        }
+        try? process.run()
     }
 
     @ViewBuilder
@@ -566,7 +645,7 @@ struct NotesView: View {
             generatingView(controller: controller, state: state)
         case .idle, .completed, .error:
             if let notes = state.loadedNotes {
-                notesContentView(notes)
+                notesContentView(notes, sessionDirectory: state.selectedSessionDirectory)
             } else {
                 notesEmptyState(controller: controller, state: state, sessionID: sessionID)
             }
@@ -597,9 +676,9 @@ struct NotesView: View {
         }
     }
 
-    private func notesContentView(_ notes: EnhancedNotes) -> some View {
+    private func notesContentView(_ notes: EnhancedNotes, sessionDirectory: URL?) -> some View {
         ScrollView {
-            markdownContent(notes.markdown)
+            markdownContent(notes.markdown, sessionDirectory: sessionDirectory)
                 .padding(16)
                 .accessibilityIdentifier("notes.renderedMarkdown")
         }
@@ -710,7 +789,7 @@ struct NotesView: View {
 
     // MARK: - Markdown Rendering
 
-    private func markdownContent(_ markdown: String) -> some View {
+    private func markdownContent(_ markdown: String, sessionDirectory: URL? = nil) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             let sections = parseMarkdownSections(markdown)
             ForEach(Array(sections.enumerated()), id: \.offset) { _, section in
@@ -721,20 +800,79 @@ struct NotesView: View {
                         .padding(.top, section.level == 1 ? 4 : 2)
                 }
                 if !section.body.isEmpty {
-                    if let attributed = try? AttributedString(markdown: section.body, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
-                        Text(attributed)
-                            .font(.system(size: 13))
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    } else {
-                        Text(section.body)
-                            .font(.system(size: 13))
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
+                    sectionBodyView(section.body, sessionDirectory: sessionDirectory)
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func sectionBodyView(_ body: String, sessionDirectory: URL?) -> some View {
+        let blocks = parseBodyBlocks(body)
+        ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
+            switch block {
+            case .text(let text):
+                if let attributed = try? AttributedString(markdown: text, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
+                    Text(attributed)
+                        .font(.system(size: 13))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    Text(text)
+                        .font(.system(size: 13))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            case .image(let path):
+                if let dir = sessionDirectory,
+                   let nsImage = NSImage(contentsOf: dir.appendingPathComponent(path)) {
+                    Image(nsImage: nsImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxWidth: 500, maxHeight: 400)
+                        .clipShape(RoundedRectangle(cornerRadius: 6))
+                } else {
+                    Label("Image not found", systemImage: "photo")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    private enum BodyBlock {
+        case text(String)
+        case image(path: String)
+    }
+
+    private func parseBodyBlocks(_ body: String) -> [BodyBlock] {
+        var blocks: [BodyBlock] = []
+        var scanner = body[...]
+
+        while let imgStart = scanner.range(of: "![") {
+            let before = String(scanner[scanner.startIndex..<imgStart.lowerBound])
+            if !before.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                blocks.append(.text(before))
+            }
+
+            let afterBracket = scanner[imgStart.upperBound...]
+            guard let closeBracket = afterBracket.range(of: "]("),
+                  let closeParen = afterBracket[closeBracket.upperBound...].range(of: ")") else {
+                blocks.append(.text(String(scanner)))
+                return blocks
+            }
+
+            let path = String(afterBracket[closeBracket.upperBound..<closeParen.lowerBound])
+            blocks.append(.image(path: path))
+            scanner = afterBracket[closeParen.upperBound...]
+        }
+
+        let tail = String(scanner)
+        if !tail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            blocks.append(.text(tail))
+        }
+
+        return blocks
     }
 
     private struct MarkdownSection {


### PR DESCRIPTION
## Summary

Adds the ability to insert screenshots and images into meeting notes, as requested in #124.

- **Insert Image menu** in the Notes toolbar with three options: From File, From Clipboard, and Capture Screenshot (uses macOS `screencapture -i` for interactive region selection)
- **Image storage**: PNGs saved to `sessions/<id>/images/` alongside existing session data
- **Inline rendering**: Markdown `![](images/...)` references parsed and displayed as resizable images in the notes view
- Works with or without existing generated notes — inserting an image into a session with no notes creates a minimal note containing just the image

Closes #124

## Test plan

- [ ] Open Notes tab for a session with generated notes
- [ ] Click "Insert Image" → "From File..." and select a PNG/JPEG — verify it appears inline in the notes
- [ ] Copy an image to clipboard, click "Insert Image" → "From Clipboard" — verify it renders
- [ ] Click "Insert Image" → "Capture Screenshot" — verify the macOS screenshot selector appears, capture a region, and confirm it appears in notes
- [ ] Insert an image into a session that has no notes yet — verify it creates notes with just the image
- [ ] Navigate away from the session and back — verify inserted images persist and render
- [ ] Delete a session with images — verify clean deletion (no orphan files)