### PR TITLE
Update Homebrew cask for 1.29.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.28.0"
-  sha256 "d7b98ef2871517c5909caa28c3402429c22709c9f79f6bc9379927d24010198d"
+  version "1.29.0"
+  sha256 "06baa9091169130334461070da9333fdb7852d8a626efbe743f219564b72a76e"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Updates `Casks/openoats.rb` to match the v1.29.0 release.

- Version: 1.28.0 → 1.29.0
- SHA256 updated to match the new DMG

Automated cask maintenance per REPO_POLICY.md.