### PR TITLE
Add Calendar full-access usage description

### DIFF
--- a/OpenOats/Sources/OpenOats/Info.plist
+++ b/OpenOats/Sources/OpenOats/Info.plist
@@ -35,7 +35,7 @@
     <string>OpenOats needs microphone access to transcribe your voice in real-time during conversations.</string>
     <key>NSAudioCaptureUsageDescription</key>
     <string>OpenOats needs system audio recording access to transcribe other participants in real time.</string>
-    <key>NSCalendarsUsageDescription</key>
+    <key>NSCalendarsFullAccessUsageDescription</key>
     <string>OpenOats can use your calendar to automatically title meeting sessions with the event name and show participant info.</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>


### PR DESCRIPTION
## Summary

- replace the deprecated/general Calendar usage key with `NSCalendarsFullAccessUsageDescription`

## Why

OpenOats requests Calendar access through EventKit's modern full-access API (`requestFullAccessToEvents()`). Apple's EventKit guide says apps implementing full Calendar access should add `NSCalendarsFullAccessUsageDescription` and request access with `requestFullAccessToEvents()`:
https://developer.apple.com/documentation/eventkit/accessing_calendar_using_eventkit_and_eventkitui

Since OpenOats targets macOS 15 and reads existing Calendar events for session matching/title suggestions, the bundle should declare the matching full-access purpose string key instead of the older general Calendar usage key.

Closes #344

## Testing

- `plutil -lint OpenOats/Sources/OpenOats/Info.plist`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
