### PR TITLE
feat: prepend title heading to generated meeting notes

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -206,10 +206,15 @@ final class NotesController {
             )
 
             if !coordinator.notesEngine.generatedMarkdown.isEmpty {
+                let generatedMarkdown = coordinator.notesEngine.generatedMarkdown
+                let session = state.sessionHistory.first { $0.id == sessionID }
+                let heading = Self.notesHeading(title: session?.title, date: session?.startedAt ?? Date())
+                let markdown = heading + generatedMarkdown
+
                 let notes = GeneratedNotes(
                     template: coordinator.templateStore.snapshot(of: template),
                     generatedAt: Date(),
-                    markdown: coordinator.notesEngine.generatedMarkdown
+                    markdown: markdown
                 )
                 await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
                 state.loadedNotes = notes
@@ -386,6 +391,20 @@ final class NotesController {
 
     func loadHistory() async {
         state.sessionHistory = await coordinator.sessionRepository.listSessions()
+    }
+
+    /// Builds a markdown heading for generated notes.
+    static func notesHeading(title: String?, date: Date) -> String {
+        let displayTitle: String
+        if let title, !title.isEmpty {
+            displayTitle = title
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .short
+            displayTitle = formatter.string(from: date)
+        }
+        return "# Meeting Notes: \(displayTitle)\n\n"
     }
 
     /// Maps engine observable state to our flat status enums.

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -185,6 +185,55 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(controller.state.selectedSessionID, sessionID)
     }
 
+    func testGenerateNotesPrependsTitleHeading() async {
+        let (root, notes) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let settings = makeSettings(notesDirectory: notes)
+        let sessionID = "session_test_heading"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID, title: "Q4 Planning")
+        await controller.loadHistory()
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        controller.generateNotes(sessionID: sessionID, settings: settings)
+        try? await Task.sleep(for: .milliseconds(500))
+
+        let markdown = controller.state.loadedNotes?.markdown ?? ""
+        XCTAssertTrue(markdown.hasPrefix("# Meeting Notes: Q4 Planning\n\n"))
+    }
+
+    func testGenerateNotesHeadingFallsBackToDate() async {
+        let (root, notes) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let settings = makeSettings(notesDirectory: notes)
+        let sessionID = "session_test_heading_fallback"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID, title: "")
+        await controller.loadHistory()
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        controller.generateNotes(sessionID: sessionID, settings: settings)
+        try? await Task.sleep(for: .milliseconds(500))
+
+        let markdown = controller.state.loadedNotes?.markdown ?? ""
+        XCTAssertTrue(markdown.hasPrefix("# Meeting Notes: "), "Should have heading with date fallback")
+        XCTAssertFalse(markdown.hasPrefix("# Meeting Notes: \n"), "Should not have empty title")
+    }
+
+    func testNotesHeadingStaticHelper() {
+        let withTitle = NotesController.notesHeading(title: "Standup", date: Date())
+        XCTAssertEqual(withTitle, "# Meeting Notes: Standup\n\n")
+
+        let withEmpty = NotesController.notesHeading(title: "", date: Date(timeIntervalSince1970: 1_700_000_000))
+        XCTAssertTrue(withEmpty.hasPrefix("# Meeting Notes: "))
+        XCTAssertFalse(withEmpty.contains("# Meeting Notes: \n"))
+
+        let withNil = NotesController.notesHeading(title: nil, date: Date(timeIntervalSince1970: 1_700_000_000))
+        XCTAssertTrue(withNil.hasPrefix("# Meeting Notes: "))
+    }
+
     func testOriginalTranscriptToggle() async {
         let (root, _) = makeTempDirs()
         let (controller, _) = makeController(root: root)


### PR DESCRIPTION
## Summary
- Generated meeting notes now start with a `# Meeting Notes: <title>` heading before the LLM-generated body
- Falls back to a formatted date string when the session has no title
- Heading is added after LLM generation but before persistence, keeping the prompt unchanged
- Bumps Homebrew cask from v1.41.0 to v1.41.2

Closes #290

## Test plan
- [x] New `testGenerateNotesPrependsTitleHeading` verifies heading with session title
- [x] New `testGenerateNotesHeadingFallsBackToDate` verifies date fallback for untitled sessions
- [x] New `testNotesHeadingStaticHelper` unit tests the static helper method
- [x] All 11 NotesControllerTests pass
- [x] Build compiles cleanly