### PR TITLE
feat: list available Ollama models in settings

### DIFF
--- a/OpenOats/Sources/OpenOats/Intelligence/OllamaModelFetcher.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/OllamaModelFetcher.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Fetches the list of locally available models from an Ollama instance.
+enum OllamaModelFetcher {
+    struct ModelInfo: Decodable {
+        let name: String
+    }
+
+    private struct TagsResponse: Decodable {
+        let models: [ModelInfo]
+    }
+
+    /// Returns model names sorted alphabetically, or an empty array on failure.
+    static func fetchModels(baseURL: String) async -> [String] {
+        let trimmed = baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/ "))
+        guard !trimmed.isEmpty,
+              let url = URL(string: trimmed + "/api/tags") else {
+            return []
+        }
+
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 5
+
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              let http = response as? HTTPURLResponse,
+              (200...299).contains(http.statusCode) else {
+            return []
+        }
+
+        guard let decoded = try? JSONDecoder().decode(TagsResponse.self, from: data) else {
+            return []
+        }
+
+        return decoded.models.map(\.name).sorted()
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/OllamaModelField.swift
+++ b/OpenOats/Sources/OpenOats/Views/OllamaModelField.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+/// A text field with a dropdown button that lists models available on the configured Ollama instance.
+struct OllamaModelField: View {
+    @Binding var modelName: String
+    let baseURL: String
+    let placeholder: String
+
+    @State private var availableModels: [String] = []
+    @State private var isLoading = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            TextField("Model", text: $modelName, prompt: Text(placeholder))
+                .font(.system(size: 12, design: .monospaced))
+
+            if isLoading {
+                ProgressView()
+                    .controlSize(.small)
+                    .frame(width: 16, height: 16)
+            } else {
+                Menu {
+                    if availableModels.isEmpty {
+                        Button("No models found") {}
+                            .disabled(true)
+                    } else {
+                        ForEach(availableModels, id: \.self) { model in
+                            Button(model) {
+                                modelName = model
+                            }
+                        }
+                    }
+                    Divider()
+                    Button("Refresh") {
+                        Task { await fetchModels() }
+                    }
+                } label: {
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 10))
+                        .frame(width: 16, height: 16)
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+            }
+        }
+        .task(id: baseURL) {
+            await fetchModels()
+        }
+    }
+
+    private func fetchModels() async {
+        guard !baseURL.trimmingCharacters(in: .whitespaces).isEmpty else {
+            availableModels = []
+            return
+        }
+        isLoading = true
+        availableModels = await OllamaModelFetcher.fetchModels(baseURL: baseURL)
+        isLoading = false
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -402,8 +402,7 @@ private struct IntelligenceSettingsTab: View {
                         TextField("Ollama URL", text: $settings.ollamaBaseURL, prompt: Text("http://localhost:11434"))
                             .font(.system(size: 12, design: .monospaced))
 
-                        TextField("Model", text: $settings.ollamaLLMModel, prompt: Text("e.g. qwen3:8b"))
-                            .font(.system(size: 12, design: .monospaced))
+                        OllamaModelField(modelName: $settings.ollamaLLMModel, baseURL: settings.ollamaBaseURL, placeholder: "e.g. qwen3:8b")
                     case .mlx:
                         TextField("MLX Server URL", text: $settings.mlxBaseURL, prompt: Text("http://localhost:8080"))
                             .font(.system(size: 12, design: .monospaced))
@@ -435,8 +434,7 @@ private struct IntelligenceSettingsTab: View {
                         SecureField("API Key", text: $settings.voyageApiKey)
                             .font(.system(size: 12, design: .monospaced))
                     case .ollama:
-                        TextField("Embedding Model", text: $settings.ollamaEmbedModel, prompt: Text("e.g. nomic-embed-text"))
-                            .font(.system(size: 12, design: .monospaced))
+                        OllamaModelField(modelName: $settings.ollamaEmbedModel, baseURL: settings.ollamaBaseURL, placeholder: "e.g. nomic-embed-text")
 
                         if settings.llmProvider != .ollama && settings.llmProvider != .mlx {
                             TextField("Ollama URL", text: $settings.ollamaBaseURL, prompt: Text("http://localhost:11434"))
@@ -469,8 +467,7 @@ private struct IntelligenceSettingsTab: View {
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)
                     case .ollama:
-                        TextField("Speed Model", text: $settings.realtimeOllamaModel, prompt: Text("Leave empty to use main model"))
-                            .font(.system(size: 12, design: .monospaced))
+                        OllamaModelField(modelName: $settings.realtimeOllamaModel, baseURL: settings.ollamaBaseURL, placeholder: "Leave empty to use main model")
                         Text("Optional Ollama model for real-time suggestions. Uses your main model if empty.")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)


### PR DESCRIPTION
Closes #221

## Summary

When the LLM or embedding provider is set to Ollama, model name fields now include a dropdown button that fetches available models from the configured Ollama instance via `/api/tags`. Users can still type a model name manually for full flexibility.

**Changes:**
- **`OllamaModelFetcher.swift`** — calls Ollama's `/api/tags` endpoint and returns sorted model names (5s timeout, graceful failure)
- **`OllamaModelField.swift`** — reusable SwiftUI view combining a text field with a dropdown menu of discovered models, plus a manual refresh option
- **`SettingsView.swift`** — replaced three Ollama model TextFields (LLM model, embedding model, speed model) with the new `OllamaModelField`

The model list refreshes automatically when the Ollama URL changes. If the Ollama instance is unreachable, the field degrades gracefully to a plain text input.

## Test plan

- [ ] Set LLM provider to Ollama with a running local instance — verify dropdown shows available models
- [ ] Select a model from the dropdown — verify it populates the text field
- [ ] Change the Ollama URL — verify the model list refreshes
- [ ] Set an invalid/unreachable URL — verify the dropdown shows "No models found" without errors
- [ ] Verify embedding model and speed model fields also show the dropdown
- [ ] Type a custom model name manually — verify it still works