### PR TITLE
fix: don't show suggestion overlay during model download

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -40,6 +40,8 @@ final class LiveSessionController {
     private let coordinator: AppCoordinator
     private let container: AppContainer
 
+    private var downloadTask: Task<Void, Never>?
+
     // Tracked-change sentinels
     private var observedUtteranceCount = 0
     private var observedIsRunning = false
@@ -123,6 +125,16 @@ final class LiveSessionController {
     func confirmDownloadAndStart(settings: AppSettings) {
         coordinator.transcriptionEngine?.downloadConfirmed = true
         startSession(settings: settings)
+    }
+
+    func downloadModelOnly(settings: AppSettings) {
+        guard downloadTask == nil else { return }
+        downloadTask = Task {
+            await coordinator.transcriptionEngine?.downloadModelOnly(
+                transcriptionModel: settings.transcriptionModel
+            )
+            downloadTask = nil
+        }
     }
 
     func toggleMicMute() {

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -197,13 +197,44 @@ final class TranscriptionEngine {
         }
     }
 
+    /// Download the model without starting a transcription session.
+    func downloadModelOnly(transcriptionModel: TranscriptionModel) async {
+        guard !isRunning, downloadProgress == nil else { return }
+
+        refreshModelAvailability()
+        guard needsModelDownload else { return }
+
+        lastError = nil
+        assetStatus = "Downloading \(transcriptionModel.displayName)..."
+        beginDownloadTracking(for: transcriptionModel)
+
+        let vocab = settings.transcriptionCustomVocabulary
+        let backend = transcriptionModel.makeBackend(customVocabulary: vocab)
+        do {
+            try await prepareBackend(backend)
+            needsModelDownload = false
+            downloadConfirmed = false
+            clearDownloadTracking()
+            assetStatus = "Ready"
+        } catch is CancellationError {
+            clearDownloadTracking()
+            assetStatus = "Ready"
+        } catch {
+            lastError = "Failed to download: \(error.localizedDescription)"
+            assetStatus = "Ready"
+            clearDownloadTracking()
+            transcriptionModel.makeBackend().clearModelCache()
+            needsModelDownload = true
+        }
+    }
+
     func start(
         locale: Locale,
         inputDeviceID: AudioDeviceID = 0,
         transcriptionModel: TranscriptionModel
     ) async {
         Log.transcription.info("start() called, isRunning=\(self.isRunning, privacy: .public)")
-        guard !isRunning else { return }
+        guard !isRunning, downloadProgress == nil else { return }
         lastError = nil
         refreshModelAvailability()
 
@@ -248,28 +279,13 @@ final class TranscriptionEngine {
             ? "Downloading \(transcriptionModel.displayName)..."
             : "Loading \(transcriptionModel.displayName)..."
         if isDownloading {
-            downloadProgress = 0
-            downloadStartTime = Date()
-            downloadTotalBytes = transcriptionModel.estimatedDownloadBytes
-            downloadDetail = DownloadProgressDetail(fraction: 0, sizeText: nil, speedText: nil, etaText: nil)
+            beginDownloadTracking(for: transcriptionModel)
         }
         Log.transcription.info("Loading transcription model \(transcriptionModel.rawValue, privacy: .public)")
         do {
             let vocab = settings.transcriptionCustomVocabulary
             let mic = transcriptionModel.makeBackend(customVocabulary: vocab)
-            try await mic.prepare(
-                onStatus: { [weak self] status in
-                    Task { @MainActor in
-                        self?.assetStatus = status
-                    }
-                },
-                onProgress: { [weak self] fraction in
-                    Task { @MainActor in
-                        self?.downloadProgress = fraction
-                        self?.updateDownloadDetail(fraction: fraction)
-                    }
-                }
-            )
+            try await prepareBackend(mic)
             self.micBackend = mic
 
             // Parakeet needs a separate backend for system audio (mutable decoder state).
@@ -302,10 +318,7 @@ final class TranscriptionEngine {
 
             needsModelDownload = false
             downloadConfirmed = false
-            downloadProgress = nil
-            downloadDetail = nil
-            downloadStartTime = nil
-            downloadTotalBytes = nil
+            clearDownloadTracking()
             assetStatus = "Models ready"
             Log.transcription.info("Transcription model loaded")
         } catch {
@@ -314,11 +327,7 @@ final class TranscriptionEngine {
             lastError = msg
             assetStatus = "Ready"
             isRunning = false
-            downloadProgress = nil
-            downloadDetail = nil
-            downloadStartTime = nil
-            downloadTotalBytes = nil
-            // Clear corrupt cache so the next attempt triggers a fresh download
+            clearDownloadTracking()
             activeTranscriptionSession?.clearModelCache()
             Log.transcription.info(
                 "Cleared model cache for \(transcriptionModel.rawValue, privacy: .public)"
@@ -943,6 +952,36 @@ final class TranscriptionEngine {
             lastError.localizedCaseInsensitiveContains("audio output device") {
             self.lastError = nil
         }
+    }
+
+    // MARK: - Download Helpers
+
+    private func beginDownloadTracking(for model: TranscriptionModel) {
+        downloadProgress = 0
+        downloadStartTime = Date()
+        downloadTotalBytes = model.estimatedDownloadBytes
+        downloadDetail = DownloadProgressDetail(fraction: 0, sizeText: nil, speedText: nil, etaText: nil)
+    }
+
+    private func clearDownloadTracking() {
+        downloadProgress = nil
+        downloadDetail = nil
+        downloadStartTime = nil
+        downloadTotalBytes = nil
+    }
+
+    private func prepareBackend(_ backend: any TranscriptionBackend) async throws {
+        try await backend.prepare(
+            onStatus: { [weak self] status in
+                Task { @MainActor in self?.assetStatus = status }
+            },
+            onProgress: { [weak self] fraction in
+                Task { @MainActor in
+                    self?.downloadProgress = fraction
+                    self?.updateDownloadDetail(fraction: fraction)
+                }
+            }
+        )
     }
 
     // MARK: - Download Progress Detail

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -472,17 +472,11 @@ struct ContentView: View {
         case .toggle:
             if liveSessionController?.state.isRunning ?? false {
                 stopSession()
-            } else {
+            } else if liveSessionController?.state.downloadProgress == nil {
                 startSession()
             }
         case .confirmDownload:
-            guard settings.hasAcknowledgedRecordingConsent else {
-                withAnimation(.easeInOut(duration: 0.25)) {
-                    showConsentSheet = true
-                }
-                return
-            }
-            liveSessionController?.confirmDownloadAndStart(settings: settings)
+            liveSessionController?.downloadModelOnly(settings: settings)
         }
     }
 }


### PR DESCRIPTION
## Summary
- "Download Now" button called `confirmDownloadAndStart()` which started the full transcription session while the model was still downloading - showing the floating suggestion panel, minibar, and "Live" status with nothing to transcribe
- Add `downloadModelOnly()` to `TranscriptionEngine` that fetches and prepares the model without starting mic/system capture or setting `isRunning`
- Rewire the "Download Now" button to use the download-only path. User starts a session manually when ready.

## Test plan
- [ ] Click "Download Now" on a model that needs downloading - verify no session starts (no "Live" status, no floating panel, no minibar)
- [ ] Download progress bar and speed/ETA still display correctly during download
- [ ] After download completes, click Start - verify session starts normally with all panels
- [ ] If download fails, verify error message shows and "Download Now" reappears