### PR TITLE
chore: update Homebrew cask to 1.39.2

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.39.1"
-  sha256 "c9842dadc5886590617add823d1f0fb213d84f1847ba489c6ff15cc36b0abd19"
+  version "1.39.2"
+  sha256 "a465eb9a7ffd8d56bd4efea575437332655271eb0633ab8c6705a7f5ec538ba8"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Update Homebrew cask version and SHA256 for v1.39.2 release.

- version: 1.39.1 → 1.39.2
- sha256 updated to match the new DMG

Automated cask update from the release workflow.