### PR TITLE
fix: render demo video in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ A meeting note-taker that talks back.
 OpenOats sits next to your call, transcribes both sides of the conversation in real time, and searches your own notes to surface things worth saying — right when you need them.
 
 <p align="center">
-  <video src="assets/demo.mp4" autoplay loop muted playsinline width="720"></video>
+
+https://github.com/yazinsai/OpenOats/raw/main/assets/demo.mp4
+
 </p>
 
 ## Features


### PR DESCRIPTION
## Summary
- The `<video>` HTML tag added in #242 is stripped by GitHub's Markdown sanitizer, so the demo video doesn't render
- Replaces it with a bare `.mp4` URL on its own line, which GitHub auto-renders as an embedded video player

## Test plan
- [ ] Verify the video plays inline on the repo's README page after merge