### PR TITLE
fix: Whisper model detection, ElevenLabs no_verbatim, cloud ASR retry (#265, #266, #267)

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.39.3"
-  sha256 "ff584397a6e0b1830f70c39f919f50d6400b5f87598f79e25987fd0c117bf79d"
+  version "1.40.0"
+  sha256 "2b677f2d97cf4a4f7f7cd5a40a9726c93148257fe980f3d0d5bd725c733a6ee8"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -386,6 +386,17 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _removeFillerWords: Bool
+    var removeFillerWords: Bool {
+        get { access(keyPath: \.removeFillerWords); return _removeFillerWords }
+        set {
+            withMutation(keyPath: \.removeFillerWords) {
+                _removeFillerWords = newValue
+                defaults.set(newValue, forKey: "removeFillerWords")
+            }
+        }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _saveAudioRecording: Bool
     var saveAudioRecording: Bool {
         get { access(keyPath: \.saveAudioRecording); return _saveAudioRecording }
@@ -711,6 +722,7 @@ final class SettingsStore {
         ) ?? .parakeetV2
         self._transcriptionLocale = defaults.string(forKey: "transcriptionLocale") ?? "en-US"
         self._transcriptionCustomVocabulary = defaults.string(forKey: "transcriptionCustomVocabulary") ?? ""
+        self._removeFillerWords = defaults.bool(forKey: "removeFillerWords")
         self._saveAudioRecording = defaults.bool(forKey: "saveAudioRecording")
 
         if defaults.object(forKey: "enableEchoCancellation") == nil {

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -341,7 +341,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         }
     }
 
-    func makeBackend(customVocabulary: String = "", apiKey: String = "") -> any TranscriptionBackend {
+    func makeBackend(customVocabulary: String = "", apiKey: String = "", removeFillerWords: Bool = false) -> any TranscriptionBackend {
         switch self {
         case .parakeetV2: return ParakeetBackend(version: .v2, customVocabulary: customVocabulary)
         case .parakeetV3: return ParakeetBackend(version: .v3, customVocabulary: customVocabulary)
@@ -350,7 +350,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         case .whisperSmall: return WhisperKitBackend(variant: .small)
         case .whisperLargeV3Turbo: return WhisperKitBackend(variant: .largeV3Turbo)
         case .assemblyAI: return AssemblyAIBackend(apiKey: apiKey, customVocabulary: customVocabulary)
-        case .elevenLabsScribe: return ElevenLabsScribeBackend(apiKey: apiKey, customVocabulary: customVocabulary)
+        case .elevenLabsScribe: return ElevenLabsScribeBackend(apiKey: apiKey, customVocabulary: customVocabulary, removeFillerWords: removeFillerWords)
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Transcription/AssemblyAIBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/AssemblyAIBackend.swift
@@ -28,6 +28,41 @@ enum CloudASRError: LocalizedError {
     }
 }
 
+// MARK: - Transient Retry Helper
+
+/// Retries a throwing async operation on transient HTTP failures (5xx, timeouts).
+/// Respects task cancellation between attempts.
+func withTransientRetry<T>(
+    maxAttempts: Int = 3,
+    initialDelay: Duration = .milliseconds(250),
+    operation: () async throws -> T
+) async throws -> T {
+    var lastError: Error?
+    for attempt in 0 ..< maxAttempts {
+        try Task.checkCancellation()
+        do {
+            return try await operation()
+        } catch let error as CloudASRError where error.isTransient {
+            lastError = error
+        } catch let error as URLError where error.code == .timedOut || error.code == .networkConnectionLost {
+            lastError = error
+        }
+        if attempt < maxAttempts - 1 {
+            let delay = initialDelay * (1 << attempt)
+            try await Task.sleep(for: delay)
+        }
+    }
+    throw lastError!
+}
+
+extension CloudASRError {
+    var isTransient: Bool {
+        if case .httpError(let code) = self { return code >= 500 }
+        if case .timeout = self { return true }
+        return false
+    }
+}
+
 // MARK: - AssemblyAI Backend
 
 /// Cloud transcription backend using the AssemblyAI REST API.
@@ -128,17 +163,19 @@ final class AssemblyAIBackend: TranscriptionBackend, @unchecked Sendable {
         request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
         request.httpBody = data
 
-        let (responseData, response) = try await session.data(for: request)
-        try checkHTTPStatus(response)
+        return try await withTransientRetry { [session] in
+            let (responseData, response) = try await session.data(for: request)
+            try self.checkHTTPStatus(response)
 
-        let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
-        guard let urlString = json?["upload_url"] as? String,
-              let url = URL(string: urlString)
-        else {
-            throw CloudASRError.invalidUploadURL
+            let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+            guard let urlString = json?["upload_url"] as? String,
+                  let url = URL(string: urlString)
+            else {
+                throw CloudASRError.invalidUploadURL
+            }
+
+            return url
         }
-
-        return url
     }
 
     // MARK: - Private: Create Transcript
@@ -162,15 +199,17 @@ final class AssemblyAIBackend: TranscriptionBackend, @unchecked Sendable {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
-        let (responseData, response) = try await session.data(for: request)
-        try checkHTTPStatus(response)
+        return try await withTransientRetry { [session] in
+            let (responseData, response) = try await session.data(for: request)
+            try self.checkHTTPStatus(response)
 
-        let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
-        guard let id = json?["id"] as? String else {
-            throw CloudASRError.transcriptionFailed("Missing transcript ID in response.")
+            let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+            guard let id = json?["id"] as? String else {
+                throw CloudASRError.transcriptionFailed("Missing transcript ID in response.")
+            }
+
+            return id
         }
-
-        return id
     }
 
     // MARK: - Private: Poll

--- a/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
@@ -10,6 +10,7 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
 
     private let apiKey: String
     private let keyterms: [String]
+    private let removeFillerWords: Bool
     private let session: URLSession
     private var prepared = false
 
@@ -17,9 +18,10 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
 
     // MARK: - Init
 
-    init(apiKey: String, customVocabulary: String = "") {
+    init(apiKey: String, customVocabulary: String = "", removeFillerWords: Bool = false) {
         self.apiKey = apiKey
         self.keyterms = Self.parseKeyterms(customVocabulary)
+        self.removeFillerWords = removeFillerWords
         self.session = URLSession(configuration: .ephemeral)
     }
 
@@ -95,6 +97,10 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
             body.appendMultipart(boundary: boundary, name: "keyterms", value: jsonString)
         }
 
+        if removeFillerWords {
+            body.appendMultipart(boundary: boundary, name: "no_verbatim", value: "true")
+        }
+
         // Closing boundary
         body.append("--\(boundary)--\r\n".data(using: .utf8)!)
 
@@ -108,21 +114,23 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
         request.httpBody = body
         request.timeoutInterval = 30
 
-        let (responseData, response) = try await session.data(for: request)
+        let text: String = try await withTransientRetry { [session] in
+            let (responseData, response) = try await session.data(for: request)
 
-        if let http = response as? HTTPURLResponse {
-            if http.statusCode == 401 || http.statusCode == 403 {
-                throw CloudASRError.invalidAPIKey(backend: "ElevenLabs")
+            if let http = response as? HTTPURLResponse {
+                if http.statusCode == 401 || http.statusCode == 403 {
+                    throw CloudASRError.invalidAPIKey(backend: "ElevenLabs")
+                }
+                if !(200 ..< 300).contains(http.statusCode) {
+                    throw CloudASRError.httpError(statusCode: http.statusCode)
+                }
             }
-            if !(200 ..< 300).contains(http.statusCode) {
-                throw CloudASRError.httpError(statusCode: http.statusCode)
-            }
-        }
 
-        // 4. Parse JSON response
-        let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
-        guard let text = json?["text"] as? String else {
-            throw CloudASRError.transcriptionFailed("Missing text field in response.")
+            let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
+            guard let text = json?["text"] as? String else {
+                throw CloudASRError.transcriptionFailed("Missing text field in response.")
+            }
+            return text
         }
 
         Self.log.info("ElevenLabs Scribe transcription completed")

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -285,7 +285,8 @@ final class TranscriptionEngine {
         do {
             let vocab = settings.transcriptionCustomVocabulary
             let apiKey = settings.cloudASRApiKey
-            let mic = transcriptionModel.makeBackend(customVocabulary: vocab, apiKey: apiKey)
+            let noFiller = settings.removeFillerWords
+            let mic = transcriptionModel.makeBackend(customVocabulary: vocab, apiKey: apiKey, removeFillerWords: noFiller)
             try await prepareBackend(mic)
             self.micBackend = mic
 
@@ -294,7 +295,7 @@ final class TranscriptionEngine {
             if transcriptionModel == .qwen3ASR06B || transcriptionModel.isCloud {
                 self.systemBackend = mic
             } else {
-                let sys = transcriptionModel.makeBackend(customVocabulary: vocab, apiKey: apiKey)
+                let sys = transcriptionModel.makeBackend(customVocabulary: vocab, apiKey: apiKey, removeFillerWords: noFiller)
                 try await sys.prepare { _ in }
                 self.systemBackend = sys
             }

--- a/OpenOats/Sources/OpenOats/Transcription/WhisperKitManager.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/WhisperKitManager.swift
@@ -84,27 +84,26 @@ final class WhisperKitManager: @unchecked Sendable {
     /// Check whether the model files already exist locally.
     static func modelExists(variant: Variant) -> Bool {
         let fm = FileManager.default
-        // WhisperKit downloads models into ~/Library/Caches/huggingface/models/argmaxinc/whisperkit-coreml/
-        // and then into a subfolder matching the variant. We check if any compiled model
-        // folder exists. A simpler heuristic: check the default download location.
-        let cachesDir = fm.urls(for: .cachesDirectory, in: .userDomainMask).first
-        guard let cachesDir else { return false }
+        let subpath = ["huggingface", "models", "argmaxinc", "whisperkit-coreml"]
 
-        // WhisperKit stores models under:
-        // ~/Library/Caches/huggingface/models/argmaxinc/whisperkit-coreml/openai_whisper-{variant}
-        let hfCacheDir = cachesDir
-            .appendingPathComponent("huggingface")
-            .appendingPathComponent("models")
-            .appendingPathComponent("argmaxinc")
-            .appendingPathComponent("whisperkit-coreml")
+        // WhisperKit's Hub client downloads models into ~/Documents/huggingface/…
+        // Earlier versions used ~/Library/Caches/huggingface/… — check both for
+        // backward compatibility.
+        let roots: [URL?] = [
+            fm.urls(for: .documentDirectory, in: .userDomainMask).first,
+            fm.urls(for: .cachesDirectory, in: .userDomainMask).first,
+        ]
 
-        guard fm.fileExists(atPath: hfCacheDir.path) else { return false }
+        for root in roots.compactMap({ $0 }) {
+            var dir = root
+            for component in subpath { dir.appendPathComponent(component) }
 
-        // Look for a directory containing the variant name
-        guard let contents = try? fm.contentsOfDirectory(atPath: hfCacheDir.path) else {
-            return false
+            guard let contents = try? fm.contentsOfDirectory(atPath: dir.path) else { continue }
+            if contents.contains(where: { $0.contains("whisper-\(variant.rawValue)") }) {
+                return true
+            }
         }
-        return contents.contains { $0.contains("whisper-\(variant.rawValue)") }
+        return false
     }
 
     enum WhisperKitManagerError: LocalizedError {

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -335,6 +335,11 @@ private struct TranscriptionSettingsTab: View {
                                 .font(.system(size: 11))
                                 .foregroundStyle(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)
+                            Toggle("Remove filler words", isOn: $settings.removeFillerWords)
+                                .font(.system(size: 12))
+                            Text("Strips filler words, false starts, and non-speech sounds server-side before returning the transcript.")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
                         default:
                             EmptyView()
                         }


### PR DESCRIPTION
## Summary

- **Fix Whisper model path mismatch (#267):** `modelExists()` was checking `~/Library/Caches/huggingface/` but WhisperKit downloads to `~/Documents/huggingface/`. Now checks both locations for backward compatibility.
- **Add "Remove filler words" setting (#266):** New opt-in toggle for ElevenLabs Scribe that sends `no_verbatim=true` to strip filler words, false starts, and non-speech sounds server-side.
- **Add retry logic for cloud ASR (#265):** Both ElevenLabs and AssemblyAI backends now retry up to 3 times with exponential backoff on transient HTTP failures (5xx, timeouts). Respects task cancellation between attempts.
- **Update Homebrew cask to 1.40.0**

## Files changed

- `WhisperKitManager.swift` — check both document and cache directories
- `ElevenLabsScribeBackend.swift` — accept `removeFillerWords`, send `no_verbatim`, wrap HTTP in retry
- `AssemblyAIBackend.swift` — add shared `withTransientRetry` helper, wrap upload and createTranscript
- `SettingsStore.swift` — add `removeFillerWords` boolean setting
- `SettingsTypes.swift` — pass `removeFillerWords` through `makeBackend()`
- `TranscriptionEngine.swift` — pass setting to backend factory
- `SettingsView.swift` — add toggle under ElevenLabs settings
- `Casks/openoats.rb` — bump version and sha256 to 1.40.0

## Test plan

- [x] `swift build` compiles successfully
- [x] All 382 tests pass with 0 failures

Closes #267, closes #266, closes #265