### PR TITLE
Update Homebrew cask for 1.30.2

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.30.1"
-  sha256 "4dd7228ec209b4c35585c23abc6839c1c63788cae486311627cf868caa5299df"
+  version "1.30.2"
+  sha256 "33767e8c5690ac2470a0b40119d4c63d92baca4df21175241c2ad673afceb1a5"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary

- Update Homebrew cask version from 1.30.1 to 1.30.2
- Update SHA256 hash to match the v1.30.2 DMG

Routine cask maintenance to keep the Homebrew install path current with the latest release.