### PR TITLE
fix: cloud ASR validation and streaming pipeline

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
@@ -39,7 +39,9 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
 
         onStatus("Validating ElevenLabs API key...")
 
-        var request = URLRequest(url: URL(string: "https://api.elevenlabs.io/v1/user")!)
+        // Validate using /v1/voices — universally accessible with any valid key,
+        // unlike /v1/user which requires elevated account permissions.
+        var request = URLRequest(url: URL(string: "https://api.elevenlabs.io/v1/voices")!)
         request.httpMethod = "GET"
         request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
 

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
@@ -24,12 +24,18 @@ final class StreamingTranscriber: @unchecked Sendable {
     /// Flush interval in 16kHz samples. Determined by the transcription model.
     private let flushInterval: Int
 
+    /// When true, skip inline partial hypotheses to avoid blocking the VAD loop.
+    /// Cloud backends (AssemblyAI, ElevenLabs) are too slow for partial transcription
+    /// because each call involves an HTTP upload + polling cycle that stalls audio processing.
+    private let skipPartials: Bool
+
     init(
         backend: any TranscriptionBackend,
         locale: Locale,
         vadManager: VadManager,
         speaker: Speaker,
         flushInterval: Int,
+        skipPartials: Bool = false,
         onPartial: @escaping @Sendable (String) -> Void,
         onFinal: @escaping @Sendable (String) -> Void
     ) {
@@ -38,6 +44,7 @@ final class StreamingTranscriber: @unchecked Sendable {
         self.vadManager = vadManager
         self.speaker = speaker
         self.flushInterval = flushInterval
+        self.skipPartials = skipPartials
         self.onPartial = onPartial
         self.onFinal = onFinal
     }
@@ -142,8 +149,11 @@ final class StreamingTranscriber: @unchecked Sendable {
                         }
                     } else if isSpeaking {
 
-                        // Throttled partial hypothesis every ~400ms
-                        if !isRunningPartial,
+                        // Throttled partial hypothesis every ~400ms.
+                        // Skipped for cloud backends — each call blocks the VAD loop
+                        // for seconds while the HTTP round-trip completes.
+                        if !skipPartials,
+                           !isRunningPartial,
                            speechSamples.count > Self.minimumSpeechSamples,
                            Date.now.timeIntervalSince(lastPartialTime) >= 0.4 {
                             isRunningPartial = true

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -872,12 +872,14 @@ final class TranscriptionEngine {
             Log.transcription.error("makeTranscriber called without initialized backend for \(speaker.storageKey, privacy: .public)")
             return nil
         }
+        let model = currentTranscriptionModel()
         return StreamingTranscriber(
             backend: backend,
             locale: locale,
             vadManager: vadManager,
             speaker: speaker,
-            flushInterval: currentTranscriptionModel().flushIntervalSamples,
+            flushInterval: model.flushIntervalSamples,
+            skipPartials: model.isCloud,
             onPartial: onPartial,
             onFinal: onFinal
         )


### PR DESCRIPTION
## Summary

Fixes two bugs in the cloud ASR backends introduced in v1.39.0:

- **ElevenLabs API key validation** (#248): The `/v1/user` endpoint used for key validation requires elevated account permissions that not all API keys have. Switched to `/v1/voices` which is universally accessible with any valid key.
- **AssemblyAI produces no transcription output** (#247): The streaming transcriber was attempting partial hypotheses (inline transcription previews) for cloud backends. Each partial triggers a full HTTP upload → create-transcript → poll cycle that blocks the VAD processing loop for 5–30+ seconds, preventing speech-end detection and stalling final transcription. Partial hypotheses are now skipped for cloud backends.

Closes #247
Closes #248