### PR TITLE
chore: update Homebrew cask to 1.47.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.46.0"
-  sha256 "c099386ed29e2167443c8ca95b181d3912a6a817d4bf6dd3a81ea86abc04b0ca"
+  version "1.47.0"
+  sha256 "b2e40e8ba54ad18bad2c9832709eb664e2a31779d15082e65e3c9d4fbab93df5"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary

- Updates Homebrew cask version from 1.46.0 to 1.47.0
- Updates SHA256 hash to match the new release DMG

Automated update from the release workflow.