### PR TITLE
fix: propagate task cancellation to cloud ASR backends on stop

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -126,6 +126,9 @@ final class AppCoordinator {
     /// Guard against finalization hanging forever.
     private var finalizationTimeoutTask: Task<Void, Never>?
 
+    /// The active finalization task, retained so the timeout can cancel it.
+    private var finalizationTask: Task<Void, Never>?
+
     /// Retained reference to the active settings for side effects.
     var activeSettings: AppSettings?
 
@@ -174,9 +177,10 @@ final class AppCoordinator {
             finalizationTimeoutTask = Task {
                 try? await Task.sleep(for: .seconds(30))
                 guard !Task.isCancelled else { return }
+                finalizationTask?.cancel()
                 handle(.finalizationTimeout)
             }
-            Task {
+            finalizationTask = Task {
                 await liveSessionController?.finalizeCurrentSession(settings: settings)
                 finalizationTimeoutTask?.cancel()
                 finalizationTimeoutTask = nil
@@ -189,9 +193,11 @@ final class AppCoordinator {
         case .finalizationComplete:
             finalizationTimeoutTask?.cancel()
             finalizationTimeoutTask = nil
+            finalizationTask = nil
 
         case .finalizationTimeout:
             finalizationTimeoutTask = nil
+            finalizationTask = nil
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
@@ -99,6 +99,8 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
         body.append("--\(boundary)--\r\n".data(using: .utf8)!)
 
         // 3. POST to speech-to-text endpoint
+        try Task.checkCancellation()
+
         var request = URLRequest(url: URL(string: "https://api.elevenlabs.io/v1/speech-to-text")!)
         request.httpMethod = "POST"
         request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
@@ -71,6 +71,7 @@ final class StreamingTranscriber: @unchecked Sendable {
         var isRunningPartial = false
 
         for await buffer in stream {
+            guard !Task.isCancelled else { break }
             bufferCount += 1
             if bufferCount <= 3 {
                 let fmt = buffer.format
@@ -195,6 +196,7 @@ final class StreamingTranscriber: @unchecked Sendable {
 
     private func transcribeSegment(_ samples: [Float]) async {
         do {
+            try Task.checkCancellation()
             let text = try await backend.transcribe(samples, locale: locale, previousContext: previousContext)
             guard !text.isEmpty else { return }
             Log.streaming.debug("[\(self.speaker.storageKey, privacy: .public)] transcribed: \(text.prefix(80), privacy: .private)")

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -573,6 +573,8 @@ final class TranscriptionEngine {
         micCapture.finishStream()
         systemCapture.finishStream()
 
+        micTask?.cancel()
+        sysTask?.cancel()
         await micTask?.value
         await sysTask?.value
 


### PR DESCRIPTION
## Summary

Fixes #260 — the stop button could hang for up to 30 seconds when using cloud transcription backends (ElevenLabs Scribe) because task cancellation was not propagated through the transcription pipeline.

**Changes:**

- Add `Task.checkCancellation()` in `ElevenLabsScribeBackend.transcribe()` before the HTTP POST
- Add cancellation check in `StreamingTranscriber.transcribeSegment()` before calling the backend
- Break `StreamingTranscriber.run()` loop on task cancellation
- Cancel `micTask`/`sysTask` in `TranscriptionEngine.finalize()` before awaiting their values
- Store and cancel the finalization task from `AppCoordinator`'s 30-second timeout handler

## Test plan

- [ ] Start a recording session with ElevenLabs Scribe backend
- [ ] Press Stop while a transcription segment is in-flight
- [ ] Verify session finalizes promptly (< 2s) instead of hanging for 30s
- [ ] Verify normal stop flow (no in-flight request) still works correctly
- [ ] Verify local Whisper backend is unaffected