### PR TITLE
fix: avoid Keychain access in AppSettingsTests

### DIFF
--- a/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
@@ -3,6 +3,20 @@ import XCTest
 
 @MainActor
 final class AppSettingsTests: XCTestCase {
+    private func makeSettings() -> AppSettings {
+        let suiteName = "com.openoats.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let storage = AppSettingsStorage(
+            defaults: defaults,
+            secretStore: .ephemeral,
+            defaultNotesDirectory: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("AppSettingsTests"),
+            runMigrations: false
+        )
+        return AppSettings(storage: storage)
+    }
 
     // MARK: - LLMProvider
 
@@ -115,19 +129,19 @@ final class AppSettingsTests: XCTestCase {
     // MARK: - AppSettings Defaults
 
     func testAppSettingsDefaultTranscriptionLocale() {
-        let settings = AppSettings()
+        let settings = makeSettings()
         // Default locale should be en-US unless previously set
         XCTAssertFalse(settings.transcriptionLocale.isEmpty)
     }
 
     func testAppSettingsLocaleProperty() {
-        let settings = AppSettings()
+        let settings = makeSettings()
         let locale = settings.locale
         XCTAssertFalse(locale.identifier.isEmpty)
     }
 
     func testAppSettingsKbFolderURLWhenEmpty() {
-        let settings = AppSettings()
+        let settings = makeSettings()
         let originalPath = settings.kbFolderPath
         settings.kbFolderPath = ""
         XCTAssertNil(settings.kbFolderURL)
@@ -135,7 +149,7 @@ final class AppSettingsTests: XCTestCase {
     }
 
     func testAppSettingsKbFolderURLWhenSet() {
-        let settings = AppSettings()
+        let settings = makeSettings()
         let originalPath = settings.kbFolderPath
         settings.kbFolderPath = "/tmp/test-kb"
         XCTAssertNotNil(settings.kbFolderURL)


### PR DESCRIPTION
## Summary

Fixes a developer/test bug where `swift test` could trigger a macOS Keychain prompt from `xctest`.

`AppSettingsTests` was constructing production `AppSettings()` instances, which use live settings storage and read from the real `com.openoats.app` Keychain service. The test suite now uses isolated test settings with an ephemeral secret store.

Closes #341.

## Root Cause

`AppSettings` is a typealias for `SettingsStore`, and the default initializer uses `SettingsStorage.live()`. That live storage reads API keys from Keychain during initialization.

When those tests run under `xctest`, macOS sees `xctest` trying to access OpenOats Keychain items and prompts for permission.

## Fix

- Added a local `makeSettings()` helper in `AppSettingsTests`
- Uses a unique `UserDefaults` suite per test settings instance
- Uses `secretStore: .ephemeral`
- Disables migrations with `runMigrations: false`
- Replaced the remaining bare `AppSettings()` calls in that test file

## Testing

- [x] `swift test --filter AppSettingsTests`
- [x] `swift test`

Full suite result: 413 tests passed.
