### PR TITLE
feat: upgrade ElevenLabs Scribe to v2 and support language auto-detection

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.39.2"
-  sha256 "a465eb9a7ffd8d56bd4efea575437332655271eb0633ab8c6705a7f5ec538ba8"
+  version "1.39.3"
+  sha256 "ff584397a6e0b1830f70c39f919f50d6400b5f87598f79e25987fd0c117bf79d"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -327,7 +327,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         case .assemblyAI:
             "Optional language hint for AssemblyAI. Leave as en-US for English or set to your expected meeting language."
         case .elevenLabsScribe:
-            "Optional language hint for ElevenLabs Scribe. Leave as en-US for English or set to your meeting language."
+            "Optional language hint for ElevenLabs Scribe. Leave empty for auto-detection (recommended for multilingual meetings), or set to a language code like en, fr, de."
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
@@ -3,7 +3,7 @@ import os
 
 // MARK: - ElevenLabs Scribe Backend
 
-/// Cloud transcription backend using the ElevenLabs Scribe v1 REST API.
+/// Cloud transcription backend using the ElevenLabs Scribe v2 REST API.
 /// @unchecked Sendable: session and prepared are written once in prepare() before any transcribe() calls.
 final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
     let displayName = "ElevenLabs Scribe"
@@ -74,7 +74,7 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
         let boundary = UUID().uuidString
         var body = Data()
 
-        body.appendMultipart(boundary: boundary, name: "model_id", value: "scribe_v1")
+        body.appendMultipart(boundary: boundary, name: "model_id", value: "scribe_v2")
 
         let languageCode = locale.language.languageCode?.identifier ?? ""
         if !languageCode.isEmpty {


### PR DESCRIPTION
## Summary

- Upgrades ElevenLabs Scribe from deprecated `scribe_v1` to `scribe_v2` for improved accuracy, reduced hallucinations, and working keyterm prompting support
- Surfaces language auto-detection in the UI: the help text now explains that clearing the language hint field enables auto-detection (the backend already omits `language_code` when empty)
- Bumps Homebrew cask to 1.39.3

Closes #262, closes #263