### PR TITLE
Update Homebrew cask for 1.43.2

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.42.0"
-  sha256 "0019dfc4b32d63c1392aa264aed2253c1e0c2fb09216f8e2cc269bbfb8bb49b5"
+  version "1.43.2"
+  sha256 "05106ca4cc099e34d118628d573c5f1728e0243f4e06398d380f4959aee88a10"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Automated follow-up from the v1.43.2 release workflow after direct pushes to protected `main` were blocked by branch protection.\n\nThis updates the Homebrew cask version and SHA256 to match the published v1.43.2 DMG.