### PR TITLE
fix: prevent stack buffer overflow in camera device enumeration

### DIFF
--- a/OpenOats/Sources/OpenOats/Meeting/CameraActivityMonitor.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CameraActivityMonitor.swift
@@ -170,11 +170,21 @@ final class CoreMediaIOSignalSource: CameraSignalSource, @unchecked Sendable {
         ) == kCMIOHardwareNoError else { return [] }
 
         let count = Int(dataSize) / MemoryLayout<CMIOObjectID>.size
-        var deviceIDs = [CMIOObjectID](repeating: 0, count: count)
+        guard count > 0 else { return [] }
+
+        // Use explicit heap allocation to avoid stack buffer overflow when
+        // CoreMediaIO writes device IDs through the raw pointer.
+        let buffer = UnsafeMutableBufferPointer<CMIOObjectID>.allocate(capacity: count)
+        defer { buffer.deallocate() }
+        buffer.initialize(repeating: 0)
+
         var dataUsed: UInt32 = 0
         guard CMIOObjectGetPropertyData(
-            CMIOObjectID(kCMIOObjectSystemObject), &address, 0, nil, dataSize, &deviceIDs, &dataUsed
+            CMIOObjectID(kCMIOObjectSystemObject), &address, 0, nil, dataSize, buffer.baseAddress!, &dataUsed
         ) == kCMIOHardwareNoError else { return [] }
+
+        let actualCount = min(Int(dataUsed) / MemoryLayout<CMIOObjectID>.size, count)
+        let deviceIDs = Array(buffer.prefix(actualCount))
 
         return deviceIDs.filter { deviceID in
             var streamAddress = CMIOObjectPropertyAddress(


### PR DESCRIPTION
## Summary
- Fixes launch crash (SIGABRT / `__stack_chk_fail`) on the `com.openoats.camera-listener` queue
- `CMIOObjectGetPropertyData` writes through a raw pointer; Swift's Array bridging used a stack buffer that could overflow when the device list changed between size query and data fetch
- Switches to explicit heap allocation via `UnsafeMutableBufferPointer` and clamps result count to allocated capacity

## Test plan
- [x] Builds cleanly (`swift build`)
- [ ] Launch app with camera connected — no crash
- [ ] Hot-plug camera during session — no crash