### PR TITLE
Notes Performance & Generation UX

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -24,6 +24,9 @@ struct NotesState {
     var audioFileURL: URL?
     /// Whether audio is currently playing.
     var isPlayingAudio: Bool = false
+    /// Sessions whose notes were freshly generated while the user was on a different session.
+    /// Cleared when the user opens that session. Used to show the blue "unread" indicator.
+    var freshlyGeneratedSessionIDs: Set<String> = []
 }
 
 enum CleanupStatus: Equatable {
@@ -126,6 +129,7 @@ final class NotesController {
         state.selectedSessionDirectory = coordinator.sessionRepository.sessionsDirectoryURL
             .appendingPathComponent(sessionID, isDirectory: true)
         state.showingOriginal = false
+        state.freshlyGeneratedSessionIDs.remove(sessionID)
         coordinator.batchTextCleaner.cancel()
         syncCleanupStatus()
 
@@ -256,10 +260,15 @@ final class NotesController {
             await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
             await loadHistory()
 
-            // Only update visible UI state if the user is still on this session
-            guard state.selectedSessionID == sessionID else { return }
-            state.loadedNotes = notes
-            state.notesGenerationStatus = .completed
+            if state.selectedSessionID == sessionID {
+                // User is still on this session — update UI directly
+                state.loadedNotes = notes
+                state.notesGenerationStatus = .completed
+            } else {
+                // User has moved away — show the blue "unread" badge in the sidebar
+                state.freshlyGeneratedSessionIDs.insert(sessionID)
+            }
+            return
         } else if state.selectedSessionID == sessionID {
             if let error = coordinator.notesEngine.error {
                 state.notesGenerationStatus = .error(error)
@@ -420,6 +429,18 @@ final class NotesController {
     /// Notes engine error for display (when not yet mapped to status).
     var notesEngineError: String? {
         coordinator.notesEngine.error
+    }
+
+    /// True whenever any session's notes are being generated.
+    var isAnyGenerationInProgress: Bool {
+        generatingSessionID != nil
+    }
+
+    /// Display name of the session currently being generated (for tooltip messaging).
+    var generatingSessionName: String {
+        guard let id = generatingSessionID else { return "" }
+        let title = state.sessionHistory.first { $0.id == id }?.title ?? ""
+        return title.isEmpty ? "Untitled" : title
     }
 
     // MARK: - Private

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -436,6 +436,11 @@ final class NotesController {
         generatingSessionID != nil
     }
 
+    /// Returns true if the given session is currently being generated.
+    func isGenerating(sessionID: String) -> Bool {
+        generatingSessionID == sessionID
+    }
+
     /// Display name of the session currently being generated (for tooltip messaging).
     var generatingSessionName: String {
         guard let id = generatingSessionID else { return "" }

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -54,6 +54,10 @@ final class NotesController {
     /// Observation polling task for engine state mapping.
     @ObservationIgnored nonisolated(unsafe) private var engineObservationTask: Task<Void, Never>?
 
+    /// The session ID that triggered the currently in-progress generation, if any.
+    /// Used to prevent bleeding status/content onto a different session when the user switches mid-generation.
+    @ObservationIgnored private var generatingSessionID: String?
+
     /// Audio player for session recordings.
     @ObservationIgnored private var audioPlayer: AVPlayer?
     @ObservationIgnored private var playerObservation: Any?
@@ -125,14 +129,18 @@ final class NotesController {
         coordinator.batchTextCleaner.cancel()
         syncCleanupStatus()
 
-        Task {
-            let notes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
-            let transcript = await coordinator.sessionRepository.loadTranscript(sessionID: sessionID)
-            let audioURL = await coordinator.sessionRepository.audioFileURL(for: sessionID)
+        // If generation is running for a different session, don't show its status here
+        if generatingSessionID != sessionID {
+            state.notesGenerationStatus = .idle
+            state.streamingMarkdown = ""
+        }
 
-            state.loadedNotes = notes
-            state.loadedTranscript = transcript
-            state.audioFileURL = audioURL
+        Task {
+            let data = await coordinator.sessionRepository.loadSessionData(sessionID: sessionID)
+
+            state.loadedNotes = data.notes
+            state.loadedTranscript = data.transcript
+            state.audioFileURL = data.audioURL
 
             let session = state.sessionHistory.first { $0.id == sessionID }
             if let snapID = session?.templateSnapshot?.id {
@@ -141,7 +149,7 @@ final class NotesController {
                 state.selectedTemplate = coordinator.templateStore.template(for: TemplateStore.genericID)
             }
 
-            let hasAny = transcript.contains { $0.cleanedText != nil }
+            let hasAny = data.transcript.contains { $0.cleanedText != nil }
             state.cleanupStatus = hasAny ? .completed : .idle
         }
     }
@@ -196,38 +204,27 @@ final class NotesController {
             ?? coordinator.templateStore.template(for: TemplateStore.genericID)
             ?? TemplateStore.builtInTemplates.first!
 
+        // Capture transcript immediately — before any suspension — so session switches
+        // mid-load don't swap in the wrong session's records.
+        let capturedTranscript = state.loadedTranscript
+
+        generatingSessionID = sessionID
         state.notesGenerationStatus = .generating
         state.streamingMarkdown = ""
 
         Task {
             let scratchpad = await coordinator.sessionRepository.loadScratchpad(sessionID: sessionID)
-            await coordinator.notesEngine.generate(
-                transcript: state.loadedTranscript,
+
+            coordinator.notesEngine.generate(
+                transcript: capturedTranscript,
                 template: template,
                 settings: settings,
                 scratchpad: scratchpad.isEmpty ? nil : scratchpad
-            )
-
-            if !coordinator.notesEngine.generatedMarkdown.isEmpty {
-                let generatedMarkdown = coordinator.notesEngine.generatedMarkdown
-                let session = state.sessionHistory.first { $0.id == sessionID }
-                let heading = Self.notesHeading(title: session?.title, date: session?.startedAt ?? Date())
-                let markdown = heading + generatedMarkdown
-
-                let notes = GeneratedNotes(
-                    template: coordinator.templateStore.snapshot(of: template),
-                    generatedAt: Date(),
-                    markdown: markdown
-                )
-                await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
-                state.loadedNotes = notes
-
-                await loadHistory()
-                state.notesGenerationStatus = .completed
-            } else if let error = coordinator.notesEngine.error {
-                state.notesGenerationStatus = .error(error)
-            } else {
-                state.notesGenerationStatus = .idle
+            ) { [weak self] in
+                guard let self else { return }
+                Task {
+                    await self.finishGeneration(sessionID: sessionID, template: template)
+                }
             }
         }
     }
@@ -241,8 +238,40 @@ final class NotesController {
         generateNotes(sessionID: sessionID, settings: settings)
     }
 
+    private func finishGeneration(sessionID: String, template: MeetingTemplate) async {
+        defer { generatingSessionID = nil }
+
+        // Always save notes to disk regardless of which session the user is now on
+        if !coordinator.notesEngine.generatedMarkdown.isEmpty {
+            let generatedMarkdown = coordinator.notesEngine.generatedMarkdown
+            let session = state.sessionHistory.first { $0.id == sessionID }
+            let heading = Self.notesHeading(title: session?.title, date: session?.startedAt ?? Date())
+            let markdown = heading + generatedMarkdown
+
+            let notes = GeneratedNotes(
+                template: coordinator.templateStore.snapshot(of: template),
+                generatedAt: Date(),
+                markdown: markdown
+            )
+            await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
+            await loadHistory()
+
+            // Only update visible UI state if the user is still on this session
+            guard state.selectedSessionID == sessionID else { return }
+            state.loadedNotes = notes
+            state.notesGenerationStatus = .completed
+        } else if state.selectedSessionID == sessionID {
+            if let error = coordinator.notesEngine.error {
+                state.notesGenerationStatus = .error(error)
+            } else {
+                state.notesGenerationStatus = .idle
+            }
+        }
+    }
+
     func cancelGeneration() {
         coordinator.notesEngine.cancel()
+        generatingSessionID = nil
         state.notesGenerationStatus = .idle
         state.streamingMarkdown = ""
     }
@@ -445,14 +474,13 @@ final class NotesController {
 
     private func syncGenerationStatus() {
         let engine = coordinator.notesEngine
-        if engine.isGenerating {
-            if state.notesGenerationStatus != .generating {
-                state.notesGenerationStatus = .generating
-            }
-            if state.streamingMarkdown != engine.generatedMarkdown {
-                state.streamingMarkdown = engine.generatedMarkdown
-            }
+        // Only propagate engine state if the generation belongs to the currently selected session
+        guard engine.isGenerating, generatingSessionID == state.selectedSessionID else { return }
+        if state.notesGenerationStatus != .generating {
+            state.notesGenerationStatus = .generating
         }
-        // Don't override .error or .completed set by generateNotes
+        if state.streamingMarkdown != engine.generatedMarkdown {
+            state.streamingMarkdown = engine.generatedMarkdown
+        }
     }
 }

--- a/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
@@ -36,13 +36,15 @@ final class NotesEngine {
         self.mode = mode
     }
 
-    /// Streams note generation from the LLM, updating `generatedMarkdown` in real time.
+    /// Starts streaming note generation from the LLM, updating `generatedMarkdown` in real time.
+    /// Returns immediately — generation runs in the background. Call `onFinished` to react when done.
     func generate(
         transcript: [SessionRecord],
         template: MeetingTemplate,
         settings: AppSettings,
-        scratchpad: String? = nil
-    ) async {
+        scratchpad: String? = nil,
+        onFinished: @escaping @MainActor () -> Void = {}
+    ) {
         currentTask?.cancel()
         isGenerating = true
         generatedMarkdown = ""
@@ -51,6 +53,7 @@ final class NotesEngine {
         if case .scripted(let markdown) = mode {
             generatedMarkdown = markdown
             isGenerating = false
+            onFinished()
             return
         }
 
@@ -68,6 +71,7 @@ final class NotesEngine {
             guard let ollamaURL = OpenRouterClient.chatCompletionsURL(from: settings.ollamaBaseURL) else {
                 error = "Invalid Ollama URL: \(settings.ollamaBaseURL)"
                 isGenerating = false
+                onFinished()
                 return
             }
             baseURL = ollamaURL
@@ -77,6 +81,7 @@ final class NotesEngine {
             guard let mlxURL = OpenRouterClient.chatCompletionsURL(from: settings.mlxBaseURL) else {
                 error = "Invalid MLX URL: \(settings.mlxBaseURL)"
                 isGenerating = false
+                onFinished()
                 return
             }
             baseURL = mlxURL
@@ -86,6 +91,7 @@ final class NotesEngine {
             guard let openAIURL = OpenRouterClient.chatCompletionsURL(from: settings.openAILLMBaseURL) else {
                 error = "Invalid OpenAI Compatible URL: \(settings.openAILLMBaseURL)"
                 isGenerating = false
+                onFinished()
                 return
             }
             baseURL = openAIURL
@@ -112,10 +118,14 @@ final class NotesEngine {
                     maxTokens: 4096,
                     baseURL: baseURL
                 )
-                guard let stream else { return }
+                guard let stream else {
+                    self?.isGenerating = false
+                    onFinished()
+                    return
+                }
 
                 for try await chunk in stream {
-                    guard !Task.isCancelled else { return }
+                    guard !Task.isCancelled else { break }
                     self?.generatedMarkdown += chunk
                 }
             } catch {
@@ -124,9 +134,9 @@ final class NotesEngine {
                 }
             }
             self?.isGenerating = false
+            onFinished()
         }
         currentTask = task
-        await task.value
     }
 
     func cancel() {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -435,7 +435,7 @@ actor SessionRepository {
         }
 
         // Mirror to notesFolderPath
-        mirrorNotesArtifacts(sessionID: sessionID)
+        scheduleMirror(sessionID: sessionID)
     }
 
     // MARK: - Notes
@@ -464,8 +464,8 @@ actor SessionRepository {
             writeSessionMetadata(sessionMeta, sessionID: sessionID)
         }
 
-        // Mirror to notesFolderPath
-        mirrorNotesArtifacts(sessionID: sessionID)
+        // Mirror to notesFolderPath — pass markdown through to avoid re-reading from disk
+        scheduleMirror(sessionID: sessionID, notesMarkdown: notes.markdown)
     }
 
     func loadNotes(sessionID: String) -> GeneratedNotes? {
@@ -648,7 +648,7 @@ actor SessionRepository {
         if var meta = loadSessionMetadataFile(sessionID: sessionID) {
             meta.title = title.isEmpty ? nil : title
             writeSessionMetadata(meta, sessionID: sessionID)
-            mirrorNotesArtifacts(sessionID: sessionID)
+            scheduleMirror(sessionID: sessionID)
             return
         }
 
@@ -993,6 +993,80 @@ actor SessionRepository {
         return playable.first
     }
 
+    // MARK: - Concurrent Session Loading
+
+    /// Loads notes, transcript, and audio URL concurrently off the actor, then returns all three.
+    /// Prefer this over three separate awaited calls to avoid sequential actor hops.
+    nonisolated func loadSessionData(sessionID: String) async -> (notes: GeneratedNotes?, transcript: [SessionRecord], audioURL: URL?) {
+        let sessDir = sessionsDirectoryURL
+        let dir = sessDir.appendingPathComponent(sessionID, isDirectory: true)
+
+        async let notes = Task.detached(priority: .userInitiated) {
+            SessionRepository.readNotes(sessionID: sessionID, dir: dir, sessionsDirectory: sessDir)
+        }.value
+        async let transcript = Task.detached(priority: .userInitiated) {
+            SessionRepository.readTranscript(sessionID: sessionID, dir: dir, sessionsDirectory: sessDir)
+        }.value
+        async let audioURL = Task.detached(priority: .userInitiated) {
+            SessionRepository.readAudioFileURL(dir: dir)
+        }.value
+
+        return await (notes, transcript, audioURL)
+    }
+
+    private nonisolated static func readNotes(sessionID: String, dir: URL, sessionsDirectory: URL) -> GeneratedNotes? {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let mdURL = dir.appendingPathComponent("notes.md")
+        let metaURL = dir.appendingPathComponent("notes.meta.json")
+
+        if let markdown = try? String(contentsOf: mdURL, encoding: .utf8),
+           let metaData = try? Data(contentsOf: metaURL),
+           let meta = try? decoder.decode(NotesMeta.self, from: metaData) {
+            return GeneratedNotes(template: meta.templateSnapshot, generatedAt: meta.generatedAt, markdown: markdown)
+        }
+
+        return LegacySessionReader.loadNotes(sessionID: sessionID, sessionsDirectory: sessionsDirectory)
+    }
+
+    private nonisolated static func readTranscript(sessionID: String, dir: URL, sessionsDirectory: URL) -> [SessionRecord] {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        func parse(_ content: String) -> [SessionRecord] {
+            content.components(separatedBy: "\n").filter { !$0.isEmpty }.compactMap { line in
+                guard let data = line.data(using: .utf8) else { return nil }
+                return try? decoder.decode(SessionRecord.self, from: data)
+            }
+        }
+
+        let finalURL = dir.appendingPathComponent("transcript.final.jsonl")
+        if FileManager.default.fileExists(atPath: finalURL.path),
+           let content = try? String(contentsOf: finalURL, encoding: .utf8) {
+            let records = parse(content)
+            if !records.isEmpty { return records }
+        }
+
+        let liveURL = dir.appendingPathComponent("transcript.live.jsonl")
+        if FileManager.default.fileExists(atPath: liveURL.path),
+           let content = try? String(contentsOf: liveURL, encoding: .utf8) {
+            let records = parse(content)
+            if !records.isEmpty { return records }
+        }
+
+        return LegacySessionReader.loadTranscript(sessionID: sessionID, sessionsDirectory: sessionsDirectory)
+    }
+
+    private nonisolated static func readAudioFileURL(dir: URL) -> URL? {
+        let audioDir = dir.appendingPathComponent("audio", isDirectory: true)
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: audioDir.path),
+              let contents = try? fm.contentsOfDirectory(at: audioDir, includingPropertiesForKeys: nil)
+        else { return nil }
+        let skipExtensions: Set<String> = ["caf", "json"]
+        return contents.filter { !skipExtensions.contains($0.pathExtension.lowercased()) }.first
+    }
+
     // MARK: - Private Helpers
 
     private func sessionDirectory(for sessionID: String) -> URL {
@@ -1096,13 +1170,38 @@ actor SessionRepository {
 
     // MARK: - Notes Folder Mirroring
 
-    /// Mirror notes.md and plain-text transcript to the user-visible notesFolderPath.
-    private func mirrorNotesArtifacts(sessionID: String) {
+    /// Schedule a background mirror of the session's notes and transcript to notesFolderPath.
+    /// Captures all actor-isolated state before spawning so the work runs entirely off-actor.
+    /// - Parameter notesMarkdown: Pass the markdown when already in memory (e.g. from saveNotes)
+    ///   to avoid a redundant disk read; nil causes the background task to read it from disk.
+    private func scheduleMirror(sessionID: String, notesMarkdown: String? = nil) {
         guard let outputDir = notesFolderPath else { return }
-
+        let sessDir = sessionsDirectory
         let meta = loadSessionMetadataFile(sessionID: sessionID)
-        let records = loadTranscript(sessionID: sessionID)
+        Task.detached(priority: .background) {
+            SessionRepository.performMirror(
+                sessionID: sessionID,
+                meta: meta,
+                notesMarkdown: notesMarkdown,
+                outputDir: outputDir,
+                sessionsDirectory: sessDir
+            )
+        }
+    }
+
+    private nonisolated static func performMirror(
+        sessionID: String,
+        meta: SessionMetadata?,
+        notesMarkdown: String?,
+        outputDir: URL,
+        sessionsDirectory: URL
+    ) {
+        let dir = sessionsDirectory.appendingPathComponent(sessionID, isDirectory: true)
+        let records = readTranscript(sessionID: sessionID, dir: dir, sessionsDirectory: sessionsDirectory)
         guard !records.isEmpty else { return }
+
+        let resolvedMarkdown = notesMarkdown
+            ?? readNotes(sessionID: sessionID, dir: dir, sessionsDirectory: sessionsDirectory)?.markdown
 
         let index = SessionIndex(
             id: meta?.id ?? sessionID,
@@ -1111,7 +1210,7 @@ actor SessionRepository {
             templateSnapshot: meta?.templateSnapshot,
             title: meta?.title,
             utteranceCount: meta?.utteranceCount ?? records.count,
-            hasNotes: meta?.hasNotes ?? false,
+            hasNotes: (meta?.hasNotes ?? false) || resolvedMarkdown != nil,
             language: meta?.language,
             meetingApp: meta?.meetingApp,
             engine: meta?.engine,
@@ -1119,14 +1218,10 @@ actor SessionRepository {
             source: meta?.source
         )
 
-        // Load generated notes (if any) to include in the export
-        let notes = loadNotes(sessionID: sessionID)
-
-        // Write/update Markdown meeting notes
         MarkdownMeetingWriter.write(
             metadata: .init(from: index),
             records: records,
-            notesMarkdown: notes?.markdown,
+            notesMarkdown: resolvedMarkdown,
             outputDirectory: outputDir
         )
     }

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -209,7 +209,11 @@ struct NotesView: View {
                 if session.hasNotes {
                     Image(systemName: "doc.text.fill")
                         .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(
+                            controller.state.freshlyGeneratedSessionIDs.contains(session.id)
+                                ? Color.accentColor
+                                : Color.secondary
+                        )
                 }
             }
 
@@ -582,7 +586,10 @@ struct NotesView: View {
             .menuStyle(.button)
             .buttonStyle(.bordered)
             .fixedSize()
-            .help("Click to regenerate, or pick a different template")
+            .disabled(controller.isAnyGenerationInProgress)
+            .help(controller.isAnyGenerationInProgress
+                ? "Generating notes for \"\(controller.generatingSessionName)\"..."
+                : "Click to regenerate, or pick a different template")
         }
 
         imageInsertMenu(controller: controller, state: state)
@@ -741,7 +748,10 @@ struct NotesView: View {
                 Label("Generate Notes", systemImage: "sparkles")
             }
             .buttonStyle(.borderedProminent)
-            .disabled(state.loadedTranscript.isEmpty)
+            .disabled(state.loadedTranscript.isEmpty || controller.isAnyGenerationInProgress)
+            .help(controller.isAnyGenerationInProgress
+                ? "Generating notes for \"\(controller.generatingSessionName)\"..."
+                : "")
             .accessibilityIdentifier("notes.generateButton")
         }
     }

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -742,17 +742,25 @@ struct NotesView: View {
                     .font(.system(size: 12))
             }
 
-            Button {
-                controller.generateNotes(sessionID: sessionID, settings: settings)
-            } label: {
-                Label("Generate Notes", systemImage: "sparkles")
+            VStack(spacing: 8) {
+                Button {
+                    controller.generateNotes(sessionID: sessionID, settings: settings)
+                } label: {
+                    Label("Generate Notes", systemImage: "sparkles")
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(state.loadedTranscript.isEmpty || controller.isAnyGenerationInProgress)
+                .accessibilityIdentifier("notes.generateButton")
+
+                if controller.isAnyGenerationInProgress {
+                    HStack(spacing: 6) {
+                        ProgressView().controlSize(.mini)
+                        Text("Generating notes for \"\(controller.generatingSessionName)\"...")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+                }
             }
-            .buttonStyle(.borderedProminent)
-            .disabled(state.loadedTranscript.isEmpty || controller.isAnyGenerationInProgress)
-            .help(controller.isAnyGenerationInProgress
-                ? "Generating notes for \"\(controller.generatingSessionName)\"..."
-                : "")
-            .accessibilityIdentifier("notes.generateButton")
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -206,7 +206,9 @@ struct NotesView: View {
                         .lineLimit(1)
                 }
                 Spacer()
-                if session.hasNotes {
+                if controller.isGenerating(sessionID: session.id) {
+                    ProgressView().controlSize(.mini).scaleEffect(0.7)
+                } else if session.hasNotes {
                     Image(systemName: "doc.text.fill")
                         .font(.system(size: 10))
                         .foregroundStyle(

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -281,4 +281,63 @@ final class NotesControllerTests: XCTestCase {
         controller.toggleShowingOriginal()
         XCTAssertFalse(controller.state.showingOriginal)
     }
+
+    func testGenerateNotesUpdatesGeneratingFlags() async {
+        let (root, notes) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let settings = makeSettings(notesDirectory: notes)
+        let sessionID = "session_test_flags"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID)
+        await controller.loadHistory()
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertFalse(controller.isAnyGenerationInProgress)
+        XCTAssertFalse(controller.isGenerating(sessionID: sessionID))
+
+        controller.generateNotes(sessionID: sessionID, settings: settings)
+        
+        // Synchronous start
+        XCTAssertTrue(controller.isAnyGenerationInProgress)
+        XCTAssertTrue(controller.isGenerating(sessionID: sessionID))
+        XCTAssertEqual(controller.generatingSessionName, "Test Meeting")
+
+        // Wait for finish
+        try? await Task.sleep(for: .milliseconds(500))
+
+        XCTAssertFalse(controller.isAnyGenerationInProgress)
+        XCTAssertFalse(controller.isGenerating(sessionID: sessionID))
+    }
+
+    func testGenerateNotesUpdatesFreshlyGeneratedWhenSwitchedAway() async {
+        let (root, notes) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let settings = makeSettings(notesDirectory: notes)
+        let sessionID = "session_test_fresh_switch"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID)
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        // Start generation
+        controller.generateNotes(sessionID: sessionID, settings: settings)
+
+        // Switch to a different session (or nil) immediately
+        controller.selectSession(nil)
+
+        // Wait for generation to finish in the background
+        try? await Task.sleep(for: .milliseconds(500))
+
+        XCTAssertFalse(controller.isAnyGenerationInProgress)
+        XCTAssertTrue(controller.state.freshlyGeneratedSessionIDs.contains(sessionID))
+        XCTAssertNil(controller.state.loadedNotes, "Should not update loadedNotes for the current unselected view")
+
+        // Switch back to it
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertFalse(controller.state.freshlyGeneratedSessionIDs.contains(sessionID), "Should clear the fresh badge when selected")
+        XCTAssertNotNil(controller.state.loadedNotes, "Should load the generated notes")
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -172,6 +172,40 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    func testSaveNotesMirrorsToNotesFolderPath() async {
+        let exportDir = rootDir.appendingPathComponent("exported_notes", isDirectory: true)
+        try? FileManager.default.createDirectory(at: exportDir, withIntermediateDirectories: true)
+        
+        await repo.setNotesFolderPath(exportDir)
+        
+        let sessionID = "test_mirror_session"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date(),
+            title: "Mirror Meeting"
+        )
+
+        let template = TemplateSnapshot(
+            id: UUID(), name: "Mirror", icon: "star", systemPrompt: "Be helpful"
+        )
+        let notes = GeneratedNotes(
+            template: template,
+            generatedAt: Date(),
+            markdown: "# Mirror Notes\n\nContent here."
+        )
+
+        await repo.saveNotes(sessionID: sessionID, notes: notes)
+        
+        // Wait for detached task to complete
+        try? await Task.sleep(for: .milliseconds(300))
+        
+        let contents = try? FileManager.default.contentsOfDirectory(at: exportDir, includingPropertiesForKeys: nil)
+        XCTAssertTrue(contents?.contains(where: { $0.lastPathComponent == "Mirror Meeting.md" }) ?? false)
+        
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
     // MARK: - listSessions returns all sessions
 
     func testListSessionsReturnsAllSessions() async {

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -197,11 +197,18 @@ final class SessionRepositoryTests: XCTestCase {
 
         await repo.saveNotes(sessionID: sessionID, notes: notes)
         
-        // Wait for detached task to complete
-        try? await Task.sleep(for: .milliseconds(300))
+        // Poll for detached task to complete (up to 2 seconds)
+        var didMirror = false
+        for _ in 0..<20 {
+            try? await Task.sleep(for: .milliseconds(100))
+            let contents = try? FileManager.default.contentsOfDirectory(at: exportDir, includingPropertiesForKeys: nil)
+            if contents?.contains(where: { $0.lastPathComponent.contains("mirror-meeting") && $0.pathExtension == "md" }) ?? false {
+                didMirror = true
+                break
+            }
+        }
         
-        let contents = try? FileManager.default.contentsOfDirectory(at: exportDir, includingPropertiesForKeys: nil)
-        XCTAssertTrue(contents?.contains(where: { $0.lastPathComponent == "Mirror Meeting.md" }) ?? false)
+        XCTAssertTrue(didMirror, "Background mirror task did not complete in time")
         
         await repo.deleteSession(sessionID: sessionID)
     }


### PR DESCRIPTION
A few improvements to notes generation and some tweaks to UX to make it more intuitive and easy to use. Tested it manually and also added a couple tests. 

**Summary**

- **Concurrent session loading** — Switching sessions now loads notes, transcript, and audio URL in parallel using Task.detached instead of three sequential actor hops. Total load time drops from t₁ + t₂ + t₃ to max(t₁, t₂, t₃).

- **Async notes folder mirroring** — mirrorNotesArtifacts previously blocked the SessionRepository actor while re-reading the full transcript from disk and writing the markdown export on every save. It now runs as a Task.detached(priority: .background) and returns immediately. saveNotes also passes the markdown through directly to avoid a redundant disk read.

- **Generation no longer bleeds across sessions** — Starting generation on Session A and switching to Session B previously caused Session B to show the in-progress indicator and risk overwriting its notes on completion. This is fixed by:
-- Tracking generatingSessionID
-- Capturing the transcript before any suspension point
-- Making NotesEngine.generate() non-blocking (callback-based instead of await)
-- Gating all UI state updates on selectedSessionID == sessionID
-- Notes are always saved to disk regardless of navigation.

- **Generation is now exclusive with clear feedback** — Triggering generation on a second session while one is already running previously dropped the first silently. Now:
-- Generation is globally blocked while in progress
-- Both Generate and Regenerate buttons are disabled with a tooltip
-- The empty state shows an inline spinner and: "Generating notes for '[Session Name]'..." so the reason is visible without hovering

- **Sidebar progress indicators** — The session list now shows:
-- A spinner next to the session currently generating notes
-- A blue (accent) notes icon as an unread indicator if generation completes while viewing another session
-- Selecting that session clears the badge

- **Tests**