### PR TITLE
fix: guard remaining UNUserNotificationCenter call sites

### DIFF
--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -367,6 +367,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func showBackgroundModeHintIfNeeded() {
         guard !defaults.bool(forKey: "hasShownBackgroundModeHint") else { return }
         guard settings?.meetingAutoDetectEnabled == true else { return }
+        // UNUserNotificationCenter asserts when there's no bundle identifier
+        // (e.g. when built and run via `swift run`).
+        guard Bundle.main.bundleIdentifier != nil else { return }
 
         defaults.set(true, forKey: "hasShownBackgroundModeHint")
 

--- a/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
@@ -4,6 +4,11 @@ import UserNotifications
 /// Manages macOS notification delivery for meeting detection prompts.
 @MainActor
 final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
+    /// UNUserNotificationCenter requires a valid bundle identifier and will
+    /// assert (SIGABRT) on every API call when one isn't present. This is the
+    /// case when the app is built and run unbundled (e.g. `swift run`).
+    /// When false, all notification methods become no-ops.
+    private let isAvailable: Bool = Bundle.main.bundleIdentifier != nil
     private var hasRequestedPermission = false
     private var pendingTimeoutTask: Task<Void, Never>?
 
@@ -41,9 +46,7 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     // MARK: - Category Registration
 
     private func registerCategory() {
-        // UNUserNotificationCenter requires a valid bundle identifier;
-        // guard so the app doesn't crash when run unbundled (e.g. swift run).
-        guard Bundle.main.bundleIdentifier != nil else { return }
+        guard isAvailable else { return }
 
         // "Start Transcribing" is the default action (tap on notification body).
         // Only secondary actions appear in the dropdown.
@@ -84,6 +87,7 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     // MARK: - Permission
 
     private func ensurePermission() async -> Bool {
+        guard isAvailable else { return false }
         if hasRequestedPermission {
             let settings = await UNUserNotificationCenter.current().notificationSettings()
             return settings.authorizationStatus == .authorized
@@ -184,6 +188,7 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     func cancelPending() {
         pendingTimeoutTask?.cancel()
         pendingTimeoutTask = nil
+        guard isAvailable else { return }
         UNUserNotificationCenter.current().removeDeliveredNotifications(
             withIdentifiers: ["meeting-detection"]
         )


### PR DESCRIPTION
## Summary
Follow-up to #311. That PR only guarded `registerCategory()`, but the app would still crash later — the first time a meeting was actually detected — because every other call site to `UNUserNotificationCenter.current()` also asserts when there is no bundle identifier (e.g. when running via `swift run`).

I hit this myself: app launched fine after #311, then crashed ~33 hours later in `NotificationService.ensurePermission()` at line 94 the first time meeting detection fired.

## Changes
- `NotificationService`: cache `isAvailable` once at init (`Bundle.main.bundleIdentifier != nil`) and gate every public entry point on it. `postMeetingDetected` and `postBatchCompleted` are already covered transitively via `ensurePermission`.
- `OpenOatsApp.showBackgroundModeHintIfNeeded`: same guard.

When `isAvailable` is false, all notification methods become no-ops — which is the only sensible behavior, since `UNUserNotificationCenter` literally cannot function without a bundle ID.

## Test plan
- [x] `swift build` succeeds
- [x] `swift run OpenOats` no longer crashes when meeting detection fires
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)