### PR TITLE
Add Settings links to menu bar and main window

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.34.1"
-  sha256 "92d7116f05efe64a52dfaabf9874abc5d335c505874b0ec56083bfe8d4263734"
+  version "1.34.2"
+  sha256 ""
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -59,6 +59,16 @@ struct ContentView: View {
                 .foregroundStyle(.secondary)
                 .help("View past meeting notes")
                 .accessibilityIdentifier("app.pastMeetingsButton")
+
+                SettingsLink {
+                    Image(systemName: "gearshape")
+                        .font(.system(size: 12))
+                        .padding(4)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help("Settings")
+                .accessibilityIdentifier("app.settingsButton")
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 10)

--- a/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
+++ b/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
@@ -52,6 +52,18 @@ struct MenuBarPopoverView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
 
+            Button(action: {
+                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            }) {
+                HStack {
+                    Text("Settings…")
+                    Spacer()
+                }
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+
             Divider()
 
             Button(action: onQuit) {


### PR DESCRIPTION
## Summary
- Adds "Settings…" menu item to the menu bar dropdown (between Check for Updates and Quit)
- Adds a gear icon next to "Past Meetings" in the main window header

## Test plan
- [ ] Open menu bar dropdown → verify "Settings…" item appears and opens Settings window
- [ ] Check main window header → verify gear icon appears next to "Past Meetings" and opens Settings