### PR TITLE
Update Homebrew cask for 1.38.1

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.38.0"
-  sha256 "5e322eeb0a40f26f6325f0298aeaad85878d749ebfa381b13659ef9f8cfd6e1b"
+  version "1.38.1"
+  sha256 "7c893642a17d9749de0b0b3e795f79189f5daadbfc9021581965d25ef7b81eae"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Updates `Casks/openoats.rb` version from 1.38.0 to 1.38.1 with new SHA256

The `automation/homebrew-cask-1.38.0` branch was already merged, but no automation branch was created for 1.38.1. This brings the cask up to the latest release.

## Test plan
- [ ] CI green
- [ ] Download URL resolves to the correct DMG