### PR TITLE
feat: add Always on Top toggle for Classic Suggestions

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.45.5"
-  sha256 "c6a7c0016cc53a20edcbee8f897a8245ad72f786f98cba159d22070223e12fc9"
+  version "1.46.0"
+  sha256 "c099386ed29e2167443c8ca95b181d3912a6a817d4bf6dd3a81ea86abc04b0ca"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -274,6 +274,17 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _suggestionsAlwaysOnTop: Bool
+    var suggestionsAlwaysOnTop: Bool {
+        get { access(keyPath: \.suggestionsAlwaysOnTop); return _suggestionsAlwaysOnTop }
+        set {
+            withMutation(keyPath: \.suggestionsAlwaysOnTop) {
+                _suggestionsAlwaysOnTop = newValue
+                defaults.set(newValue, forKey: "suggestionsAlwaysOnTop")
+            }
+        }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _sidebarMode: SidebarMode
     var sidebarMode: SidebarMode {
         get { access(keyPath: \.sidebarMode); return _sidebarMode }
@@ -839,6 +850,11 @@ final class SettingsStore {
             self._suggestionPanelEnabled = true
         } else {
             self._suggestionPanelEnabled = defaults.bool(forKey: "suggestionPanelEnabled")
+        }
+        if defaults.object(forKey: "suggestionsAlwaysOnTop") == nil {
+            self._suggestionsAlwaysOnTop = true
+        } else {
+            self._suggestionsAlwaysOnTop = defaults.bool(forKey: "suggestionsAlwaysOnTop")
         }
         self._sidebarMode = SidebarMode(rawValue: defaults.string(forKey: "sidebarMode") ?? "") ?? .classicSuggestions
         self._sidecastIntensity = SidecastIntensity(rawValue: defaults.string(forKey: "sidecastIntensity") ?? "") ?? .balanced

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -392,6 +392,9 @@ struct ContentView: View {
         .onChange(of: settings.calendarIntegrationEnabled) {
             container.updateCalendarIntegration(enabled: settings.calendarIntegrationEnabled)
         }
+        .onChange(of: settings.suggestionsAlwaysOnTop) {
+            overlayManager.updateAlwaysOnTop(settings.suggestionsAlwaysOnTop)
+        }
         .onChange(of: settings.sidebarMode) {
             if settings.sidebarMode == .classicSuggestions {
                 coordinator.suggestionEngine?.startPreFetching()

--- a/OpenOats/Sources/OpenOats/Views/OverlayPanel.swift
+++ b/OpenOats/Sources/OpenOats/Views/OverlayPanel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 /// A floating NSPanel that is invisible to screen sharing.
 final class OverlayPanel: NSPanel {
-    init(contentRect: NSRect, defaults: UserDefaults = .standard) {
+    init(contentRect: NSRect, defaults: UserDefaults = .standard, alwaysOnTop: Bool = true) {
         super.init(
             contentRect: contentRect,
             styleMask: [.nonactivatingPanel, .titled, .closable, .resizable, .fullSizeContentView],
@@ -11,8 +11,8 @@ final class OverlayPanel: NSPanel {
             defer: false
         )
 
-        isFloatingPanel = true
-        level = .floating
+        isFloatingPanel = alwaysOnTop
+        level = alwaysOnTop ? .floating : .normal
         let hidden = defaults.object(forKey: "hideFromScreenShare") == nil
             ? true
             : defaults.bool(forKey: "hideFromScreenShare")
@@ -28,6 +28,12 @@ final class OverlayPanel: NSPanel {
 
         // Remember position
         setFrameAutosaveName("OverlayPanel")
+    }
+
+    /// Update the always-on-top state of an existing panel.
+    func applyAlwaysOnTop(_ enabled: Bool) {
+        isFloatingPanel = enabled
+        level = enabled ? .floating : .normal
     }
 }
 
@@ -63,7 +69,10 @@ final class OverlayManager: ObservableObject {
                 width: Self.classicWidth,
                 height: Self.classicMaxHeight
             )
-            let newPanel = OverlayPanel(contentRect: rect, defaults: defaults)
+            let alwaysOnTop = defaults.object(forKey: "suggestionsAlwaysOnTop") == nil
+                ? true
+                : defaults.bool(forKey: "suggestionsAlwaysOnTop")
+            let newPanel = OverlayPanel(contentRect: rect, defaults: defaults, alwaysOnTop: alwaysOnTop)
             newPanel.minSize = NSSize(width: Self.classicWidth, height: Self.classicMinHeight)
             newPanel.maxSize = NSSize(width: Self.classicWidth + 100, height: Self.classicMaxHeight)
             newPanel.setFrameAutosaveName("SuggestionSidePanel")
@@ -141,6 +150,11 @@ final class OverlayManager: ObservableObject {
 
     var isVisible: Bool {
         panel?.isVisible == true || sidecastPanel?.isVisible == true
+    }
+
+    /// Update the always-on-top state for the classic suggestions panel.
+    func updateAlwaysOnTop(_ enabled: Bool) {
+        panel?.applyAlwaysOnTop(enabled)
     }
 
     /// Hide after a delay (used for session end).

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -560,6 +560,9 @@ private struct IntelligenceSettingsTab: View {
                 Section("Classic Suggestions") {
                     Toggle("Floating suggestion panel", isOn: $settings.suggestionPanelEnabled)
                         .font(.system(size: 12))
+                    Toggle("Always on top", isOn: $settings.suggestionsAlwaysOnTop)
+                        .font(.system(size: 12))
+                        .disabled(!settings.suggestionPanelEnabled)
                     Text("Configure the original single-stream suggestion panel. The multi-persona sidebar lives in the Sidecast tab.")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary

Adds a new **Always on Top** toggle in Settings > Intelligence > Classic Suggestions that lets users disable the floating window level for the suggestion panel. Closes #335.

- New `suggestionsAlwaysOnTop` setting in `SettingsStore` (defaults to `true`, preserving current behavior)
- Toggle in the Classic Suggestions settings section, disabled when the panel itself is off
- `OverlayPanel` accepts an `alwaysOnTop` parameter; when disabled, the window uses normal level instead of floating
- Live update: changing the setting immediately updates any visible panel without requiring restart
- Also bumps Homebrew cask to v1.46.0 (from automation branch)

## Test plan

- [ ] Open Settings > Intelligence > Classic Suggestions
- [ ] Verify "Always on top" toggle is visible and defaults to on
- [ ] Disable the toggle, start a meeting — suggestion panel should appear behind other windows when they're focused
- [ ] Re-enable the toggle — suggestion panel should float above other windows again
- [ ] Verify the toggle is grayed out when "Floating suggestion panel" is off