### PR TITLE
feat: auto-stop recording when meeting app exits

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -223,24 +223,28 @@ final class AppCoordinator {
                 switch event {
                 case .accepted(let metadata):
                     // Start silence monitoring for auto-detected sessions
-                    if case .appLaunched = metadata.detectionContext?.signal {
+                    if case .appLaunched(let app) = metadata.detectionContext?.signal {
                         controller.startSilenceMonitoring()
+                        controller.startAppExitMonitoring(bundleID: app.bundleID)
                     }
                     self.handle(.userStarted(metadata), settings: self.activeSettings)
                 case .meetingAppExited:
                     if case .recording(let meta) = self.state,
                        case .appLaunched = meta.detectionContext?.signal {
                         controller.stopSilenceMonitoring()
+                        controller.stopAppExitMonitoring()
                         self.handle(.userStopped)
                     }
                 case .silenceTimeout:
                     if case .recording = self.state {
                         controller.stopSilenceMonitoring()
+                        controller.stopAppExitMonitoring()
                         self.handle(.userStopped)
                     }
                 case .systemSleep:
                     if case .recording = self.state {
                         controller.stopSilenceMonitoring()
+                        controller.stopAppExitMonitoring()
                         self.handle(.userStopped)
                     }
                 case .notAMeeting, .dismissed, .timeout:

--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -62,6 +62,9 @@ final class MeetingDetectionController {
     /// Task monitoring silence timeout during detected sessions.
     private var silenceCheckTask: Task<Void, Never>?
 
+    /// Task polling for meeting app process exit during recording.
+    private var appExitMonitorTask: Task<Void, Never>?
+
     /// Observer token for system sleep notifications.
     private var sleepObserver: Any?
 
@@ -176,6 +179,9 @@ final class MeetingDetectionController {
         silenceCheckTask = nil
         isMonitoringSilence = false
 
+        appExitMonitorTask?.cancel()
+        appExitMonitorTask = nil
+
         Task {
             await meetingDetector?.stop()
         }
@@ -256,6 +262,42 @@ final class MeetingDetectionController {
     /// Called when a new utterance arrives, resets the silence timer.
     func noteUtterance() {
         lastUtteranceAt = Date()
+    }
+
+    // MARK: - Meeting App Process Monitor
+
+    /// Start polling for meeting app process exit during recording.
+    /// When the meeting app that triggered detection is no longer running,
+    /// yield `.meetingAppExited` so the coordinator can auto-stop.
+    func startAppExitMonitoring(bundleID: String) {
+        appExitMonitorTask?.cancel()
+
+        appExitMonitorTask = Task { [weak self] in
+            // Poll every 5 seconds
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(5))
+                guard !Task.isCancelled else { break }
+                guard let self else { break }
+
+                let isRunning = NSWorkspace.shared.runningApplications.contains {
+                    $0.bundleIdentifier == bundleID
+                }
+
+                if !isRunning {
+                    if self.activeSettings?.detectionLogEnabled == true {
+                        logger.info("Meeting app exited (\(bundleID, privacy: .public)), yielding event")
+                    }
+                    self.eventContinuation.yield(.meetingAppExited)
+                    break
+                }
+            }
+        }
+    }
+
+    /// Stop monitoring for meeting app process exit.
+    func stopAppExitMonitoring() {
+        appExitMonitorTask?.cancel()
+        appExitMonitorTask = nil
     }
 
     // MARK: - Evaluate Immediate

--- a/OpenOats/Tests/OpenOatsTests/MeetingDetectionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MeetingDetectionControllerTests.swift
@@ -178,4 +178,60 @@ final class MeetingDetectionControllerTests: XCTestCase {
         _ = controller.events
         // Reaching this point means the stream didn't block on init
     }
+
+    // MARK: - App Exit Monitoring
+
+    func testAppExitMonitorYieldsEventWhenAppNotRunning() async throws {
+        let controller = MeetingDetectionController()
+        var receivedEvent: DetectionEvent?
+
+        let consumeTask = Task { @MainActor in
+            for await event in controller.events {
+                receivedEvent = event
+                break
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Use a bundle ID that is definitely not running
+        controller.startAppExitMonitoring(bundleID: "com.test.fake-app-not-running")
+
+        // The monitor polls every 5 seconds; wait for it to fire
+        try await Task.sleep(for: .seconds(6))
+
+        if case .meetingAppExited = receivedEvent {
+            // correct — the monitor detected the app is not running
+        } else {
+            XCTFail("Expected .meetingAppExited, got \(String(describing: receivedEvent))")
+        }
+
+        consumeTask.cancel()
+    }
+
+    func testStopAppExitMonitoringPreventsEvent() async throws {
+        let controller = MeetingDetectionController()
+        var receivedEvent: DetectionEvent?
+
+        let consumeTask = Task { @MainActor in
+            for await event in controller.events {
+                receivedEvent = event
+                break
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Start monitoring then immediately stop
+        controller.startAppExitMonitoring(bundleID: "com.test.fake-app-not-running")
+        controller.stopAppExitMonitoring()
+
+        // Wait past the poll interval
+        try await Task.sleep(for: .seconds(6))
+
+        // No event should have been yielded since we stopped monitoring
+        XCTAssertNil(receivedEvent)
+
+        consumeTask.cancel()
+    }
 }


### PR DESCRIPTION
## Summary

- Add meeting app process monitoring to `MeetingDetectionController` — polls every 5s to detect when the meeting app that triggered auto-detection exits
- Wire up the new monitor in `AppCoordinator`: starts when recording begins via app detection, stops on any recording end
- Previously, the mic deactivation signal couldn't fire during recording because OpenOats itself keeps the mic active — this was the gap
- No new permissions or entitlements required

## How it works

When a session starts via app-launched detection (e.g. Zoom detected), `startAppExitMonitoring(bundleID:)` begins polling `NSWorkspace.shared.runningApplications`. When the meeting app is no longer found, it yields `.meetingAppExited`, which the coordinator handles by stopping recording.

The existing auto-stop mechanisms (silence timeout, system sleep) remain as fallbacks for cases where the app stays open after the call ends.

## Test plan

- [x] Added test: monitor yields `.meetingAppExited` when app is not running
- [x] Added test: `stopAppExitMonitoring()` cancels the monitor and prevents event
- [ ] CI: `validate-swift` must pass

Closes #186