### PR TITLE
[codex] Fix FluidAudio Swift 6.2 build

### DIFF
--- a/OpenOats/Package.resolved
+++ b/OpenOats/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9f4c93cd5ee212d4911133479b18eac8606bf1e7ce1f2c2da04a1fe23783d327",
+  "originHash" : "6ffc818420221776cc3a99c386333b6e123a919f3f197f136988f4bfea55aaf6",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "2d2979486bd7125558fe783741ef9a2757b3c1bb",
-        "version" : "0.12.5"
+        "revision" : "aa800cb9630dc14727507ac0c955fa4d7ca415ec",
+        "version" : "0.12.6"
       }
     },
     {

--- a/OpenOats/Package.swift
+++ b/OpenOats/Package.swift
@@ -20,10 +20,13 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", from: "0.12.5"),
+        .package(
+            url: "https://github.com/FluidInference/FluidAudio.git",
+            .upToNextMinor(from: "0.12.6")
+        ),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
         // Fork with relaxed swift-transformers constraint (from: "1.1.6" instead of upToNextMinor)
-        // to allow coexistence with FluidAudio 0.12.5 which requires swift-transformers >= 1.2.0.
+        // to allow coexistence with FluidAudio 0.12.6 which requires swift-transformers >= 1.2.0.
         // TODO: Switch back to argmaxinc/WhisperKit once upstream relaxes the constraint.
         .package(url: "https://github.com/yazins-ai/WhisperKit.git", branch: "fix/swift-transformers-compat"),
         .package(url: "https://github.com/sindresorhus/LaunchAtLogin-Modern", from: "1.1.0"),


### PR DESCRIPTION
## What changed
- bump FluidAudio from 0.12.5 to 0.12.6
- tighten the package requirement to the 0.12.x line to avoid pulling a broader 0.x upgrade
- refresh Package.resolved to the upstream concurrency-fix release

## Why
FluidAudio 0.12.5 fails to compile under Swift 6.2 because its streaming ASR code triggers strict concurrency data-race diagnostics. Upstream fixed that in 0.12.6, so OpenOats should consume the fixed release instead of carrying a local patch.

## Validation
- swift build
- ./scripts/build_swift_app.sh