### PR TITLE
feat: show download speed, size, and ETA during model downloads

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -22,6 +22,7 @@ struct LiveSessionState {
     var errorMessage: String? = nil
     var needsDownload: Bool = false
     var downloadProgress: Double? = nil
+    var downloadDetail: DownloadProgressDetail? = nil
     var transcriptionPrompt: String = ""
     var modelDisplayName: String = ""
     var showLiveTranscript: Bool = true
@@ -481,6 +482,7 @@ final class LiveSessionController {
         next.errorMessage = coordinator.transcriptionEngine?.lastError
         next.needsDownload = coordinator.transcriptionEngine?.needsModelDownload ?? false
         next.downloadProgress = coordinator.transcriptionEngine?.downloadProgress
+        next.downloadDetail = coordinator.transcriptionEngine?.downloadDetail
         next.transcriptionPrompt = settings.transcriptionModel.downloadPrompt
         next.modelDisplayName = activeModelRaw.split(separator: "/").last.map(String.init) ?? activeModelRaw
         next.showLiveTranscript = settings.showLiveTranscript

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -117,6 +117,17 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         }
     }
 
+    /// Approximate total download size in bytes, used for progress display.
+    /// Returns nil when the size is unknown.
+    var estimatedDownloadBytes: Int64? {
+        switch self {
+        case .whisperBase: 142_000_000
+        case .whisperSmall: 244_000_000
+        case .whisperLargeV3Turbo: 800_000_000
+        case .parakeetV2, .parakeetV3, .qwen3ASR06B: nil
+        }
+    }
+
     var supportsExplicitLanguageHint: Bool {
         true
     }

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -28,6 +28,17 @@ enum TranscriptionEngineError: LocalizedError {
     }
 }
 
+/// Enriched download progress info computed from fraction changes over time.
+struct DownloadProgressDetail: Sendable {
+    let fraction: Double
+    /// Formatted string like "142 MB / 800 MB"
+    let sizeText: String?
+    /// Formatted string like "3.5 MB/s"
+    let speedText: String?
+    /// Formatted string like "2m 15s remaining"
+    let etaText: String?
+}
+
 /// Orchestrates dual StreamingTranscriber instances for mic (you) and system audio (them).
 @Observable
 @MainActor
@@ -82,6 +93,16 @@ final class TranscriptionEngine {
         get { access(keyPath: \.downloadProgress); return _downloadProgress }
         set { withMutation(keyPath: \.downloadProgress) { _downloadProgress = newValue } }
     }
+
+    @ObservationIgnored nonisolated(unsafe) private var _downloadDetail: DownloadProgressDetail?
+    var downloadDetail: DownloadProgressDetail? {
+        get { access(keyPath: \.downloadDetail); return _downloadDetail }
+        set { withMutation(keyPath: \.downloadDetail) { _downloadDetail = newValue } }
+    }
+
+    // Progress tracking state (not observed)
+    @ObservationIgnored private var downloadStartTime: Date?
+    @ObservationIgnored private var downloadTotalBytes: Int64?
 
     private let systemCapture = SystemAudioCapture()
     private let micCapture = MicCapture()
