### PR TITLE
chore: update Homebrew cask to 1.41.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.40.0"
-  sha256 "2b677f2d97cf4a4f7f7cd5a40a9726c93148257fe980f3d0d5bd725c733a6ee8"
+  version "1.41.0"
+  sha256 "28389ec8b3991baf72bd902f6d050d5e73a967346f0a0df04dcf4014a33ae9c3"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Update Homebrew cask formula for OpenOats 1.41.0.

- Version: 1.40.0 → 1.41.0
- SHA256 updated to match the new DMG

Automated post-release cask update.