### PR TITLE
feat: add EventKit calendar integration for auto-titling sessions

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppContainer.swift
+++ b/OpenOats/Sources/OpenOats/App/AppContainer.swift
@@ -19,6 +19,10 @@ final class AppContainer {
     /// even when detection is not enabled.
     private(set) var notificationService: NotificationService?
 
+    /// Calendar manager for looking up current events.
+    /// Created when the calendar integration setting is enabled.
+    private(set) var calendarManager: CalendarManager?
+
     private var didSeedInitialData = false
     private var didInitializeServices = false
 
@@ -80,6 +84,7 @@ final class AppContainer {
             defaults.set(true, forKey: "hasAcknowledgedRecordingConsent")
             defaults.set(false, forKey: "meetingAutoDetectEnabled")
             defaults.set(false, forKey: "hasShownAutoDetectExplanation")
+            defaults.set(false, forKey: "calendarIntegrationEnabled")
             defaults.set(false, forKey: "hideFromScreenShare")
             defaults.set(true, forKey: "showLiveTranscript")
             defaults.set(false, forKey: "saveAudioRecording")
@@ -190,6 +195,8 @@ final class AppContainer {
         controller.setup(settings: settings)
         // Expose the notification service for batch completion notifications
         notificationService = controller.notificationService
+        // Share the calendar manager with the detection controller for auto-detected sessions
+        controller.calendarManager = calendarManager
         coordinator.activeSettings = settings
         coordinator.startDetectionEventLoop(controller)
     }
@@ -201,6 +208,23 @@ final class AppContainer {
         detectionController?.teardown()
         detectionController = nil
         // NotificationService remains accessible if already set (for batch notifications)
+    }
+
+    /// Enable or disable calendar event lookup based on the user setting.
+    /// When enabled for the first time, creates the CalendarManager and requests access.
+    func updateCalendarIntegration(enabled: Bool) {
+        if enabled {
+            if calendarManager == nil {
+                calendarManager = CalendarManager()
+            }
+            if calendarManager?.accessState == .notDetermined {
+                Task {
+                    _ = await calendarManager?.requestAccess()
+                }
+            }
+        } else {
+            calendarManager = nil
+        }
     }
 
     func seedIfNeeded(coordinator: AppCoordinator) async {

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -118,7 +118,11 @@ final class LiveSessionController {
     func startSession(settings: AppSettings) {
         coordinator.suggestionEngine?.clear()
         coordinator.sidecastEngine?.clear()
-        coordinator.handle(.userStarted(.manual()), settings: settings)
+        let calEvent = settings.calendarIntegrationEnabled
+            ? container.calendarManager?.currentEvent()
+            : nil
+        let metadata = MeetingMetadata.manual(calendarEvent: calEvent)
+        coordinator.handle(.userStarted(metadata), settings: settings)
     }
 
     func stopSession(settings: AppSettings) {

--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -79,6 +79,10 @@ final class MeetingDetectionController {
     /// Used to suppress detection prompts during active recording.
     var isSessionActive: () -> Bool = { false }
 
+    /// Calendar manager for looking up current events during auto-detected sessions.
+    /// Set by the container when calendar integration is enabled.
+    var calendarManager: CalendarManager?
+
     // MARK: - Init
 
     init() {
@@ -200,6 +204,7 @@ final class MeetingDetectionController {
         }
 
         dismissedEvents.removeAll()
+        calendarManager = nil
         activeSettings = nil
         isEnabled = false
         detectedApp = nil
@@ -356,16 +361,18 @@ final class MeetingDetectionController {
     private func handleDetectionAccepted() {
         Task {
             let app = await meetingDetector?.detectedApp
+            let calEvent = calendarManager?.currentEvent()
             let context = DetectionContext(
                 signal: app.map { .appLaunched($0) } ?? .audioActivity,
                 detectedAt: Date(),
                 meetingApp: app,
-                calendarEvent: nil
+                calendarEvent: calEvent
             )
+            let title = calEvent?.title ?? app?.name
             let metadata = MeetingMetadata(
                 detectionContext: context,
-                calendarEvent: nil,
-                title: app?.name,
+                calendarEvent: calEvent,
+                title: title,
                 startedAt: Date(),
                 endedAt: nil
             )

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -432,7 +432,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         if coordinator.isRecording {
             coordinator.handle(.userStopped, settings: settings)
         } else {
-            coordinator.handle(.userStarted(.manual()), settings: settings)
+            let calEvent = settings.calendarIntegrationEnabled
+                ? container?.calendarManager?.currentEvent()
+                : nil
+            coordinator.handle(.userStarted(.manual(calendarEvent: calEvent)), settings: settings)
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
+++ b/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
@@ -68,14 +68,17 @@ struct MeetingMetadata: Sendable, Equatable, Codable {
     let startedAt: Date
     var endedAt: Date?
 
-    static func manual() -> MeetingMetadata {
+    static func manual(calendarEvent: CalendarEvent? = nil) -> MeetingMetadata {
         let now = Date()
         return MeetingMetadata(
             detectionContext: DetectionContext(
-                signal: .manual, detectedAt: now,
-                meetingApp: nil, calendarEvent: nil
+                signal: calendarEvent.map { .calendarEvent($0) } ?? .manual,
+                detectedAt: now,
+                meetingApp: nil,
+                calendarEvent: calendarEvent
             ),
-            calendarEvent: nil, title: nil,
+            calendarEvent: calendarEvent,
+            title: calendarEvent?.title,
             startedAt: now, endedAt: nil
         )
     }

--- a/OpenOats/Sources/OpenOats/Info.plist
+++ b/OpenOats/Sources/OpenOats/Info.plist
@@ -35,6 +35,8 @@
     <string>OpenOats needs microphone access to transcribe your voice in real-time during conversations.</string>
     <key>NSAudioCaptureUsageDescription</key>
     <string>OpenOats needs system audio recording access to transcribe other participants in real time.</string>
+    <key>NSCalendarsUsageDescription</key>
+    <string>OpenOats can use your calendar to automatically title meeting sessions with the event name and show participant info.</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>
     <key>SUFeedURL</key>

--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -1,0 +1,116 @@
+import EventKit
+import Foundation
+
+/// Wraps EKEventStore to look up calendar events overlapping the current time.
+/// All access is gated behind the `calendarIntegrationEnabled` setting — the app
+/// only requests calendar permission when the user explicitly enables the feature.
+@MainActor
+final class CalendarManager {
+    private let store = EKEventStore()
+
+    enum AccessState {
+        case notDetermined
+        case authorized
+        case denied
+    }
+
+    /// Current authorization status, observed at init and after requesting access.
+    private(set) var accessState: AccessState
+
+    init() {
+        self.accessState = Self.currentAccessState()
+    }
+
+    // MARK: - Authorization
+
+    /// Request calendar access. Returns true if authorized.
+    func requestAccess() async -> Bool {
+        do {
+            let granted = try await store.requestFullAccessToEvents()
+            accessState = granted ? .authorized : .denied
+            return granted
+        } catch {
+            accessState = .denied
+            return false
+        }
+    }
+
+    // MARK: - Event Lookup
+
+    /// Find the calendar event that best overlaps the given date (typically now).
+    /// Returns nil if no event is found or access is not authorized.
+    func currentEvent(at date: Date = Date()) -> CalendarEvent? {
+        guard accessState == .authorized else { return nil }
+
+        // Look for events in a window: started up to 15 min ago through 15 min from now
+        let windowStart = date.addingTimeInterval(-15 * 60)
+        let windowEnd = date.addingTimeInterval(15 * 60)
+
+        let predicate = store.predicateForEvents(
+            withStart: windowStart,
+            end: windowEnd,
+            calendars: nil
+        )
+        let events = store.events(matching: predicate)
+
+        // Prefer the event whose start is closest to now, breaking ties by duration
+        let best = events
+            .filter { !$0.isAllDay }
+            .min { a, b in
+                let distA = abs(a.startDate.timeIntervalSince(date))
+                let distB = abs(b.startDate.timeIntervalSince(date))
+                if distA != distB { return distA < distB }
+                return a.startDate < b.startDate
+            }
+
+        guard let best else { return nil }
+        return CalendarEvent(from: best)
+    }
+
+    // MARK: - Helpers
+
+    private static func currentAccessState() -> AccessState {
+        switch EKEventStore.authorizationStatus(for: .event) {
+        case .fullAccess:
+            return .authorized
+        case .notDetermined:
+            return .notDetermined
+        default:
+            return .denied
+        }
+    }
+}
+
+// MARK: - EKEvent → CalendarEvent
+
+extension CalendarEvent {
+    init(from event: EKEvent) {
+        self.init(
+            id: event.eventIdentifier ?? UUID().uuidString,
+            title: event.title ?? "Untitled Event",
+            startDate: event.startDate,
+            endDate: event.endDate,
+            organizer: event.organizer?.name,
+            participants: (event.attendees ?? []).map { Participant(from: $0) },
+            isOnlineMeeting: event.url != nil || Self.looksLikeOnlineMeeting(event),
+            meetingURL: event.url
+        )
+    }
+
+    private static func looksLikeOnlineMeeting(_ event: EKEvent) -> Bool {
+        let notes = (event.notes ?? "").lowercased()
+        let location = (event.location ?? "").lowercased()
+        let keywords = ["zoom.us", "teams.microsoft", "meet.google", "facetime", "webex"]
+        return keywords.contains { notes.contains($0) || location.contains($0) }
+    }
+}
+
+extension Participant {
+    init(from attendee: EKParticipant) {
+        self.init(
+            name: attendee.name,
+            email: attendee.url.absoluteString
+                .replacingOccurrences(of: "mailto:", with: "")
+        )
+    }
+}

--- a/OpenOats/Sources/OpenOats/OpenOats.entitlements
+++ b/OpenOats/Sources/OpenOats/OpenOats.entitlements
@@ -4,5 +4,7 @@
 <dict>
     <key>com.apple.security.device.audio-input</key>
     <true/>
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
 </dict>
 </plist>

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -562,6 +562,17 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _calendarIntegrationEnabled: Bool
+    var calendarIntegrationEnabled: Bool {
+        get { access(keyPath: \.calendarIntegrationEnabled); return _calendarIntegrationEnabled }
+        set {
+            withMutation(keyPath: \.calendarIntegrationEnabled) {
+                _calendarIntegrationEnabled = newValue
+                defaults.set(newValue, forKey: "calendarIntegrationEnabled")
+            }
+        }
+    }
+
     // MARK: - Privacy Settings
 
     @ObservationIgnored nonisolated(unsafe) private var _hasAcknowledgedRecordingConsent: Bool
@@ -797,6 +808,7 @@ final class SettingsStore {
             ? defaults.integer(forKey: "silenceTimeoutMinutes") : 15
         self._detectionLogEnabled = defaults.bool(forKey: "detectionLogEnabled")
         self._hasShownAutoDetectExplanation = defaults.bool(forKey: "hasShownAutoDetectExplanation")
+        self._calendarIntegrationEnabled = defaults.bool(forKey: "calendarIntegrationEnabled")
 
         // Privacy Settings
         self._hasAcknowledgedRecordingConsent = defaults.bool(forKey: "hasAcknowledgedRecordingConsent")

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -372,6 +372,9 @@ struct ContentView: View {
 
             await controller.performInitialSetup()
 
+            // Setup calendar integration if enabled
+            container.updateCalendarIntegration(enabled: settings.calendarIntegrationEnabled)
+
             // Setup meeting detection if enabled
             if settings.meetingAutoDetectEnabled {
                 container.enableDetection(settings: settings, coordinator: coordinator)
@@ -390,6 +393,9 @@ struct ContentView: View {
             } else {
                 container.disableDetection(coordinator: coordinator)
             }
+        }
+        .onChange(of: settings.calendarIntegrationEnabled) {
+            container.updateCalendarIntegration(enabled: settings.calendarIntegrationEnabled)
         }
         .onChange(of: settings.sidebarMode) {
             if settings.sidebarMode == .classicSuggestions {

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -174,6 +174,15 @@ private struct GeneralSettingsTab: View {
                     .font(.system(size: 12))
                 }
 
+                Section("Calendar") {
+                    Toggle("Auto-title sessions from calendar", isOn: $settings.calendarIntegrationEnabled)
+                        .font(.system(size: 12))
+
+                    Text("When enabled, OpenOats looks up your calendar for a matching event and uses its title for the session. Calendar access is requested only when you enable this.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+
                 if !settings.ignoredAppBundleIDs.isEmpty {
                     Section("Ignored Apps") {
                         Text("These apps won't trigger meeting detection notifications.")


### PR DESCRIPTION
Closes #255

## Summary
- Adds opt-in EventKit integration that auto-populates session titles from calendar events
- New `CalendarManager` wrapping `EKEventStore` — queries events overlapping the current time window (±15 min)
- `calendarIntegrationEnabled` setting in General > Calendar (off by default)
- Calendar permission is only requested when the user enables the feature
- Wired into both auto-detected sessions and manual starts (main window + hotkey)
- Calendar event title, participants, and organizer attached to `MeetingMetadata`

## Changes
- **CalendarManager.swift** (new): EventKit wrapper with access request and event lookup
- **SettingsStore.swift**: New `calendarIntegrationEnabled` boolean setting
- **Info.plist**: Added `NSCalendarsUsageDescription`
- **OpenOats.entitlements**: Added `com.apple.security.personal-information.calendars`
- **AppContainer.swift**: Calendar manager lifecycle + wiring to detection controller
- **MeetingDetectionController.swift**: Uses calendar manager in detection acceptance flow
- **MeetingTypes.swift**: `manual()` factory accepts optional `CalendarEvent`
- **LiveSessionController.swift**: Manual starts query calendar when enabled
- **OpenOatsApp.swift**: Hotkey toggle queries calendar when enabled
- **ContentView.swift**: Initializes calendar integration on appear + observes setting changes
- **SettingsView.swift**: Calendar toggle in General settings tab

## Test plan
- [ ] Enable calendar integration in Settings > General > Calendar
- [ ] Verify macOS calendar permission prompt appears
- [ ] Start a manual session while a calendar event is active — session should be titled with event name
- [ ] Start a session with no overlapping calendar event — should remain "Untitled"
- [ ] Disable calendar integration — sessions should not query calendar
- [ ] Auto-detected sessions should also pick up calendar event titles when enabled