### PR TITLE
fix: move LaunchAtLogin status check off main thread

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import CoreAudio
 import LaunchAtLogin
+import ServiceManagement
 import Sparkle
 
 struct SettingsView: View {
@@ -20,6 +21,7 @@ struct SettingsView: View {
     @State private var newTemplatePrompt = ""
     @FocusState private var focusedTemplateField: TemplateField?
     @State private var showAutoDetectExplanation = false
+    @State private var launchAtLoginEnabled = false
 
     var body: some View {
         Form {
@@ -313,8 +315,16 @@ struct SettingsView: View {
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
 
-                LaunchAtLogin.Toggle("Launch at login")
+                Toggle("Launch at login", isOn: $launchAtLoginEnabled)
                     .font(.system(size: 12))
+                    .onChange(of: launchAtLoginEnabled) { _, newValue in
+                        LaunchAtLogin.isEnabled = newValue
+                    }
+                    .task {
+                        launchAtLoginEnabled = await Task.detached {
+                            SMAppService.mainApp.status == .enabled
+                        }.value
+                    }
             }
             .sheet(isPresented: $showAutoDetectExplanation) {
                 VStack(spacing: 16) {


### PR DESCRIPTION
## Summary
- Replace `LaunchAtLogin.Toggle` with a custom `Toggle` that caches the launch-at-login state and loads it asynchronously via `Task.detached`
- Avoids synchronous `SMAppService.mainApp.status` XPC call during SwiftUI view body evaluation that hangs the UI when `backgroundtaskmanagementd` is slow

## Details
The `LaunchAtLogin` library's `isEnabled` getter calls `SMAppService.mainApp.status` synchronously on the main thread. When the system daemon (`backgroundtaskmanagementd`) is slow or unresponsive, this blocks the entire UI — in the reported case, for ~29 minutes.

The fix moves the status check to a detached task and uses `onChange` to write back, keeping the main thread free during view evaluation.

Closes #202