### PR TITLE
feat: mini bar waveform reacts to both mic and system audio

### DIFF
--- a/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
@@ -1,4 +1,5 @@
 @preconcurrency import AVFoundation
+import Accelerate
 import AudioToolbox
 import CoreAudio
 import Dispatch
@@ -7,6 +8,11 @@ import os
 
 /// Captures system output audio via a Core Audio process tap.
 final class SystemAudioCapture: @unchecked Sendable {
+    private let _audioLevel = AudioLevel()
+
+    /// Thread-safe audio level (0…1) from the system audio stream.
+    var audioLevel: Float { _audioLevel.value }
+
     private let _aggregateDeviceID = OSAllocatedUnfairLock<AudioObjectID>(
         uncheckedState: AudioObjectID(kAudioObjectUnknown)
     )
@@ -140,6 +146,7 @@ final class SystemAudioCapture: @unchecked Sendable {
 
     func stop() async {
         finishStream()
+        _audioLevel.value = 0
 
         let aggregateDeviceID = _aggregateDeviceID.withLock { state -> AudioObjectID in
             let current = state
@@ -210,6 +217,13 @@ final class SystemAudioCapture: @unchecked Sendable {
 
             memcpy(destinationData, sourceData, copySize)
             destinationBuffers[index].mDataByteSize = UInt32(copySize)
+        }
+
+        // Compute RMS audio level for the UI visualisation.
+        if let channelData = pcmBuffer.floatChannelData, pcmBuffer.frameLength > 0 {
+            var rms: Float = 0
+            vDSP_rmsqv(channelData[0], 1, &rms, vDSP_Length(pcmBuffer.frameLength))
+            _audioLevel.value = min(rms * 25, 1.0)
         }
 
         _ = _sysContinuation.withLock { $0?.yield(pcmBuffer) }

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -110,12 +110,12 @@ final class TranscriptionEngine {
     private let settings: AppSettings
     private let mode: Mode
 
-    /// Audio level from mic for the UI meter.
-    /// nonisolated is safe here — micCapture.audioLevel is thread-safe (NSLock).
+    /// Combined audio level (mic + system) for the UI meter.
+    /// nonisolated is safe here — both audioLevel properties are thread-safe (NSLock).
     nonisolated var audioLevel: Float {
         switch mode {
         case .live:
-            micCapture.audioLevel
+            max(micCapture.audioLevel, systemCapture.audioLevel)
         case .scripted:
             _isRunning ? 0.35 : 0
         }


### PR DESCRIPTION
## Summary
- Added audio level tracking to `SystemAudioCapture` (RMS computation in the IO callback)
- Changed `TranscriptionEngine.audioLevel` to return `max(mic, system)` so the mini bar waveform reacts to whichever source is louder

## Test plan
- [ ] Start a meeting with another person speaking
- [ ] Verify the mini bar waveform animates when the other person talks
- [ ] Verify it still animates when you talk