### PR TITLE
feat: add live note-taking scratchpad during recording sessions (#287)

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -27,6 +27,8 @@ struct LiveSessionState {
     var modelDisplayName: String = ""
     var showLiveTranscript: Bool = true
     var isMicMuted: Bool = false
+    /// The user's live scratchpad text for the active session.
+    var scratchpadText: String = ""
 }
 
 /// Owns all live session side effects: polling, utterance ingestion,
@@ -41,6 +43,7 @@ final class LiveSessionController {
     private let container: AppContainer
 
     private var downloadTask: Task<Void, Never>?
+    private var scratchpadSaveTask: Task<Void, Never>?
 
     // Tracked-change sentinels
     private var observedUtteranceCount = 0
@@ -140,6 +143,17 @@ final class LiveSessionController {
     func toggleMicMute() {
         guard let engine = coordinator.transcriptionEngine, engine.isRunning else { return }
         engine.isMicMuted.toggle()
+    }
+
+    /// Update the scratchpad text and schedule a debounced save.
+    func updateScratchpad(_ text: String) {
+        state.scratchpadText = text
+        scratchpadSaveTask?.cancel()
+        scratchpadSaveTask = Task {
+            try? await Task.sleep(for: .seconds(1))
+            guard !Task.isCancelled, let sessionID = _currentSessionID else { return }
+            await coordinator.sessionRepository.saveScratchpad(sessionID: sessionID, text: text)
+        }
     }
 
     // MARK: - KB Indexing
@@ -272,6 +286,7 @@ final class LiveSessionController {
             )
         )
         _currentSessionID = handle.sessionID
+        state.scratchpadText = ""
 
         if let settings {
             if settings.saveAudioRecording || settings.enableBatchRetranscription {
@@ -290,6 +305,12 @@ final class LiveSessionController {
     }
 
     func finalizeCurrentSession(settings: AppSettings?) async {
+        // 0. Flush scratchpad
+        scratchpadSaveTask?.cancel()
+        if let sessionID = _currentSessionID, !state.scratchpadText.isEmpty {
+            await coordinator.sessionRepository.saveScratchpad(sessionID: sessionID, text: state.scratchpadText)
+        }
+
         // 1. Drain audio buffers
         await coordinator.transcriptionEngine?.finalize()
 

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -199,10 +199,12 @@ final class NotesController {
         state.streamingMarkdown = ""
 
         Task {
+            let scratchpad = await coordinator.sessionRepository.loadScratchpad(sessionID: sessionID)
             await coordinator.notesEngine.generate(
                 transcript: state.loadedTranscript,
                 template: template,
-                settings: settings
+                settings: settings,
+                scratchpad: scratchpad.isEmpty ? nil : scratchpad
             )
 
             if !coordinator.notesEngine.generatedMarkdown.isEmpty {

--- a/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
@@ -40,7 +40,8 @@ final class NotesEngine {
     func generate(
         transcript: [SessionRecord],
         template: MeetingTemplate,
-        settings: AppSettings
+        settings: AppSettings,
+        scratchpad: String? = nil
     ) async {
         currentTask?.cancel()
         isGenerating = true
@@ -92,9 +93,14 @@ final class NotesEngine {
         }
 
         let transcriptText = formatTranscript(transcript)
+        var userContent = "Here is the meeting transcript:\n\n\(transcriptText)"
+        if let scratchpad, !scratchpad.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            userContent += "\n\nThe user also took the following notes during the meeting. Treat these as high-signal context — they may contain decisions, action items, or emphasis that the transcript alone may miss:\n\n\(scratchpad)"
+        }
+        userContent += "\n\nGenerate the meeting notes in markdown:"
         let messages: [OpenRouterClient.Message] = [
             .init(role: "system", content: template.systemPrompt),
-            .init(role: "user", content: "Here is the meeting transcript:\n\n\(transcriptText)\n\nGenerate the meeting notes in markdown:")
+            .init(role: "user", content: userContent)
         ]
 
         let task = Task { [weak self] in

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -487,6 +487,22 @@ actor SessionRepository {
         )
     }
 
+    // MARK: - Scratchpad
+
+    /// Save the user's live scratchpad notes for a session.
+    func saveScratchpad(sessionID: String, text: String) {
+        let dir = sessionDirectory(for: sessionID)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("scratchpad.md")
+        try? text.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// Load the user's scratchpad for a session (returns empty string if none).
+    func loadScratchpad(sessionID: String) -> String {
+        let url = sessionDirectory(for: sessionID).appendingPathComponent("scratchpad.md")
+        return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+    }
+
     // MARK: - Images
 
     func saveImage(sessionID: String, imageData: Data) -> String {

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -240,6 +240,17 @@ struct ContentView: View {
                 .padding(.vertical, 8)
             }
 
+            // Collapsible scratchpad during live session
+            if controllerState.isRunning {
+                Divider()
+                ScratchpadSection(
+                    text: Binding(
+                        get: { controllerState.scratchpadText },
+                        set: { liveSessionController?.updateScratchpad($0) }
+                    )
+                )
+            }
+
             Divider()
 
             // Bottom bar: live indicator + model
@@ -478,5 +489,37 @@ struct ContentView: View {
         case .confirmDownload:
             liveSessionController?.downloadModelOnly(settings: settings)
         }
+    }
+}
+
+// MARK: - Scratchpad Section
+
+private struct ScratchpadSection: View {
+    @Binding var text: String
+    @AppStorage("isScratchpadExpanded") private var isExpanded = true
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            TextEditor(text: $text)
+                .font(.system(size: 12))
+                .scrollContentBackground(.hidden)
+                .frame(height: 100)
+                .padding(4)
+                .background(Color(nsColor: .textBackgroundColor).opacity(0.5))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        } label: {
+            HStack(spacing: 6) {
+                Text("My Notes")
+                    .font(.system(size: 12, weight: .medium))
+                if !text.isEmpty {
+                    Circle()
+                        .fill(Color.accentColor)
+                        .frame(width: 5, height: 5)
+                }
+                Spacer()
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
     }
 }


### PR DESCRIPTION
## Summary

Add a collapsible "My Notes" panel to the live session view that lets users take notes during meetings. Notes are persisted per-session and fed into the notes generation pipeline as high-signal context.

- Per-session `scratchpad.md` stored alongside transcript artifacts in `SessionRepository`
- Debounced auto-save (1s) during recording, with flush on session finalization
- Scratchpad content injected into the LLM notes prompt as additional user context
- Collapsible "My Notes" UI section with a dot indicator when content is present

Closes #287