### PR TITLE
Increase streaming flush interval from 5s to 10s

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
@@ -40,11 +40,15 @@ final class StreamingTranscriber: @unchecked Sendable {
 
     /// Silero VAD expects chunks of 4096 samples (256ms at 16kHz).
     private static let vadChunkSize = 4096
-    private static let minimumSpeechSamples = 8000
+    /// Parakeet TDT requires >= 1s of audio; shorter segments produce unreliable output.
+    private static let minimumSpeechSamples = 16_000
     private static let prerollChunkCount = 2
-    /// Flush speech for transcription every ~5 seconds (80,000 samples at 16kHz).
-    /// A longer flush window reduces the streaming WER penalty with minimal latency impact.
-    private static let flushInterval = 80_000
+    /// Flush speech for transcription every ~10 seconds (160,000 samples at 16kHz).
+    /// Longer flush windows give the conformer encoder more context per segment,
+    /// reducing WER significantly (benchmarked: 13.6% at 5s vs 8.8% at 10s on Polish).
+    /// VAD speechEnd events still trigger immediate flush on natural pauses,
+    /// so short utterances appear without the full 10s delay.
+    private static let flushInterval = 10 * 16_000
     /// Number of trailing words to carry across segment boundaries for decoder priming.
     private static let contextWordCount = 5
 
@@ -134,7 +138,7 @@ final class StreamingTranscriber: @unchecked Sendable {
                         }
                     } else if isSpeaking {
 
-                        // Flush every ~3s for near-real-time output during continuous speech
+                        // Flush on long continuous speech (see flushInterval)
                         if speechSamples.count >= Self.flushInterval {
                             let segment = speechSamples
                             speechSamples.removeAll(keepingCapacity: true)


### PR DESCRIPTION
## What

Changes `flushInterval` from 80,000 to `10 * 16_000` samples (5s to 10s) in `StreamingTranscriber`. Also raises `minimumSpeechSamples` from 8,000 to 16,000 to match Parakeet TDT's actual minimum input length.

## Why

The conformer encoder in Parakeet TDT v3 produces significantly better transcriptions with more context per segment. At 5s, it gets too little audio to disambiguate words at segment boundaries, especially in inflected languages like Polish where word endings carry grammatical meaning.

I built a standalone benchmark framework and tested this against FLEURS test data (hand-transcribed ground truth) concatenated into 5-minute recordings with realistic silence gaps. 5 recordings per language, Parakeet TDT v3, M4 Pro:

**Polish (5x ~5min, 2620 reference words)**

| Strategy | WER |
|---|---|
| VAD Stream 10s | **8.8%** |
| Batch (FluidAudio ChunkProcessor, internal overlap + LCS dedup) | 9.3% |
| VAD Merge 15s (WhisperX-style, two-pass) | 9.6% |
| Fixed 30s chunks (no VAD) | 10.4% |
| Fixed 15s chunks (no VAD) | 11.4% |
| **VAD Stream 5s (current)** | **13.6%** |
| VAD Stream 3s | 24.9% |

**English (5x ~5min, 3033 reference words)**

| Strategy | WER |
|---|---|
| Batch | 12.3% |
| VAD Stream 10s | **12.3%** |
| VAD Merge 15s | 14.4% |
| Fixed 30s chunks (no VAD) | 15.8% |
| Fixed 15s chunks (no VAD) | 17.3% |
| VAD Stream 7s | 19.9% |
| **VAD Stream 5s (current)** | **28.7%** |
| VAD Stream 3s | 45.9% |

The 10s flush actually matches or beats batch mode. VAD places segment boundaries at natural speech pauses, which is better than cutting at fixed positions as ChunkProcessor does.

The latency tradeoff: during continuous speech without pauses, text appears every ~10s instead of ~5s. In practice, VAD fires `speechEnd` on natural pauses shorter than 10s (default `minSilenceDuration` is 0.75s), so most utterances still flush quickly. The 10s limit only kicks in during uninterrupted monologues.

The `minimumSpeechSamples` bump from 8,000 to 16,000 fixes a pre-existing issue: Parakeet TDT requires >= 1s of audio (16,000 samples), and segments shorter than that produce unreliable output or ASR errors.

## How

One constant changed (`flushInterval`), one raised (`minimumSpeechSamples`), one stale comment fixed. No architectural changes. The VAD state machine, speechEnd handling, preroll, and context carry all work identically.

## Testing

Benchmarked with a standalone framework testing 11 strategy variants across 2 languages on synthetic long-form audio derived from FLEURS test splits. Also tested VAD parameter sweeps (speechPadding, minSilenceDuration) and context carry variants. The flush interval is the single highest-impact parameter.


🤖 Generated with [Claude Code](https://claude.com/claude-code)