### PR TITLE
Update Homebrew cask for 1.37.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.36.0"
-  sha256 "2e5e23154e1de7fbdc87bddaf61618df1a7256a081a76d337993e67e54c96ca0"
+  version "1.37.0"
+  sha256 "3ddd06bb143940e562270515fc2cb503066b41a28e87bb8fd10807023b44f47c"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Update `Casks/openoats.rb` version from 1.36.0 to 1.37.0
- Update SHA256 to match the v1.37.0 release DMG

Automated cask update from the release workflow.