### PR TITLE
fix: stabilize transcription session state and diarization fallback

### DIFF
--- a/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
@@ -29,6 +29,8 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     private static let notMeetingAction = "NOT_A_MEETING"
     private static let ignoreAppAction = "IGNORE_APP"
     private static let dismissAction = "DISMISS"
+    static let batchCompletedTitle = "Re-transcription Complete"
+    static let batchCompletedBody = "Re-transcription is complete. Your meeting transcript has been updated with higher-quality text."
 
     override init() {
         super.init()
@@ -144,8 +146,8 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         guard await ensurePermission() else { return }
 
         let content = UNMutableNotificationContent()
-        content.title = "Re-transcription Complete"
-        content.body = "Batch transcription is complete. Your meeting transcript has been updated with higher-quality text."
+        content.title = Self.batchCompletedTitle
+        content.body = Self.batchCompletedBody
         content.sound = .default
 
         let request = UNNotificationRequest(

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -9,6 +9,8 @@ import Security
 final class SettingsStore {
     private let defaults: UserDefaults
     private let secretStore: AppSecretStore
+    private static let enableLiveTranscriptCleanupLegacyKey = "enableTranscriptRefinement"
+    private static let enableBatchRetranscriptionLegacyKey = "enableBatchRefinement"
 
     // MARK: - AI Settings
 
@@ -206,6 +208,7 @@ final class SettingsStore {
             withMutation(keyPath: \.enableLiveTranscriptCleanup) {
                 _enableLiveTranscriptCleanup = newValue
                 defaults.set(newValue, forKey: "enableLiveTranscriptCleanup")
+                defaults.set(newValue, forKey: Self.enableLiveTranscriptCleanupLegacyKey)
             }
         }
     }
@@ -373,6 +376,7 @@ final class SettingsStore {
             withMutation(keyPath: \.enableBatchRetranscription) {
                 _enableBatchRetranscription = newValue
                 defaults.set(newValue, forKey: "enableBatchRetranscription")
+                defaults.set(newValue, forKey: Self.enableBatchRetranscriptionLegacyKey)
             }
         }
     }
@@ -614,11 +618,11 @@ final class SettingsStore {
 
         // Migrate renamed settings keys (old -> new)
         if defaults.object(forKey: "enableLiveTranscriptCleanup") == nil,
-           let oldValue = defaults.object(forKey: "enableTranscriptRefinement") {
+           let oldValue = defaults.object(forKey: Self.enableLiveTranscriptCleanupLegacyKey) {
             defaults.set(oldValue, forKey: "enableLiveTranscriptCleanup")
         }
         if defaults.object(forKey: "enableBatchRetranscription") == nil,
-           let oldValue = defaults.object(forKey: "enableBatchRefinement") {
+           let oldValue = defaults.object(forKey: Self.enableBatchRetranscriptionLegacyKey) {
             defaults.set(oldValue, forKey: "enableBatchRetranscription")
         }
 

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -4,17 +4,6 @@ import FluidAudio
 import Observation
 import os
 
-enum TranscriptionEngineError: LocalizedError {
-    case transcriberNotInitialized
-
-    var errorDescription: String? {
-        switch self {
-        case .transcriberNotInitialized:
-            "Transcription engine is not initialized. Please check your audio settings."
-        }
-    }
-}
-
 /// Enriched download progress info computed from fraction changes over time.
 struct DownloadProgressDetail: Sendable {
     let fraction: Double
@@ -24,6 +13,41 @@ struct DownloadProgressDetail: Sendable {
     let speedText: String?
     /// Formatted string like "2m 15s remaining"
     let etaText: String?
+}
+
+/// Session-scoped transcription settings captured at start time.
+struct ActiveTranscriptionSession: Sendable, Equatable {
+    let transcriptionModel: TranscriptionModel
+
+    var flushIntervalSamples: Int {
+        transcriptionModel.flushIntervalSamples
+    }
+
+    func clearModelCache(
+        using makeBackend: (TranscriptionModel) -> any TranscriptionBackend = { $0.makeBackend() }
+    ) {
+        makeBackend(transcriptionModel).clearModelCache()
+    }
+}
+
+/// Stops forwarding diarization samples after the first feed failure.
+struct DiarizationFeedRelay: Sendable {
+    private(set) var hasFailed = false
+
+    mutating func feedAudio(
+        _ samples: [Float],
+        into feedAudio: @Sendable ([Float]) async throws -> Void,
+        onFailure: @Sendable (Error) async -> Void
+    ) async {
+        guard !hasFailed else { return }
+
+        do {
+            try await feedAudio(samples)
+        } catch {
+            hasFailed = true
+            await onFailure(error)
+        }
+    }
 }
 
 /// Orchestrates dual StreamingTranscriber instances for mic (you) and system audio (them).
@@ -134,6 +158,9 @@ final class TranscriptionEngine {
     /// Speaker diarization manager for system audio (nil when diarization is disabled).
     private var diarizationManager: DiarizationManager?
 
+    /// Active transcription model captured for the current session/startup.
+    @ObservationIgnored nonisolated(unsafe) var activeTranscriptionSession: ActiveTranscriptionSession?
+
     /// Tracks the resolved mic device ID currently in use.
     private var currentMicDeviceID: AudioDeviceID = 0
 
@@ -204,7 +231,14 @@ final class TranscriptionEngine {
             return
         }
 
-        guard await ensureMicrophonePermission() else { return }
+        activeTranscriptionSession = ActiveTranscriptionSession(
+            transcriptionModel: transcriptionModel
+        )
+
+        guard await ensureMicrophonePermission() else {
+            activeTranscriptionSession = nil
+            return
+        }
 
         isRunning = true
 
@@ -276,7 +310,7 @@ final class TranscriptionEngine {
             Log.transcription.info("Transcription model loaded")
         } catch {
             let msg = "Failed to load models: \(error.localizedDescription)"
-            Log.transcription.error("Failed to load models: \(msg, privacy: .public)")
+            Log.transcription.error("Failed to load models: \(error, privacy: .public)")
             lastError = msg
             assetStatus = "Ready"
             isRunning = false
@@ -285,14 +319,20 @@ final class TranscriptionEngine {
             downloadStartTime = nil
             downloadTotalBytes = nil
             // Clear corrupt cache so the next attempt triggers a fresh download
-            settings.transcriptionModel.makeBackend().clearModelCache()
-            Log.transcription.info("Cleared model cache for \(self.settings.transcriptionModel.rawValue, privacy: .public)")
+            activeTranscriptionSession?.clearModelCache()
+            Log.transcription.info(
+                "Cleared model cache for \(transcriptionModel.rawValue, privacy: .public)"
+            )
             needsModelDownload = true
             downloadConfirmed = false
+            activeTranscriptionSession = nil
             return
         }
 
-        guard let vadManager else { return }
+        guard let vadManager else {
+            activeTranscriptionSession = nil
+            return
+        }
 
         // 2. Start mic capture
         userSelectedDeviceID = inputDeviceID
@@ -302,6 +342,7 @@ final class TranscriptionEngine {
             lastError = msg
             assetStatus = "Ready"
             isRunning = false
+            activeTranscriptionSession = nil
             return
         }
         currentMicDeviceID = targetMicID
@@ -501,6 +542,7 @@ final class TranscriptionEngine {
             assetStatus = "Ready"
             transcriptStore.volatileYouText = ""
             transcriptStore.volatileThemText = ""
+            activeTranscriptionSession = nil
             return
         }
 
@@ -536,8 +578,10 @@ final class TranscriptionEngine {
 
         micBackend = nil
         systemBackend = nil
+        vadManager = nil
         transcriptStore.volatileYouText = ""
         transcriptStore.volatileThemText = ""
+        activeTranscriptionSession = nil
         isRunning = false
         assetStatus = "Ready"
     }
@@ -570,8 +614,10 @@ final class TranscriptionEngine {
         currentMicDeviceID = 0
         micBackend = nil
         systemBackend = nil
+        vadManager = nil
         transcriptStore.volatileYouText = ""
         transcriptStore.volatileThemText = ""
+        activeTranscriptionSession = nil
         isRunning = false
         assetStatus = "Ready"
     }
@@ -684,6 +730,7 @@ final class TranscriptionEngine {
             lastError = "Failed to create transcriber. Try restarting."
             isRunning = false
             assetStatus = "Ready"
+            activeTranscriptionSession = nil
             return
         }
         micTask = Task.detached {
@@ -704,7 +751,7 @@ final class TranscriptionEngine {
             clearSystemAudioErrorIfPresent()
         } catch {
             let msg = "Failed to start system audio: \(error.localizedDescription)"
-            Log.transcription.error("Failed to start system audio: \(msg, privacy: .public)")
+            Log.transcription.error("Failed to start system audio: \(error, privacy: .public)")
             lastError = msg
             return
         }
@@ -725,7 +772,8 @@ final class TranscriptionEngine {
             let originalSysStream = sysStream
             let (diarTapped, diarContinuation) = AsyncStream<AVAudioPCMBuffer>.makeStream()
             Task {
-                nonisolated(unsafe) let safeDm = dm
+                let safeDm = dm
+                var diarizationRelay = DiarizationFeedRelay()
                 var diarBuf: [Float] = []
                 for await buffer in originalSysStream {
                     nonisolated(unsafe) let b = buffer
@@ -737,12 +785,28 @@ final class TranscriptionEngine {
                     if diarBuf.count >= diarFlushSize {
                         let batch = diarBuf
                         diarBuf.removeAll(keepingCapacity: true)
-                        try? await safeDm.feedAudio(batch)
+                        await diarizationRelay.feedAudio(
+                            batch,
+                            into: { samples in try await safeDm.feedAudio(samples) },
+                            onFailure: { error in
+                                Log.transcription.error(
+                                    "Diarization feed failed: \(error, privacy: .public)"
+                                )
+                            }
+                        )
                     }
                 }
                 // Flush tail
                 if !diarBuf.isEmpty {
-                    try? await safeDm.feedAudio(diarBuf)
+                    await diarizationRelay.feedAudio(
+                        diarBuf,
+                        into: { samples in try await safeDm.feedAudio(samples) },
+                        onFailure: { error in
+                            Log.transcription.error(
+                                "Diarization feed failed: \(error, privacy: .public)"
+                            )
+                        }
+                    )
                 }
                 diarContinuation.finish()
             }
@@ -799,10 +863,14 @@ final class TranscriptionEngine {
             locale: locale,
             vadManager: vadManager,
             speaker: speaker,
-            flushInterval: settings.transcriptionModel.flushIntervalSamples,
+            flushInterval: currentTranscriptionModel().flushIntervalSamples,
             onPartial: onPartial,
             onFinal: onFinal
         )
+    }
+
+    func currentTranscriptionModel() -> TranscriptionModel {
+        activeTranscriptionSession?.transcriptionModel ?? settings.transcriptionModel
     }
 
     private func resolvedMicDeviceID(for inputDeviceID: AudioDeviceID) -> AudioDeviceID? {

--- a/OpenOats/Tests/OpenOatsTests/NotificationServiceTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotificationServiceTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import OpenOatsKit
+
+@MainActor
+final class NotificationServiceTests: XCTestCase {
+
+    func testBatchCompletedNotificationCopyUsesReTranscriptionWording() {
+        XCTAssertEqual(NotificationService.batchCompletedTitle, "Re-transcription Complete")
+        XCTAssertEqual(
+            NotificationService.batchCompletedBody,
+            "Re-transcription is complete. Your meeting transcript has been updated with higher-quality text."
+        )
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -135,6 +135,21 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(store.enableLiveTranscriptCleanup)
     }
 
+    func testEnableLiveTranscriptCleanupDualWritesLegacyKey() {
+        let suiteName = "com.openoats.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let store = makeStore(defaults: defaults)
+        store.enableLiveTranscriptCleanup = true
+
+        XCTAssertEqual(defaults.bool(forKey: "enableLiveTranscriptCleanup"), true)
+        XCTAssertEqual(defaults.bool(forKey: "enableTranscriptRefinement"), true)
+
+        let reopened = makeStore(defaults: defaults)
+        XCTAssertTrue(reopened.enableLiveTranscriptCleanup)
+    }
+
     // MARK: - Capture Settings Group
 
     func testDefaultInputDeviceID() {
@@ -173,6 +188,21 @@ final class SettingsStoreTests: XCTestCase {
         let store = makeStore()
         // Defaults to false when key never set
         XCTAssertFalse(store.enableBatchRetranscription)
+    }
+
+    func testEnableBatchRetranscriptionDualWritesLegacyKey() {
+        let suiteName = "com.openoats.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let store = makeStore(defaults: defaults)
+        store.enableBatchRetranscription = true
+
+        XCTAssertEqual(defaults.bool(forKey: "enableBatchRetranscription"), true)
+        XCTAssertEqual(defaults.bool(forKey: "enableBatchRefinement"), true)
+
+        let reopened = makeStore(defaults: defaults)
+        XCTAssertTrue(reopened.enableBatchRetranscription)
     }
 
     func testDefaultBatchTranscriptionModel() {

--- a/OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift
@@ -1,0 +1,154 @@
+import XCTest
+@testable import OpenOatsKit
+
+@MainActor
+final class TranscriptionEngineTests: XCTestCase {
+    // MARK: - Helpers
+
+    private func makeSettings() -> AppSettings {
+        let suiteName = "com.openoats.tests.transcription-engine.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        let storage = AppSettingsStorage(
+            defaults: defaults,
+            secretStore: .ephemeral,
+            defaultNotesDirectory: URL(fileURLWithPath: NSTemporaryDirectory()),
+            runMigrations: false
+        )
+        return AppSettings(storage: storage)
+    }
+
+    // MARK: - Active Session Model
+
+    func testActiveTranscriptionSessionCapturesModelForFlushAndCacheClearing() {
+        let session = ActiveTranscriptionSession(transcriptionModel: .whisperLargeV3Turbo)
+        XCTAssertEqual(
+            session.flushIntervalSamples,
+            TranscriptionModel.whisperLargeV3Turbo.flushIntervalSamples
+        )
+
+        let backend = CacheClearingBackend()
+        var capturedModel: TranscriptionModel?
+        session.clearModelCache(using: { model in
+            capturedModel = model
+            return backend
+        })
+
+        XCTAssertEqual(capturedModel, .whisperLargeV3Turbo)
+        XCTAssertEqual(backend.clearModelCacheCallCount, 1)
+    }
+
+    func testCurrentTranscriptionModelPrefersActiveSessionOverMutableSettings() {
+        let settings = makeSettings()
+        settings.transcriptionModel = .parakeetV2
+
+        let engine = TranscriptionEngine(
+            transcriptStore: TranscriptStore(),
+            settings: settings,
+            mode: .scripted([])
+        )
+        engine.activeTranscriptionSession = ActiveTranscriptionSession(
+            transcriptionModel: .whisperBase
+        )
+
+        settings.transcriptionModel = .qwen3ASR06B
+
+        XCTAssertEqual(engine.currentTranscriptionModel(), .whisperBase)
+    }
+
+    // MARK: - Diarization Feed Gate
+
+    func testDiarizationFeedRelayStopsAfterFirstFailure() async {
+        var relay = DiarizationFeedRelay()
+        let recorder = FeedRecorder(failOnCall: 2)
+        let errorRecorder = ErrorRecorder()
+
+        await relay.feedAudio(
+            [1.0, 2.0],
+            into: { samples in try await recorder.feed(samples) },
+            onFailure: { error in await errorRecorder.record(error) }
+        )
+        await relay.feedAudio(
+            [3.0, 4.0],
+            into: { samples in try await recorder.feed(samples) },
+            onFailure: { error in await errorRecorder.record(error) }
+        )
+        await relay.feedAudio(
+            [5.0, 6.0],
+            into: { samples in try await recorder.feed(samples) },
+            onFailure: { error in await errorRecorder.record(error) }
+        )
+
+        let recordedBatches = await recorder.snapshotBatches()
+        let failureCount = await errorRecorder.snapshotCount()
+
+        XCTAssertEqual(recordedBatches, [[1.0, 2.0], [3.0, 4.0]])
+        XCTAssertTrue(relay.hasFailed)
+        XCTAssertEqual(failureCount, 1)
+    }
+}
+
+// MARK: - Test Helpers
+
+private final class CacheClearingBackend: TranscriptionBackend, @unchecked Sendable {
+    let displayName = "Mock cache clearing backend"
+    private(set) var clearModelCacheCallCount = 0
+
+    func checkStatus() -> BackendStatus {
+        .ready
+    }
+
+    func prepare(
+        onStatus: @Sendable (String) -> Void,
+        onProgress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+    }
+
+    func transcribe(
+        _ samples: [Float],
+        locale: Locale,
+        previousContext: String?
+    ) async throws -> String {
+        ""
+    }
+
+    func clearModelCache() {
+        clearModelCacheCallCount += 1
+    }
+}
+
+private actor FeedRecorder {
+    private(set) var batches: [[Float]] = []
+    private let failOnCall: Int?
+    private var callCount = 0
+
+    init(failOnCall: Int?) {
+        self.failOnCall = failOnCall
+    }
+
+    func feed(_ batch: [Float]) throws {
+        callCount += 1
+        batches.append(batch)
+
+        if callCount == failOnCall {
+            struct RelayFailure: Error {}
+            throw RelayFailure()
+        }
+    }
+
+    func snapshotBatches() -> [[Float]] {
+        batches
+    }
+}
+
+private actor ErrorRecorder {
+    private(set) var count = 0
+
+    func record(_ error: Error) {
+        count += 1
+    }
+
+    func snapshotCount() -> Int {
+        count
+    }
+}


### PR DESCRIPTION
## Summary
This PR makes transcription sessions more predictable and easier to debug by fixing a set of subtle consistency problems in the active session lifecycle.

In practice, it does four things:
- keeps the requested transcription model stable for the lifetime of a session
- degrades gracefully when diarization feed calls fail instead of failing silently
- preserves renamed settings across downgrade scenarios
- aligns the batch-complete notification copy with the product's current "Re-transcription" terminology

## Why this matters
These issues are easy to miss because the app usually keeps running. The cost shows up later as confusing behavior:
- a session can start with one model selected but consult mutated settings later in the same run
- diarization can stop contributing speaker data without leaving a clear failure signal
- downgraded builds can appear to "forget" renamed settings because only the new keys were being written
- the notification copy drifts from the rest of the product language

That combination creates exactly the kind of bug report that is hard to reproduce and expensive to reason about: the system looks mostly healthy, but key parts of the session are no longer deterministic.

## What changed
- captured a session-scoped active transcription model at startup and used it for active-session decisions such as flush interval selection and prepare-failure cache clearing
- added a small diarization relay that logs the first feed failure, stops forwarding later diarization batches, and lets transcription continue
- dual-wrote the legacy `UserDefaults` keys for the renamed transcript cleanup and batch re-transcription settings so downgraded builds still read the current value
- centralized the batch-complete notification strings and updated the body copy to match the "Re-transcription" wording already used in the UI
- added regression tests for active-session model stability, diarization fallback behavior, legacy settings writes, and notification copy

## What did not change
- no new user-facing settings
- no new transcription or diarization features
- no broad architecture rewrite of the transcription engine
- this PR builds on the logging cleanup already merged in #235 and keeps scope to behavior fixes only

## How to review
- start with `OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift` for the session-scoped model capture and diarization fallback behavior
- then read `OpenOats/Sources/OpenOats/Settings/SettingsStore.swift` for the downgrade-compatibility change
- then skim `OpenOats/Sources/OpenOats/Meeting/NotificationService.swift` for the terminology fix
- finish with the new tests, especially `OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift`, because they encode the regression cases this PR is meant to lock down

## Validation
- `swift test`
