### PR TITLE
fix: re-check microphone permission on device switch (#282)

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -667,6 +667,12 @@ final class TranscriptionEngine {
 
         micTask = nil
         micCapture.stop()
+
+        guard await ensureMicrophonePermission() else {
+            Log.transcription.error("Mic permission lost during device switch")
+            return
+        }
+
         startMicStream(
             locale: settings.locale,
             vadManager: vadManager,


### PR DESCRIPTION
## Summary

- Adds a microphone permission re-check in `performMicRestart()` before starting the new mic stream
- If permission was lost during a device switch, the user now sees a clear error message instead of a silent hang
- Bumps Homebrew cask to 1.41.1

Fixes #282

## What changed

When switching microphone devices during recording, the app called `startMicStream()` without verifying that microphone permission was still granted. If macOS revoked or reset audio access during the switch (e.g., due to a system policy change or the user toggling permissions in System Settings), the audio engine would fail silently and recording would hang indefinitely.

The fix adds a `guard await ensureMicrophonePermission()` call — reusing the existing permission check — right before `startMicStream()` in the device switch path. If permission is denied, the user sees the standard "Enable it in System Settings" error message.

## Test plan

- [ ] Start a recording, switch microphone device in settings — verify recording continues on the new device
- [ ] Start a recording, revoke microphone permission in System Settings, then switch mic device — verify the app shows a permission error instead of hanging