### PR TITLE
Avoid eager Keychain secret reads

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -617,9 +617,13 @@ final class LiveSessionController {
             }
         }
 
-        if settings.voyageApiKey != observedVoyageApiKey {
+        if !settings.kbFolderPath.isEmpty,
+           settings.embeddingProvider == .voyageAI,
+           settings.voyageApiKey != observedVoyageApiKey {
             observedVoyageApiKey = settings.voyageApiKey
             indexKBIfNeeded(settings: settings)
+        } else if settings.kbFolderPath.isEmpty || settings.embeddingProvider != .voyageAI {
+            observedVoyageApiKey = ""
         }
 
         if settings.transcriptionModel != observedTranscriptionModel {

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStorage.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStorage.swift
@@ -65,6 +65,19 @@ enum KeychainHelper {
         SecItemAdd(query as CFDictionary, nil)
     }
 
+    static func saveIfMissing(key: String, value: String) {
+        guard let data = value.data(using: .utf8) else { return }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data,
+        ]
+
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
     static func load(key: String) -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -11,6 +11,23 @@ final class SettingsStore {
     private let secretStore: AppSecretStore
     private static let enableLiveTranscriptCleanupLegacyKey = "enableTranscriptRefinement"
     private static let enableBatchRetranscriptionLegacyKey = "enableBatchRefinement"
+    @ObservationIgnored private var loadedSecretKeys: Set<String> = []
+
+    private func loadSecretIfNeeded(
+        key: String,
+        currentValue: String,
+        assign: (String) -> Void
+    ) -> String {
+        guard !loadedSecretKeys.contains(key) else { return currentValue }
+        let value = secretStore.load(key: key) ?? ""
+        loadedSecretKeys.insert(key)
+        assign(value)
+        return value
+    }
+
+    private func markSecretLoaded(_ key: String) {
+        loadedSecretKeys.insert(key)
+    }
 
     // MARK: - AI Settings
 
@@ -27,11 +44,17 @@ final class SettingsStore {
 
     @ObservationIgnored nonisolated(unsafe) private var _openRouterApiKey: String
     var openRouterApiKey: String {
-        get { access(keyPath: \.openRouterApiKey); return _openRouterApiKey }
+        get {
+            access(keyPath: \.openRouterApiKey)
+            return loadSecretIfNeeded(key: "openRouterApiKey", currentValue: _openRouterApiKey) {
+                _openRouterApiKey = $0
+            }
+        }
         set {
             withMutation(keyPath: \.openRouterApiKey) {
                 let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                 _openRouterApiKey = trimmed
+                markSecretLoaded("openRouterApiKey")
                 secretStore.save(key: "openRouterApiKey", value: trimmed)
             }
         }
@@ -39,11 +62,17 @@ final class SettingsStore {
 
     @ObservationIgnored nonisolated(unsafe) private var _assemblyAIApiKey: String
     var assemblyAIApiKey: String {
-        get { access(keyPath: \.assemblyAIApiKey); return _assemblyAIApiKey }
+        get {
+            access(keyPath: \.assemblyAIApiKey)
+            return loadSecretIfNeeded(key: "assemblyAIApiKey", currentValue: _assemblyAIApiKey) {
+                _assemblyAIApiKey = $0
+            }
+        }
         set {
             withMutation(keyPath: \.assemblyAIApiKey) {
                 let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                 _assemblyAIApiKey = trimmed
+                markSecretLoaded("assemblyAIApiKey")
                 secretStore.save(key: "assemblyAIApiKey", value: trimmed)
             }
         }
@@ -51,11 +80,17 @@ final class SettingsStore {
 
     @ObservationIgnored nonisolated(unsafe) private var _elevenLabsApiKey: String
     var elevenLabsApiKey: String {
-        get { access(keyPath: \.elevenLabsApiKey); return _elevenLabsApiKey }
+        get {
+            access(keyPath: \.elevenLabsApiKey)
+            return loadSecretIfNeeded(key: "elevenLabsApiKey", currentValue: _elevenLabsApiKey) {
+                _elevenLabsApiKey = $0
+            }
+        }
         set {
             withMutation(keyPath: \.elevenLabsApiKey) {
                 let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                 _elevenLabsApiKey = trimmed
+                markSecretLoaded("elevenLabsApiKey")
                 secretStore.save(key: "elevenLabsApiKey", value: trimmed)
             }
         }
@@ -129,11 +164,17 @@ final class SettingsStore {
 
     @ObservationIgnored nonisolated(unsafe) private var _openAILLMApiKey: String
     var openAILLMApiKey: String {
-        get { access(keyPath: \.openAILLMApiKey); return _openAILLMApiKey }
+        get {
+            access(keyPath: \.openAILLMApiKey)
+            return loadSecretIfNeeded(key: "openAILLMApiKey", currentValue: _openAILLMApiKey) {
+                _openAILLMApiKey = $0
+            }
+        }
         set {
             withMutation(keyPath: \.openAILLMApiKey) {
                 let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                 _openAILLMApiKey = trimmed
+                markSecretLoaded("openAILLMApiKey")
                 secretStore.save(key: "openAILLMApiKey", value: trimmed)
             }
         }
@@ -163,11 +204,17 @@ final class SettingsStore {
 
     @ObservationIgnored nonisolated(unsafe) private var _openAIEmbedApiKey: String
     var openAIEmbedApiKey: String {
-        get { access(keyPath: \.openAIEmbedApiKey); return _openAIEmbedApiKey }
+        get {
+            access(keyPath: \.openAIEmbedApiKey)
+            return loadSecretIfNeeded(key: "openAIEmbedApiKey", currentValue: _openAIEmbedApiKey) {
+                _openAIEmbedApiKey = $0
+            }
+        }
         set {
             withMutation(keyPath: \.openAIEmbedApiKey) {
                 let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                 _openAIEmbedApiKey = trimmed
+                markSecretLoaded("openAIEmbedApiKey")
                 secretStore.save(key: "openAIEmbedApiKey", value: trimmed)
             }
         }
@@ -208,11 +255,17 @@ final class SettingsStore {
 
     @ObservationIgnored nonisolated(unsafe) private var _voyageApiKey: String
     var voyageApiKey: String {
-        get { access(keyPath: \.voyageApiKey); return _voyageApiKey }
+        get {
+            access(keyPath: \.voyageApiKey)
+            return loadSecretIfNeeded(key: "voyageApiKey", currentValue: _voyageApiKey) {
+                _voyageApiKey = $0
+            }
+        }
         set {
             withMutation(keyPath: \.voyageApiKey) {
                 let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
                 _voyageApiKey = trimmed
+                markSecretLoaded("voyageApiKey")
                 secretStore.save(key: "voyageApiKey", value: trimmed)
             }
         }
@@ -668,10 +721,16 @@ final class SettingsStore {
 
     @ObservationIgnored nonisolated(unsafe) private var _granolaApiKey: String
     var granolaApiKey: String {
-        get { access(keyPath: \.granolaApiKey); return _granolaApiKey }
+        get {
+            access(keyPath: \.granolaApiKey)
+            return loadSecretIfNeeded(key: "granolaApiKey", currentValue: _granolaApiKey) {
+                _granolaApiKey = $0
+            }
+        }
         set {
             withMutation(keyPath: \.granolaApiKey) {
                 _granolaApiKey = newValue
+                markSecretLoaded("granolaApiKey")
                 secretStore.save(key: "granolaApiKey", value: newValue)
             }
         }
@@ -703,10 +762,16 @@ final class SettingsStore {
 
     @ObservationIgnored nonisolated(unsafe) private var _webhookSecret: String
     var webhookSecret: String {
-        get { access(keyPath: \.webhookSecret); return _webhookSecret }
+        get {
+            access(keyPath: \.webhookSecret)
+            return loadSecretIfNeeded(key: "webhookSecret", currentValue: _webhookSecret) {
+                _webhookSecret = $0
+            }
+        }
         set {
             withMutation(keyPath: \.webhookSecret) {
                 _webhookSecret = newValue
+                markSecretLoaded("webhookSecret")
                 secretStore.save(key: "webhookSecret", value: newValue)
             }
         }
@@ -823,23 +888,23 @@ final class SettingsStore {
 
         // AI Settings
         self._llmProvider = LLMProvider(rawValue: defaults.string(forKey: "llmProvider") ?? "") ?? .openRouter
-        self._openRouterApiKey = storage.secretStore.load(key: "openRouterApiKey") ?? ""
-        self._assemblyAIApiKey = storage.secretStore.load(key: "assemblyAIApiKey") ?? ""
-        self._elevenLabsApiKey = storage.secretStore.load(key: "elevenLabsApiKey") ?? ""
+        self._openRouterApiKey = ""
+        self._assemblyAIApiKey = ""
+        self._elevenLabsApiKey = ""
         self._ollamaBaseURL = defaults.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
         self._ollamaLLMModel = defaults.string(forKey: "ollamaLLMModel") ?? "qwen3:8b"
         self._ollamaEmbedModel = defaults.string(forKey: "ollamaEmbedModel") ?? "nomic-embed-text"
         self._mlxBaseURL = defaults.string(forKey: "mlxBaseURL") ?? "http://localhost:8080"
         self._mlxModel = defaults.string(forKey: "mlxModel") ?? "mlx-community/Llama-3.2-3B-Instruct-4bit"
         self._openAILLMBaseURL = defaults.string(forKey: "openAILLMBaseURL") ?? "http://localhost:4000"
-        self._openAILLMApiKey = storage.secretStore.load(key: "openAILLMApiKey") ?? ""
+        self._openAILLMApiKey = ""
         self._openAILLMModel = defaults.string(forKey: "openAILLMModel") ?? ""
         self._openAIEmbedBaseURL = defaults.string(forKey: "openAIEmbedBaseURL") ?? "http://localhost:8080"
-        self._openAIEmbedApiKey = storage.secretStore.load(key: "openAIEmbedApiKey") ?? ""
+        self._openAIEmbedApiKey = ""
         self._openAIEmbedModel = defaults.string(forKey: "openAIEmbedModel") ?? "text-embedding-3-small"
         self._selectedModel = defaults.string(forKey: "selectedModel") ?? "google/gemini-3-flash-preview"
         self._embeddingProvider = EmbeddingProvider(rawValue: defaults.string(forKey: "embeddingProvider") ?? "") ?? .voyageAI
-        self._voyageApiKey = storage.secretStore.load(key: "voyageApiKey") ?? ""
+        self._voyageApiKey = ""
         self._suggestionVerbosity = SuggestionVerbosity(
             rawValue: defaults.string(forKey: "suggestionVerbosity") ?? ""
         ) ?? .quiet
@@ -936,12 +1001,12 @@ final class SettingsStore {
         }
 
         // Import Settings
-        self._granolaApiKey = storage.secretStore.load(key: "granolaApiKey") ?? ""
+        self._granolaApiKey = ""
 
         // Webhook Settings
         self._webhookEnabled = defaults.bool(forKey: "webhookEnabled")
         self._webhookURL = defaults.string(forKey: "webhookURL") ?? ""
-        self._webhookSecret = storage.secretStore.load(key: "webhookSecret") ?? ""
+        self._webhookSecret = ""
 
         // UI Settings
         if defaults.object(forKey: "showLiveTranscript") == nil {
@@ -1083,9 +1148,8 @@ extension SettingsStore {
         let oldService = "com.onthespot.app"
         let keychainKeys = ["openRouterApiKey", "voyageApiKey"]
         for key in keychainKeys {
-            if KeychainHelper.load(key: key) == nil,
-               let oldValue = Self.loadKeychain(service: oldService, key: key) {
-                KeychainHelper.save(key: key, value: oldValue)
+            if let oldValue = Self.loadKeychain(service: oldService, key: key) {
+                KeychainHelper.saveIfMissing(key: key, value: oldValue)
             }
         }
     }
@@ -1117,9 +1181,8 @@ extension SettingsStore {
         let oldService = "com.opengranola.app"
         let keychainKeys = ["openRouterApiKey", "voyageApiKey"]
         for key in keychainKeys {
-            if KeychainHelper.load(key: key) == nil,
-               let oldValue = Self.loadKeychain(service: oldService, key: key) {
-                KeychainHelper.save(key: key, value: oldValue)
+            if let oldValue = Self.loadKeychain(service: oldService, key: key) {
+                KeychainHelper.saveIfMissing(key: key, value: oldValue)
             }
         }
 
@@ -1196,9 +1259,8 @@ extension SettingsStore {
         let oldService = "com.opengranola.app"
         let keychainKeys = ["openRouterApiKey", "voyageApiKey", "openAIEmbedApiKey", "openAILLMApiKey"]
         for key in keychainKeys {
-            if KeychainHelper.load(key: key) == nil,
-               let oldValue = loadKeychain(service: oldService, key: key) {
-                KeychainHelper.save(key: key, value: oldValue)
+            if let oldValue = loadKeychain(service: oldService, key: key) {
+                KeychainHelper.saveIfMissing(key: key, value: oldValue)
             }
         }
     }

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -3,6 +3,9 @@ import XCTest
 
 @MainActor
 final class LiveSessionControllerTests: XCTestCase {
+    private final class SecretLoadTracker: @unchecked Sendable {
+        var loadedKeys: [String] = []
+    }
 
     // MARK: - Helpers
 
@@ -16,7 +19,10 @@ final class LiveSessionControllerTests: XCTestCase {
         return (root, notesDirectory)
     }
 
-    private func makeSettings(notesDirectory: URL) -> AppSettings {
+    private func makeSettings(
+        notesDirectory: URL,
+        secretStore: AppSecretStore = .ephemeral
+    ) -> AppSettings {
         let suiteName = "com.openoats.tests.livesession.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName) ?? .standard
         defaults.removePersistentDomain(forName: suiteName)
@@ -24,7 +30,7 @@ final class LiveSessionControllerTests: XCTestCase {
         defaults.set(true, forKey: "hasAcknowledgedRecordingConsent")
         let storage = AppSettingsStorage(
             defaults: defaults,
-            secretStore: .ephemeral,
+            secretStore: secretStore,
             defaultNotesDirectory: notesDirectory,
             runMigrations: false
         )
@@ -242,6 +248,32 @@ final class LiveSessionControllerTests: XCTestCase {
         controller.confirmDownloadAndStart(settings: settings)
 
         XCTAssertTrue(coordinator.transcriptionEngine?.downloadConfirmed ?? false)
+    }
+
+    func testPollingDoesNotReadVoyageKeyWhenKnowledgeBaseFolderUnset() async {
+        let dirs = makeTempDirs()
+        let tracker = SecretLoadTracker()
+        let secretStore = AppSecretStore(
+            loadValue: { key in
+                tracker.loadedKeys.append(key)
+                return key == "voyageApiKey" ? "pa-existing" : nil
+            },
+            saveValue: { _, _ in }
+        )
+        let settings = makeSettings(notesDirectory: dirs.notes, secretStore: secretStore)
+        let (controller, _) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings
+        )
+
+        let task = Task {
+            await controller.runPollingLoop(settings: settings)
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+        task.cancel()
+
+        XCTAssertFalse(tracker.loadedKeys.contains("voyageApiKey"))
     }
 
     func testFullSessionLifecycle() async {

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -3,6 +3,10 @@ import XCTest
 
 @MainActor
 final class SettingsStoreTests: XCTestCase {
+    private final class LoadTracker: @unchecked Sendable {
+        var loadedKeys: [String] = []
+        var savedValues: [String: String] = [:]
+    }
 
     /// Build a SettingsStore backed by an ephemeral UserDefaults suite.
     private func makeStore(
@@ -381,6 +385,36 @@ final class SettingsStoreTests: XCTestCase {
 
     func testStorageTypealiasCompiles() {
         let _: AppSettingsStorage.Type = SettingsStorage.self
+    }
+
+    func testSecretsLoadLazily() {
+        let tracker = LoadTracker()
+        let secretStore = AppSecretStore(
+            loadValue: { key in
+                tracker.loadedKeys.append(key)
+                return key == "openRouterApiKey" ? "sk-existing" : nil
+            },
+            saveValue: { key, value in
+                tracker.savedValues[key] = value
+            }
+        )
+
+        let store = makeStore(secretStore: secretStore)
+
+        XCTAssertTrue(tracker.loadedKeys.isEmpty)
+        XCTAssertEqual(store.llmProvider, .openRouter)
+        XCTAssertTrue(tracker.loadedKeys.isEmpty)
+
+        XCTAssertEqual(store.openRouterApiKey, "sk-existing")
+        XCTAssertEqual(tracker.loadedKeys, ["openRouterApiKey"])
+
+        XCTAssertEqual(store.openRouterApiKey, "sk-existing")
+        XCTAssertEqual(tracker.loadedKeys, ["openRouterApiKey"])
+
+        store.openRouterApiKey = " sk-updated "
+        XCTAssertEqual(store.openRouterApiKey, "sk-updated")
+        XCTAssertEqual(tracker.loadedKeys, ["openRouterApiKey"])
+        XCTAssertEqual(tracker.savedValues["openRouterApiKey"], "sk-updated")
     }
 
     // MARK: - Cloud ASR API Keys


### PR DESCRIPTION
## Summary

- lazy-load saved API credentials instead of reading every Keychain item during `SettingsStore` initialization
- avoid reading the Voyage API key while knowledge-base indexing is inactive
- avoid reading current-service Keychain items during legacy migration checks by using add-if-missing writes
- add regression coverage for lazy secret loading and the polling-loop Voyage-key guard

## Why

OpenOats can show repeated, identical-looking macOS Keychain prompts on launch when the app is newly signed, rebuilt, or run with a different local signing identity. This is most visible during local development, where a dev build can use the production bundle ID but have a different code-signing identity from the installed production app. Production releases signed consistently with the same identity should usually keep Keychain trust across normal updates.

The underlying issue is still product code: startup reads several saved secrets even when the corresponding feature does not need them yet.

This keeps persisted secret behavior unchanged once a secret is actually accessed or edited, but avoids touching unrelated Keychain items during normal startup paths.

Closes #346

## Testing

- `swift test --filter SettingsStoreTests`
- `swift test --filter LiveSessionControllerTests`
- `git diff --check`