@@ -205,7 +226,12 @@ final class TranscriptionEngine {
         assetStatus = isDownloading
             ? "Downloading \(transcriptionModel.displayName)..."
             : "Loading \(transcriptionModel.displayName)..."
-        if isDownloading { downloadProgress = 0 }
+        if isDownloading {
+            downloadProgress = 0
+            downloadStartTime = Date()
+            downloadTotalBytes = transcriptionModel.estimatedDownloadBytes
+            downloadDetail = DownloadProgressDetail(fraction: 0, sizeText: nil, speedText: nil, etaText: nil)
+        }
         diagLog("[ENGINE-1] loading transcription model \(transcriptionModel.rawValue)...")
         do {
             let vocab = settings.transcriptionCustomVocabulary
@@ -219,6 +245,7 @@ final class TranscriptionEngine {
                 onProgress: { [weak self] fraction in
                     Task { @MainActor in
                         self?.downloadProgress = fraction
+                        self?.updateDownloadDetail(fraction: fraction)
                     }
                 }
             )
@@ -255,6 +282,9 @@ final class TranscriptionEngine {
             needsModelDownload = false
             downloadConfirmed = false
             downloadProgress = nil
+            downloadDetail = nil
+            downloadStartTime = nil
+            downloadTotalBytes = nil
             assetStatus = "Models ready"
             diagLog("[ENGINE-2] transcription model loaded")
         } catch {
@@ -264,6 +294,9 @@ final class TranscriptionEngine {
             assetStatus = "Ready"
             isRunning = false
             downloadProgress = nil
+            downloadDetail = nil
+            downloadStartTime = nil
+            downloadTotalBytes = nil
             // Clear corrupt cache so the next attempt triggers a fresh download
             settings.transcriptionModel.makeBackend().clearModelCache()
             diagLog("[ENGINE-2-FAIL] cleared model cache for \(settings.transcriptionModel.rawValue)")
@@ -855,5 +888,73 @@ final class TranscriptionEngine {
             lastError.localizedCaseInsensitiveContains("audio output device") {
             self.lastError = nil
         }
+    }
+
+    // MARK: - Download Progress Detail
+
+    private func updateDownloadDetail(fraction: Double) {
+        guard let startTime = downloadStartTime else {
+            downloadDetail = DownloadProgressDetail(fraction: fraction, sizeText: nil, speedText: nil, etaText: nil)
+            return
+        }
+
+        let elapsed = Date().timeIntervalSince(startTime)
+        let totalBytes = downloadTotalBytes
+
+        // Size text: "142 MB / 800 MB" (only when total is known)
+        var sizeText: String?
+        if let totalBytes {
+            let downloaded = Int64(fraction * Double(totalBytes))
+            sizeText = "\(Self.formatBytes(downloaded)) / \(Self.formatBytes(totalBytes))"
+        }
+
+        // Speed and ETA need enough elapsed time to be meaningful
+        var speedText: String?
+        var etaText: String?
+        if elapsed > 1, fraction > 0.01 {
+            // Speed from fraction progress rate + known total
+            if let totalBytes {
+                let bytesDownloaded = fraction * Double(totalBytes)
+                let bytesPerSecond = bytesDownloaded / elapsed
+                speedText = "\(Self.formatBytes(Int64(bytesPerSecond)))/s"
+
+                let remaining = Double(totalBytes) - bytesDownloaded
+                if bytesPerSecond > 0 {
+                    let secondsLeft = remaining / bytesPerSecond
+                    etaText = Self.formatDuration(secondsLeft)
+                }
+            } else {
+                // No total bytes known — estimate ETA from fraction rate alone
+                let fractionPerSecond = fraction / elapsed
+                if fractionPerSecond > 0 {
+                    let remainingFraction = 1.0 - fraction
+                    let secondsLeft = remainingFraction / fractionPerSecond
+                    etaText = Self.formatDuration(secondsLeft)
+                }
+            }
+        }
+
+        downloadDetail = DownloadProgressDetail(
+            fraction: fraction,
+            sizeText: sizeText,
+            speedText: speedText,
+            etaText: etaText
+        )
+    }
+
+    private static func formatBytes(_ bytes: Int64) -> String {
+        if bytes >= 1_000_000_000 {
+            return String(format: "%.1f GB", Double(bytes) / 1_000_000_000)
+        } else {
+            return String(format: "%.0f MB", Double(bytes) / 1_000_000)
+        }
+    }
+
+    private static func formatDuration(_ seconds: Double) -> String {
+        let s = Int(seconds)
+        if s < 60 { return "\(s)s remaining" }
+        let m = s / 60
+        let rem = s % 60
+        return rem > 0 ? "\(m)m \(rem)s remaining" : "\(m)m remaining"
     }
 }

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -253,6 +253,7 @@ struct ContentView: View {
                 errorMessage: controllerState.errorMessage,
                 needsDownload: controllerState.needsDownload,
                 downloadProgress: controllerState.downloadProgress,
+                downloadDetail: controllerState.downloadDetail,
                 onToggle: {
                     pendingControlBarAction = .toggle
                 },

--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -10,6 +10,7 @@ struct ControlBar: View {
     let errorMessage: String?
     let needsDownload: Bool
     let downloadProgress: Double?
+    let downloadDetail: DownloadProgressDetail?
     let onToggle: () -> Void
     let onMuteToggle: () -> Void
     let onConfirmDownload: () -> Void
@@ -61,6 +62,23 @@ struct ControlBar: View {
                         ProgressView(value: progress)
                             .progressViewStyle(.linear)
                             .accessibilityIdentifier("app.controlBar.downloadProgress")
+
+                        if let detail = downloadDetail {
+                            HStack(spacing: 8) {
+                                if let sizeText = detail.sizeText {
+                                    Text(sizeText)
+                                }
+                                if let speedText = detail.speedText {
+                                    Text(speedText)
+                                }
+                                if let etaText = detail.etaText {
+                                    Spacer()
+                                    Text(etaText)
+                                }
+                            }
+                            .font(.system(size: 10))
+                            .foregroundStyle(.tertiary)
+                        }
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
Closes #222

## Summary

Enhances the existing download progress bar to show richer information during model downloads:
- **Size**: Total size and amount downloaded (e.g., "142 MB / 800 MB") — shown for Whisper models with known sizes
- **Speed**: Current download speed (e.g., "3.5 MB/s") — computed from bytes downloaded over elapsed time
- **ETA**: Estimated time remaining (e.g., "2m 15s remaining") — computed from progress rate for all models

The detail line appears below the existing progress bar and degrades gracefully: when total size is unknown (Parakeet, Qwen3), only ETA is shown based on the fraction-complete rate.

**Changes:**
- **`SettingsTypes.swift`** — added `estimatedDownloadBytes` property to `TranscriptionModel`
- **`TranscriptionEngine.swift`** — added `DownloadProgressDetail` struct and progress tracking logic that computes speed/ETA from fraction changes over time
- **`LiveSessionController.swift`** — passes `downloadDetail` through to the UI state
- **`ControlBar.swift`** — displays the detail line (size, speed, ETA) below the progress bar
- **`ContentView.swift`** — passes the new `downloadDetail` parameter

## Test plan

- [ ] Download a Whisper model — verify size, speed, and ETA are shown below the progress bar
- [ ] Download a Parakeet/Qwen3 model — verify ETA appears but size/speed are gracefully omitted
- [ ] Verify the detail line disappears when download completes
- [ ] Verify the progress bar still works correctly for non-download loading states