### PR TITLE
Update Homebrew cask for 1.42.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.41.2"
-  sha256 "5c7eea7884f5e60353069ae0f6c9fedc4cea2b194ed6bbe4954debb40b6c1ce8"
+  version "1.42.0"
+  sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary

- Bump Homebrew cask version from 1.41.2 to 1.42.0 with updated SHA256

Catches up the cask to the latest release. Only changes are version string and sha256 in `Casks/openoats.rb`.