### PR TITLE
Update Homebrew cask for 1.34.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.33.1"
-  sha256 "ff2013927d1c66b85d1b0d1f996b194d72603399f89904d1889c999099f91945"
+  version "1.34.0"
+  sha256 "4f58f25697ddbaf672916b9a1d499716cc90b9b74a86597e04b1cc6880adff8d"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Bumps Homebrew cask version from 1.33.1 to 1.34.0
- Updates SHA256 hash for the new DMG

Automated cask update following the v1.34.0 release.