### PR TITLE
fix: replace "listening" copy with non-surveillance language

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
+++ b/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
@@ -108,7 +108,7 @@ struct MenuBarPopoverView: View {
                 Circle()
                     .fill(.secondary)
                     .frame(width: 8, height: 8)
-                Text("Listening for meetings...")
+                Text("Meeting detection on")
                     .font(.system(size: 13))
                     .foregroundStyle(.secondary)
             } else {

--- a/OpenOats/Sources/OpenOats/Views/OnboardingView.swift
+++ b/OpenOats/Sources/OpenOats/Views/OnboardingView.swift
@@ -8,7 +8,7 @@ struct OnboardingView: View {
         (
             "waveform.circle",
             "Welcome to OpenOats",
-            "A real-time meeting copilot that listens to your conversations and generates smart talking points — all running locally on your Mac."
+            "A real-time meeting copilot that detects your meetings, transcribes conversations, and generates smart talking points — all running locally on your Mac."
         ),
         (
             "text.quote",

--- a/OpenOats/Sources/OpenOats/Views/SidecastPanelContent.swift
+++ b/OpenOats/Sources/OpenOats/Views/SidecastPanelContent.swift
@@ -160,7 +160,7 @@ private struct SidecastPersonaCard: View {
                         }
                     }
                 } else {
-                    Text("Listening…")
+                    Text("Processing…")
                         .font(.system(size: 12))
                         .foregroundStyle(.white.opacity(0.25))
                         .italic()

--- a/OpenOats/Sources/OpenOats/Views/SuggestionPanelContent.swift
+++ b/OpenOats/Sources/OpenOats/Views/SuggestionPanelContent.swift
@@ -54,7 +54,7 @@ struct SuggestionPanelContent: View {
 
     private var idleView: some View {
         VStack(spacing: 6) {
-            Text("Listening...")
+            Text("Processing...")
                 .font(.system(size: 12))
                 .foregroundStyle(.tertiary)
         }


### PR DESCRIPTION
## Summary
- Replace all "Listening" UI copy that carries surveillance connotations
- The app monitors mic activation status to detect meetings — it doesn't listen
- "Listening for meetings..." → "Meeting detection on" (menu bar)
- "Listening..." → "Processing..." (suggestion panel, sidecast cards)
- Onboarding reworded from "listens to your conversations" to "detects your meetings, transcribes conversations"

## Test plan
- [ ] Verify menu bar popover shows "Meeting detection on" when auto-detect is enabled
- [ ] Verify suggestion panel idle state shows "Processing..."
- [ ] Verify sidecast persona cards show "Processing…" before generating output
- [ ] Verify onboarding welcome text reads correctly