### PR TITLE
fix: add required speech_models parameter to AssemblyAI API requests

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/AssemblyAIBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/AssemblyAIBackend.swift
@@ -181,7 +181,10 @@ final class AssemblyAIBackend: TranscriptionBackend, @unchecked Sendable {
     // MARK: - Private: Create Transcript
 
     private func createTranscript(audioURL: URL, locale: Locale) async throws -> String {
-        var body: [String: Any] = ["audio_url": audioURL.absoluteString]
+        var body: [String: Any] = [
+            "audio_url": audioURL.absoluteString,
+            "speech_models": ["universal-3-pro", "universal-2"],
+        ]
 
         // Language code from locale (e.g. "en", "pl", "de")
         let languageCode = locale.language.languageCode?.identifier
@@ -201,6 +204,13 @@ final class AssemblyAIBackend: TranscriptionBackend, @unchecked Sendable {
 
         return try await withTransientRetry { [session] in
             let (responseData, response) = try await session.data(for: request)
+
+            // Log diagnostic info for client errors before throwing
+            if let http = response as? HTTPURLResponse, (400 ..< 500).contains(http.statusCode) {
+                let errorMessage = (try? JSONSerialization.jsonObject(with: responseData) as? [String: Any])?["error"] as? String
+                Self.log.error("Transcript creation failed (HTTP \(http.statusCode, privacy: .public)): \(errorMessage ?? "unknown", privacy: .public)")
+            }
+
             try self.checkHTTPStatus(response)
 
             let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]


### PR DESCRIPTION
## Summary

- AssemblyAI's API now requires the `speech_models` parameter in transcript creation requests. Without it, the API returns HTTP 400 — this is the root cause of #277.
- Adds `["universal-3-pro", "universal-2"]` as the default model chain, providing best accuracy where supported with broad language fallback via Universal-2.
- Adds diagnostic logging for 4xx errors from the transcript creation endpoint to aid future debugging.

Closes #277

## Test plan

- [ ] Build compiles (verified locally)
- [ ] CI passes (validate-swift, package-smoke)
- [ ] Verify AssemblyAI transcription works with the new `speech_models` parameter