### PR TITLE
Update Homebrew cask for 1.29.4

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.29.3"
-  sha256 "10b79332885f2ee78699af8c011a8e05b3146ead9803e675d6b8fd6328e29025"
+  version "1.29.4"
+  sha256 "388d92c66186af35ae382a77603abcf24cd50477bb0128d5f81729e3fbeee62b"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary

- Updates `Casks/openoats.rb` version from 1.29.1 to 1.29.4 with the correct SHA256

The cask was 3 releases behind the latest GitHub release (v1.29.4). Per REPO_POLICY.md stale cask detection, this is treated as a bug to fix immediately.