### PR TITLE
fix: pass locale language code to WhisperKit decoder

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/WhisperKitBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/WhisperKitBackend.swift
@@ -50,6 +50,6 @@ final class WhisperKitBackend: TranscriptionBackend, @unchecked Sendable {
         guard let whisperManager else {
             throw TranscriptionBackendError.notPrepared
         }
-        return try await whisperManager.transcribe(samples, previousContext: previousContext)
+        return try await whisperManager.transcribe(samples, locale: locale, previousContext: previousContext)
     }
 }

--- a/OpenOats/Sources/OpenOats/Transcription/WhisperKitManager.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/WhisperKitManager.swift
@@ -57,7 +57,7 @@ final class WhisperKitManager: @unchecked Sendable {
     /// Returns the transcribed text (empty string if nothing recognized).
     /// - Parameter previousContext: Trailing words from the prior segment, encoded as prompt
     ///   tokens to prime the Whisper decoder for cross-segment continuity.
-    func transcribe(_ samples: [Float], previousContext: String? = nil) async throws -> String {
+    func transcribe(_ samples: [Float], locale: Locale? = nil, previousContext: String? = nil) async throws -> String {
         guard let pipe else {
             throw WhisperKitManagerError.notInitialized
         }
@@ -70,9 +70,13 @@ final class WhisperKitManager: @unchecked Sendable {
                 promptTokens = encoded
             }
         }
+        // Extract 2-letter language code (e.g. "he", "en") from locale.
+        // When nil, Whisper auto-detects — but auto-detect often outputs
+        // Latin transliteration for non-Latin scripts like Hebrew/Arabic.
+        let languageCode = locale?.language.languageCode?.identifier
+
         let options = DecodingOptions(
-            // Let Whisper auto-detect the language
-            language: nil,
+            language: languageCode,
             wordTimestamps: false,
             promptTokens: promptTokens
         )


### PR DESCRIPTION
## Summary

Fixes a bug where transcriptions in non-Latin scripts (Hebrew, Arabic, CJK, etc.) were being output as Latin transliterations instead of in their native script.

## Bug

When recording speech in a non-Latin language, WhisperKit would auto-detect the language but emit a Latin transliteration. For example, the Hebrew word "בדיקה" (bdika, meaning "test") was transcribed as `Bdika` instead of `בדיקה`. Same issue affected Arabic, Chinese, Japanese, Korean, etc.

## Root Cause

The user's selected locale was threaded through the entire transcription call chain, but dropped at the final step. `WhisperKitManager.transcribe()` constructed `DecodingOptions` with `language: nil` hard-coded, causing WhisperKit to fall back to auto-detection with Latin-script output.

## Fix

Two small changes:

1. **`WhisperKitManager.swift`** — Added a `locale` parameter to `transcribe()`. Extracts the 2-letter ISO 639-1 code via `locale.language.languageCode?.identifier` (e.g. `"he"` for Hebrew) and passes it as `DecodingOptions.language`.

2. **`WhisperKitBackend.swift`** — Forwards the already-available `locale` through to the manager.

No API changes for callers upstream of the backend — the locale was already being passed in, just not all the way down.

## Testing

Verified with a Hebrew meeting recording:
- **Before:** Latin transliteration (`Bdika, shalom...`)
- **After:** Native Hebrew script (`בדיקה, שלום...`)

Should also resolve the same class of bug for Arabic, Chinese, Japanese, Korean, Russian, Thai, and any other non-Latin-script language supported by Whisper.