### PR TITLE
fix: sync Notes window session list when coordinator history changes

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -64,6 +64,9 @@ struct NotesView: View {
         .onChange(of: coordinator.lastEndedSession?.id) {
             Task { await controller.handleLastEndedSessionChanged() }
         }
+        .onChange(of: coordinator.sessionHistory.count) {
+            Task { await controller.loadHistory() }
+        }
         .onChange(of: coordinator.requestedSessionSelectionID) {
             if controller.handleRequestedSessionSelection() {
                 detailViewMode = .notes


### PR DESCRIPTION
## Summary

- Fixes the Notes window not showing a newly finished meeting when the window was already open prior to recording (#182)
- Adds a second `onChange` observer on `coordinator.sessionHistory.count` so the sidebar refreshes whenever the coordinator's session list changes, regardless of whether the `lastEndedSession` observer fires

## Root Cause

The Notes window maintains its own `sessionHistory` copy in `NotesController.state`. When a recording ends, `LiveSessionController` updates the coordinator's history via `coordinator.loadHistory()`, but the NotesController only refreshes if the `onChange(of: coordinator.lastEndedSession?.id)` observer fires. In some cases (e.g., window already open), the SwiftUI observation chain may not reliably propagate this change.

## Fix

A belt-and-suspenders `onChange(of: coordinator.sessionHistory.count)` observer that reloads the NotesController's history whenever the coordinator's session count changes. This is a 3-line addition with no structural changes.

Closes #182