### PR TITLE
fix: restore Homebrew cask to v1.34.1

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.34.2"
-  sha256 ""
+  version "1.34.1"
+  sha256 "92d7116f05efe64a52dfaabf9874abc5d335c505874b0ec56083bfe8d4263734"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary

- Restores `Casks/openoats.rb` to version 1.34.1 with the correct sha256
- PR #214 accidentally bumped the cask to v1.34.2 (which doesn't exist) with an empty sha256 as part of an in-flight cask update attempt

## Labels

kind:housekeeping, risk:low, release:none