### PR TITLE
Update Homebrew cask for 1.45.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.44.3"
-  sha256 "94b5439f45429b82f554ffce46fbed8605f55563c9b4ba3b575357150a1b97ca"
+  version "1.45.0"
+  sha256 "d11b873e31bb8b3a2afb9d9d4de0337beadc9a579b50fc43e9d9de04c94c7c14"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Update Homebrew cask to v1.45.0 with new DMG URL and SHA256

## Test plan
- [ ] Verify `brew install --cask openoats` installs 1.45.0