### PR TITLE
fix: transcript window not displaying live utterances

### DIFF
--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -107,6 +107,7 @@ public struct OpenOatsRootApp: App {
             TranscriptWindowView()
                 .environment(container)
                 .environment(coordinator)
+                .environment(coordinator.transcriptStore)
                 .defaultAppStorage(defaults)
         }
         .defaultSize(width: 600, height: 700)

--- a/OpenOats/Sources/OpenOats/Views/TranscriptWindowView.swift
+++ b/OpenOats/Sources/OpenOats/Views/TranscriptWindowView.swift
@@ -1,10 +1,9 @@
 import SwiftUI
 
 struct TranscriptWindowView: View {
-    @Environment(AppCoordinator.self) private var coordinator
+    @Environment(TranscriptStore.self) private var store
 
     var body: some View {
-        let store = coordinator.transcriptStore
         VStack(spacing: 0) {
             HStack {
                 Text("Live Transcript")


### PR DESCRIPTION
## Summary
- The full transcript window was empty because `TranscriptWindowView` accessed the `TranscriptStore` indirectly through `coordinator.transcriptStore` (a `nonisolated`, `@ObservationIgnored` property), so SwiftUI's observation tracking never picked up changes
- Inject `TranscriptStore` directly into the environment and read it via `@Environment(TranscriptStore.self)` instead

## Test plan
- [ ] Start a live transcription session
- [ ] Open the full transcript window (expand icon in transcript section)
- [ ] Verify utterances appear in real-time in both the main window and transcript window