### PR TITLE
chore: update FluidAudio to 0.13.4, switch to upstream WhisperKit

### DIFF
--- a/OpenOats/Package.resolved
+++ b/OpenOats/Package.resolved
@@ -1,22 +1,13 @@
 {
-  "originHash" : "6ffc818420221776cc3a99c386333b6e123a919f3f197f136988f4bfea55aaf6",
+  "originHash" : "9df271457e29cab8b6649c2f578ceb155216c310a2fc7ed80367851407a822a2",
   "pins" : [
-    {
-      "identity" : "eventsource",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/mattt/EventSource.git",
-      "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
-      }
-    },
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "aa800cb9630dc14727507ac0c955fa4d7ca415ec",
-        "version" : "0.12.6"
+        "revision" : "d9eef864d29783fc22754b12090631da5388c3a9",
+        "version" : "0.13.4"
       }
     },
     {
@@ -56,15 +47,6 @@
       }
     },
     {
-      "identity" : "swift-atomics",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-atomics.git",
-      "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
-      }
-    },
-    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -83,15 +65,6 @@
       }
     },
     {
-      "identity" : "swift-huggingface",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-huggingface.git",
-      "state" : {
-        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
-        "version" : "0.9.0"
-      }
-    },
-    {
       "identity" : "swift-jinja",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
@@ -101,39 +74,21 @@
       }
     },
     {
-      "identity" : "swift-nio",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio.git",
-      "state" : {
-        "revision" : "b31565862a8f39866af50bc6676160d8dda7de35",
-        "version" : "2.96.0"
-      }
-    },
-    {
-      "identity" : "swift-system",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-system.git",
-      "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
-      }
-    },
-    {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "eed7264ac5e4ec5dfa6165c6e5c5577364344fe4",
-        "version" : "1.2.0"
+        "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
+        "version" : "1.1.9"
       }
     },
     {
       "identity" : "whisperkit",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/yazins-ai/WhisperKit.git",
+      "location" : "https://github.com/argmaxinc/WhisperKit.git",
       "state" : {
-        "branch" : "fix/swift-transformers-compat",
-        "revision" : "219200b8d915c7a59f11c28fe1edd68cb1dcb9ae"
+        "revision" : "26577ce3017aae8c9edfd9a0dd17851bd248c731",
+        "version" : "0.17.0"
       }
     },
     {

--- a/OpenOats/Package.swift
+++ b/OpenOats/Package.swift
@@ -22,13 +22,10 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/FluidInference/FluidAudio.git",
-            .upToNextMinor(from: "0.12.6")
+            .upToNextMinor(from: "0.13.4")
         ),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.7.0"),
-        // Fork with relaxed swift-transformers constraint (from: "1.1.6" instead of upToNextMinor)
-        // to allow coexistence with FluidAudio 0.12.6 which requires swift-transformers >= 1.2.0.
-        // TODO: Switch back to argmaxinc/WhisperKit once upstream relaxes the constraint.
-        .package(url: "https://github.com/yazins-ai/WhisperKit.git", branch: "fix/swift-transformers-compat"),
+        .package(url: "https://github.com/argmaxinc/WhisperKit.git", from: "0.9.0"),
         .package(url: "https://github.com/sindresorhus/LaunchAtLogin-Modern", from: "1.1.0"),
     ],
     targets: [

--- a/OpenOats/Sources/OpenOats/Transcription/ParakeetBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/ParakeetBackend.swift
@@ -6,12 +6,10 @@ import Foundation
 final class ParakeetBackend: TranscriptionBackend, @unchecked Sendable {
     let displayName: String
     private let version: AsrModelVersion
-    private let customVocabularyText: String
     private var asrManager: AsrManager?
 
     init(version: AsrModelVersion, customVocabulary: String = "") {
         self.version = version
-        self.customVocabularyText = customVocabulary
         self.displayName = version == .v2 ? "Parakeet TDT v2" : "Parakeet TDT v3"
     }
 
@@ -36,26 +34,6 @@ final class ParakeetBackend: TranscriptionBackend, @unchecked Sendable {
         onStatus("Initializing \(displayName)...")
         let asr = AsrManager(config: .default)
         try await asr.initialize(models: models)
-
-        // Configure custom vocabulary boosting if provided
-        let vocab = customVocabularyText.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !vocab.isEmpty {
-            let tempURL = FileManager.default.temporaryDirectory
-                .appendingPathComponent("openoats-custom-vocabulary-\(UUID().uuidString).txt")
-            try vocab.write(to: tempURL, atomically: true, encoding: .utf8)
-            defer { try? FileManager.default.removeItem(at: tempURL) }
-
-            let (customVocabulary, ctcModels) = try await CustomVocabularyContext.loadWithCtcTokens(
-                from: tempURL.path
-            )
-            if !customVocabulary.terms.isEmpty {
-                try await asr.configureVocabularyBoosting(
-                    vocabulary: customVocabulary,
-                    ctcModels: ctcModels
-                )
-            }
-        }
-
         self.asrManager = asr
     }
 


### PR DESCRIPTION
## Summary

- Updates FluidAudio from 0.12.6 to 0.13.4 (swift-transformers dependency removed upstream)
- Switches WhisperKit from `yazins-ai/WhisperKit` fork (`fix/swift-transformers-compat` branch) back to upstream `argmaxinc/WhisperKit` 0.17.0
- Removes vocabulary boosting from `ParakeetBackend` — FluidAudio 0.13.4 moved this API to `SlidingWindowAsrManager`; the batch `AsrManager` no longer supports it

**Note:** Custom vocabulary is still accepted as a parameter but is currently a no-op for Parakeet backends. This can be revisited if OpenOats adopts `SlidingWindowAsrManager` in the future.

Closes #226

## Test plan

- [x] `swift package resolve` succeeds with no version conflicts
- [x] `swift build` compiles with no errors
- [x] All 299 tests pass