### PR TITLE
feat: show Calendar access state and upcoming events in Settings

### DIFF
--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -5,8 +5,9 @@ import Foundation
 /// All access is gated behind the `calendarIntegrationEnabled` setting — the app
 /// only requests calendar permission when the user explicitly enables the feature.
 @MainActor
+@Observable
 final class CalendarManager {
-    private let store = EKEventStore()
+    @ObservationIgnored private let store = EKEventStore()
 
     enum AccessState {
         case notDetermined
@@ -65,6 +66,29 @@ final class CalendarManager {
 
         guard let best else { return nil }
         return CalendarEvent(from: best)
+    }
+
+    /// Upcoming calendar events starting within the given time window, ordered by start date.
+    /// Returns an empty array if access is not authorized.
+    func upcomingEvents(
+        from date: Date = Date(),
+        within window: TimeInterval = 12 * 60 * 60,
+        limit: Int = 5
+    ) -> [CalendarEvent] {
+        guard accessState == .authorized else { return [] }
+
+        let windowEnd = date.addingTimeInterval(window)
+        let predicate = store.predicateForEvents(
+            withStart: date,
+            end: windowEnd,
+            calendars: nil
+        )
+        let events = store.events(matching: predicate)
+            .filter { !$0.isAllDay && $0.startDate >= date }
+            .sorted { $0.startDate < $1.startDate }
+            .prefix(limit)
+
+        return events.map { CalendarEvent(from: $0) }
     }
 
     // MARK: - Helpers

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import CoreAudio
 import LaunchAtLogin
@@ -181,6 +182,10 @@ private struct GeneralSettingsTab: View {
                     Text("When enabled, OpenOats looks up your calendar for a matching event and uses its title for the session. Calendar access is requested only when you enable this.")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
+
+                    if settings.calendarIntegrationEnabled {
+                        CalendarStatusView()
+                    }
                 }
 
                 if !settings.ignoredAppBundleIDs.isEmpty {
@@ -1037,6 +1042,193 @@ private struct GranolaImportButton: View {
             } catch {
                 importState = .failed(error.localizedDescription)
                 isImporting = false
+            }
+        }
+    }
+}
+
+// MARK: - Calendar Status View
+
+/// Displays the current Calendar authorization state, the currently matching event
+/// (if any), and a short list of upcoming events. Scoped to Settings visibility —
+/// does not change session title or finalization behavior.
+private struct CalendarStatusView: View {
+    @Environment(AppContainer.self) private var container
+
+    @State private var accessState: CalendarManager.AccessState = .notDetermined
+    @State private var currentEvent: CalendarEvent?
+    @State private var upcomingEvents: [CalendarEvent] = []
+    @State private var refreshTick: Int = 0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            statusRow
+
+            switch accessState {
+            case .authorized:
+                authorizedContent
+            case .denied:
+                deniedContent
+            case .notDetermined:
+                Text("OpenOats will ask for Calendar access shortly.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.top, 4)
+        .task(id: refreshTick) {
+            await refresh()
+            // Periodic refresh while the Settings window is open.
+            try? await Task.sleep(for: .seconds(30))
+            refreshTick &+= 1
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var statusRow: some View {
+        HStack(spacing: 6) {
+            Image(systemName: statusIcon)
+                .font(.system(size: 12))
+                .foregroundStyle(statusColor)
+            Text(statusLabel)
+                .font(.system(size: 12, weight: .medium))
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var authorizedContent: some View {
+        if let event = currentEvent {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Currently matching")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                Text(event.title)
+                    .font(.system(size: 12, weight: .medium))
+                Text(timeRange(for: event))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.accentColor.opacity(0.1))
+            )
+        }
+
+        if upcomingEvents.isEmpty {
+            Text(currentEvent == nil
+                ? "No upcoming events in the next 12 hours."
+                : "No further upcoming events in the next 12 hours.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        } else {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Upcoming")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .textCase(.uppercase)
+                ForEach(upcomingEvents) { event in
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Text(startTime(for: event))
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 58, alignment: .leading)
+                        Text(event.title)
+                            .font(.system(size: 12))
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        Spacer()
+                    }
+                }
+            }
+        }
+    }
+
+    private var deniedContent: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Calendar access is denied. Grant access in System Settings for OpenOats to see your events.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            Button("Open Privacy Settings…") {
+                openCalendarPrivacySettings()
+            }
+            .font(.system(size: 12))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var statusIcon: String {
+        switch accessState {
+        case .authorized: return "checkmark.circle.fill"
+        case .denied: return "exclamationmark.triangle.fill"
+        case .notDetermined: return "clock"
+        }
+    }
+
+    private var statusColor: Color {
+        switch accessState {
+        case .authorized: return .green
+        case .denied: return .orange
+        case .notDetermined: return .secondary
+        }
+    }
+
+    private var statusLabel: String {
+        switch accessState {
+        case .authorized: return "Calendar access authorized"
+        case .denied: return "Calendar access denied"
+        case .notDetermined: return "Calendar access not yet requested"
+        }
+    }
+
+    private func timeRange(for event: CalendarEvent) -> String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return "\(formatter.string(from: event.startDate)) – \(formatter.string(from: event.endDate))"
+    }
+
+    private func startTime(for event: CalendarEvent) -> String {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return formatter.string(from: event.startDate)
+    }
+
+    @MainActor
+    private func refresh() async {
+        guard let manager = container.calendarManager else {
+            accessState = .notDetermined
+            currentEvent = nil
+            upcomingEvents = []
+            return
+        }
+        accessState = manager.accessState
+        if manager.accessState == .authorized {
+            let now = Date()
+            let current = manager.currentEvent(at: now)
+            currentEvent = current
+            let allUpcoming = manager.upcomingEvents(from: now, limit: 6)
+            upcomingEvents = allUpcoming.filter { $0.id != current?.id }.prefix(5).map { $0 }
+        } else {
+            currentEvent = nil
+            upcomingEvents = []
+        }
+    }
+
+    private func openCalendarPrivacySettings() {
+        let urls = [
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars",
+            "x-apple.systempreferences:com.apple.preference.security?Privacy",
+        ]
+        for urlString in urls {
+            if let url = URL(string: urlString) {
+                if NSWorkspace.shared.open(url) { return }
             }
         }
     }


### PR DESCRIPTION
Closes #348

Adds a status section to the Calendar area of General Settings that shows:

- Current authorization state (authorized / denied / not yet requested)
- Currently matching event (the one OpenOats would auto-title from)
- Up to 5 upcoming events in the next 12 hours
- An empty state when no events are visible
- A shortcut to macOS Privacy settings when access is denied

Scoped to Settings visibility; no changes to session title or finalization behavior.

## Implementation notes

- `CalendarManager` is now `@Observable` so that `accessState` changes (e.g. after the initial access prompt) propagate to SwiftUI views.
- Added `CalendarManager.upcomingEvents(from:within:limit:)` for the Settings list. Returns an empty array when access is not authorized, matching the rest of the API.
- The new `CalendarStatusView` refreshes on appear and polls every 30s while the Settings window is open.

## Testing

- `swift build` — clean
- `swift test` — 415 tests pass