### PR TITLE
Update Homebrew cask for 1.33.1

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.33.0"
-  sha256 "f22a9870ed7b688af320b414c152cc205f58f225c04782cb863d6b4552490ef0"
+  version "1.33.1"
+  sha256 "ff2013927d1c66b85d1b0d1f996b194d72603399f89904d1889c999099f91945"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary

Updates `Casks/openoats.rb` to match the v1.33.1 release:
- Version: 1.33.0 → 1.33.1
- SHA256 updated to match the new DMG

Automated branch created by the release workflow.