### PR TITLE
feat: remember selected audio devices by stable UID and auto-restore (#289)

### DIFF
--- a/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
@@ -352,6 +352,14 @@ final class MicCapture: @unchecked Sendable {
         return status == noErr ? sampleRate : nil
     }
 
+    /// Resolve a stable CoreAudio UID string back to the current AudioDeviceID, if the device is connected.
+    static func inputDeviceID(forUID uid: String) -> AudioDeviceID? {
+        for device in availableInputDevices() {
+            if deviceUID(for: device.id) == uid { return device.id }
+        }
+        return nil
+    }
+
     static func defaultInputDeviceID() -> AudioDeviceID? {
         var propertyAddress = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDefaultInputDevice,

--- a/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
@@ -323,6 +323,19 @@ final class SystemAudioCapture: @unchecked Sendable {
         return result
     }
 
+    /// Get the stable UID string for an output device.
+    static func outputDeviceUID(for deviceID: AudioDeviceID) throws -> String {
+        try deviceUID(for: deviceID)
+    }
+
+    /// Resolve a stable CoreAudio UID string back to the current AudioDeviceID, if the device is connected.
+    static func outputDeviceID(forUID uid: String) -> AudioDeviceID? {
+        for device in availableOutputDevices() {
+            if (try? deviceUID(for: device.id)) == uid { return device.id }
+        }
+        return nil
+    }
+
     private static func deviceUID(for deviceID: AudioDeviceID) throws -> String {
         var address = propertyAddress(selector: kAudioDevicePropertyDeviceUID)
         var uid: Unmanaged<CFString>?

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -338,9 +338,24 @@ final class SettingsStore {
             withMutation(keyPath: \.inputDeviceID) {
                 _inputDeviceID = newValue
                 defaults.set(Int(newValue), forKey: "inputDeviceID")
+                if newValue > 0 {
+                    if let uid = MicCapture.deviceUID(for: newValue) {
+                        defaults.set(uid, forKey: "inputDeviceUID")
+                    }
+                    let name = MicCapture.availableInputDevices().first(where: { $0.id == newValue })?.name
+                    if let name { defaults.set(name, forKey: "inputDeviceName") }
+                } else {
+                    defaults.removeObject(forKey: "inputDeviceUID")
+                    defaults.removeObject(forKey: "inputDeviceName")
+                }
             }
         }
     }
+
+    /// Stable UID of the last selected input device (survives reboots/reconnects).
+    var inputDeviceUID: String? { defaults.string(forKey: "inputDeviceUID") }
+    /// Cached display name for the last selected input device.
+    var inputDeviceName: String? { defaults.string(forKey: "inputDeviceName") }
 
     @ObservationIgnored nonisolated(unsafe) private var _outputDeviceID: AudioDeviceID
     var outputDeviceID: AudioDeviceID {
@@ -349,9 +364,24 @@ final class SettingsStore {
             withMutation(keyPath: \.outputDeviceID) {
                 _outputDeviceID = newValue
                 defaults.set(Int(newValue), forKey: "outputDeviceID")
+                if newValue > 0 {
+                    if let uid = try? SystemAudioCapture.outputDeviceUID(for: newValue) {
+                        defaults.set(uid, forKey: "outputDeviceUID")
+                    }
+                    let name = SystemAudioCapture.availableOutputDevices().first(where: { $0.id == newValue })?.name
+                    if let name { defaults.set(name, forKey: "outputDeviceName") }
+                } else {
+                    defaults.removeObject(forKey: "outputDeviceUID")
+                    defaults.removeObject(forKey: "outputDeviceName")
+                }
             }
         }
     }
+
+    /// Stable UID of the last selected output device (survives reboots/reconnects).
+    var outputDeviceUID: String? { defaults.string(forKey: "outputDeviceUID") }
+    /// Cached display name for the last selected output device.
+    var outputDeviceName: String? { defaults.string(forKey: "outputDeviceName") }
 
     @ObservationIgnored nonisolated(unsafe) private var _transcriptionModel: TranscriptionModel
     var transcriptionModel: TranscriptionModel {
@@ -717,6 +747,19 @@ final class SettingsStore {
         // Capture Settings
         self._inputDeviceID = AudioDeviceID(defaults.integer(forKey: "inputDeviceID"))
         self._outputDeviceID = AudioDeviceID(defaults.integer(forKey: "outputDeviceID"))
+        // Seed stable UIDs for users upgrading from an older version.
+        let savedInputID = _inputDeviceID
+        let savedOutputID = _outputDeviceID
+        if savedInputID > 0, defaults.string(forKey: "inputDeviceUID") == nil {
+            if let uid = MicCapture.deviceUID(for: savedInputID) { defaults.set(uid, forKey: "inputDeviceUID") }
+            let name = MicCapture.availableInputDevices().first(where: { $0.id == savedInputID })?.name
+            if let name { defaults.set(name, forKey: "inputDeviceName") }
+        }
+        if savedOutputID > 0, defaults.string(forKey: "outputDeviceUID") == nil {
+            if let uid = try? SystemAudioCapture.outputDeviceUID(for: savedOutputID) { defaults.set(uid, forKey: "outputDeviceUID") }
+            let name = SystemAudioCapture.availableOutputDevices().first(where: { $0.id == savedOutputID })?.name
+            if let name { defaults.set(name, forKey: "outputDeviceName") }
+        }
         self._transcriptionModel = TranscriptionModel(
             rawValue: defaults.string(forKey: "transcriptionModel") ?? ""
         ) ?? .parakeetV2

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -769,7 +769,15 @@ final class TranscriptionEngine {
 
         let sysStreams: SystemAudioCapture.CaptureStreams
         do {
-            let outputID: AudioDeviceID? = settings.outputDeviceID != 0 ? settings.outputDeviceID : nil
+            var outputID: AudioDeviceID? = settings.outputDeviceID != 0 ? settings.outputDeviceID : nil
+            // If the stored ID is stale, try resolving via stable UID.
+            if let id = outputID,
+               !SystemAudioCapture.availableOutputDevices().contains(where: { $0.id == id }),
+               let uid = settings.outputDeviceUID,
+               let resolved = SystemAudioCapture.outputDeviceID(forUID: uid) {
+                settings.outputDeviceID = resolved
+                outputID = resolved
+            }
             sysStreams = try await systemCapture.bufferStream(outputDeviceID: outputID)
             Log.transcription.info("System audio capture started")
             clearSystemAudioErrorIfPresent()
@@ -902,7 +910,15 @@ final class TranscriptionEngine {
     private func resolvedMicDeviceID(for inputDeviceID: AudioDeviceID) -> AudioDeviceID? {
         if inputDeviceID > 0 {
             let availableDeviceIDs = Set(MicCapture.availableInputDevices().map(\.id))
-            return availableDeviceIDs.contains(inputDeviceID) ? inputDeviceID : nil
+            if availableDeviceIDs.contains(inputDeviceID) { return inputDeviceID }
+            // Device ID is stale; try resolving via stable UID.
+            if let uid = settings.inputDeviceUID,
+               let resolved = MicCapture.inputDeviceID(forUID: uid) {
+                // Update the stored ID so future lookups are fast.
+                settings.inputDeviceID = resolved
+                return resolved
+            }
+            return nil
         }
 
         return MicCapture.defaultInputDeviceID()

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -272,6 +272,11 @@ private struct TranscriptionSettingsTab: View {
                         ForEach(inputDevices, id: \.id) { device in
                             Text(device.name).tag(device.id)
                         }
+                        if settings.inputDeviceID > 0,
+                           !inputDevices.contains(where: { $0.id == settings.inputDeviceID }),
+                           let name = settings.inputDeviceName {
+                            Text("\(name) (unavailable)").tag(settings.inputDeviceID)
+                        }
                     }
                     .font(.system(size: 12))
                     .accessibilityIdentifier("settings.microphonePicker")
@@ -280,6 +285,11 @@ private struct TranscriptionSettingsTab: View {
                         Text("System Default").tag(AudioDeviceID(0))
                         ForEach(outputDevices, id: \.id) { device in
                             Text(device.name).tag(device.id)
+                        }
+                        if settings.outputDeviceID > 0,
+                           !outputDevices.contains(where: { $0.id == settings.outputDeviceID }),
+                           let name = settings.outputDeviceName {
+                            Text("\(name) (unavailable)").tag(settings.outputDeviceID)
                         }
                     }
                     .font(.system(size: 12))
@@ -442,6 +452,19 @@ private struct TranscriptionSettingsTab: View {
         .onAppear {
             inputDevices = MicCapture.availableInputDevices()
             outputDevices = SystemAudioCapture.availableOutputDevices()
+            // Auto-restore devices by stable UID when the stored ID is stale.
+            if settings.inputDeviceID > 0,
+               !inputDevices.contains(where: { $0.id == settings.inputDeviceID }),
+               let uid = settings.inputDeviceUID,
+               let resolved = MicCapture.inputDeviceID(forUID: uid) {
+                settings.inputDeviceID = resolved
+            }
+            if settings.outputDeviceID > 0,
+               !outputDevices.contains(where: { $0.id == settings.outputDeviceID }),
+               let uid = settings.outputDeviceUID,
+               let resolved = SystemAudioCapture.outputDeviceID(forUID: uid) {
+                settings.outputDeviceID = resolved
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Persist CoreAudio device UIDs alongside transient device IDs so that preferred microphone and speaker selections survive reboots and hardware reconnects.

- Add UID-to-ID resolution helpers to `MicCapture` and `SystemAudioCapture`
- Save device UID and display name in UserDefaults when the user selects a device
- Resolve stale device IDs via stable UID at session start and in settings UI
- Show "(unavailable)" label for remembered devices not currently connected
- Seed UIDs on first launch for users upgrading from older versions

Closes #289