### PR TITLE
Show matched Calendar event title during recording

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -23,6 +23,7 @@ final class LiveSessionState {
     var kbIndexingProgress: String = ""
     var statusMessage: String? = nil
     var errorMessage: String? = nil
+    var matchedCalendarEvent: CalendarEvent? = nil
     var needsDownload: Bool = false
     var downloadProgress: Double? = nil
     var downloadDetail: DownloadProgressDetail? = nil
@@ -350,15 +351,16 @@ final class LiveSessionController {
         }
         let utterancesSnapshot = coordinator.transcriptStore.utterances
         let utteranceCount = utterancesSnapshot.count
-        let title = coordinator.transcriptStore.conversationState.currentTopic.isEmpty
-            ? nil : coordinator.transcriptStore.conversationState.currentTopic
-
-        let meetingAppName: String?
+        let endingMetadata: MeetingMetadata?
         if case .ending(let metadata) = coordinator.state {
-            meetingAppName = metadata.detectionContext?.meetingApp?.name
+            endingMetadata = metadata
         } else {
-            meetingAppName = nil
+            endingMetadata = nil
         }
+        let metadataTitle = endingMetadata?.title ?? endingMetadata?.calendarEvent?.title
+        let title = coordinator.transcriptStore.conversationState.currentTopic.isEmpty
+            ? metadataTitle : coordinator.transcriptStore.conversationState.currentTopic
+        let meetingAppName = endingMetadata?.detectionContext?.meetingApp?.name
 
         let engineName = settings?.transcriptionModel.rawValue
         let transcriptionLanguage: String? = {
@@ -539,6 +541,13 @@ final class LiveSessionController {
         }
 
         let isRunning = coordinator.transcriptionEngine?.isRunning ?? false
+        let matchedCalendarEvent: CalendarEvent?
+        switch coordinator.state {
+        case .recording(let metadata), .ending(let metadata):
+            matchedCalendarEvent = metadata.calendarEvent
+        case .idle:
+            matchedCalendarEvent = nil
+        }
 
         // Use set(_:_:) for all Equatable fields: only fires @Observable withMutation
         // when the value actually changed, preventing spurious layout passes on NSHostingView.
@@ -555,6 +564,7 @@ final class LiveSessionController {
         set(\.kbIndexingProgress, coordinator.knowledgeBase?.indexingProgress ?? "")
         set(\.statusMessage, coordinator.transcriptionEngine?.assetStatus)
         set(\.errorMessage, coordinator.transcriptionEngine?.lastError)
+        set(\.matchedCalendarEvent, matchedCalendarEvent)
         set(\.needsDownload, coordinator.transcriptionEngine?.needsModelDownload ?? false)
         set(\.downloadProgress, coordinator.transcriptionEngine?.downloadProgress)
         set(\.transcriptionPrompt, settings.transcriptionModel.downloadPrompt)

--- a/OpenOats/Sources/OpenOats/Views/CalendarEventViews.swift
+++ b/OpenOats/Sources/OpenOats/Views/CalendarEventViews.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct CalendarEventSummaryRow: View {
+    let event: CalendarEvent
+    var badge: String?
+    var iconName: String = "calendar"
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: iconName)
+                .font(.system(size: 12))
+                .foregroundStyle(.tint)
+                .frame(width: 16, height: 16)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 5) {
+                    if let badge {
+                        Text(badge.uppercased())
+                            .font(.system(size: 9, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Text(event.title)
+                        .font(.system(size: 12, weight: .medium))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+
+                Text(CalendarEventDisplay.timeRange(for: event))
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+struct MatchedCalendarEventBanner: View {
+    let event: CalendarEvent
+
+    var body: some View {
+        HStack {
+            CalendarEventSummaryRow(
+                event: event,
+                badge: "Calendar",
+                iconName: event.isOnlineMeeting ? "video.fill" : "calendar.badge.checkmark"
+            )
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(.ultraThinMaterial)
+    }
+}
+
+enum CalendarEventDisplay {
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return formatter
+    }()
+
+    private static let dateTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .short
+        return formatter
+    }()
+
+    static func timeRange(for event: CalendarEvent) -> String {
+        if Calendar.current.isDate(event.startDate, inSameDayAs: event.endDate) {
+            return "\(timeFormatter.string(from: event.startDate)) - \(timeFormatter.string(from: event.endDate))"
+        }
+
+        return "\(dateTimeFormatter.string(from: event.startDate)) - \(dateTimeFormatter.string(from: event.endDate))"
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -167,6 +167,12 @@ struct ContentView: View {
                 Divider()
             }
 
+            if controllerState.isRunning, let event = controllerState.matchedCalendarEvent {
+                MatchedCalendarEventBanner(event: event)
+
+                Divider()
+            }
+
             // Suggestion panel status
             if controllerState.isRunning {
                 HStack(spacing: 6) {

--- a/OpenOats/Tests/OpenOatsTests/AppCoordinatorIntegrationTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/AppCoordinatorIntegrationTests.swift
@@ -59,6 +59,19 @@ final class AppCoordinatorIntegrationTests: XCTestCase {
         return (root, notesDirectory)
     }
 
+    private func makeCalendarEvent(title: String = "Calendar Planning") -> CalendarEvent {
+        CalendarEvent(
+            id: UUID().uuidString,
+            title: title,
+            startDate: Date().addingTimeInterval(-300),
+            endDate: Date().addingTimeInterval(1_800),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: true,
+            meetingURL: URL(string: "https://meet.example.com/calendar-planning")
+        )
+    }
+
     func testUserStoppedFinalizesSessionAndRefreshesHistory() async {
         let dirs = makeTempDirs()
         let (coordinator, _controller, settings, sessionRepository) = makeTestHarness(
@@ -116,6 +129,45 @@ final class AppCoordinatorIntegrationTests: XCTestCase {
         XCTAssertFalse(persisted?.hasNotes ?? true)
 
         // Keep controller alive for the duration of the test (weak ref in coordinator)
+        withExtendedLifetime(_controller) {}
+    }
+
+    func testFinalizationFallsBackToCalendarEventTitle() async {
+        let dirs = makeTempDirs()
+        let (coordinator, _controller, settings, sessionRepository) = makeTestHarness(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            scripted: [
+                Utterance(text: "Let's start with the project timeline.", speaker: .you),
+            ]
+        )
+
+        let event = makeCalendarEvent(title: "Calendar Planning")
+        coordinator.handle(.userStarted(.manual(calendarEvent: event)), settings: settings)
+
+        for _ in 0..<20 {
+            if coordinator.transcriptionEngine?.isRunning == true { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        coordinator.handle(.userStopped, settings: settings)
+
+        for _ in 0..<50 {
+            if case .idle = coordinator.state, coordinator.lastEndedSession != nil { break }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+
+        guard let endedSession = coordinator.lastEndedSession else {
+            XCTFail("Expected finalized session")
+            return
+        }
+
+        XCTAssertEqual(endedSession.title, "Calendar Planning")
+
+        let indices = await sessionRepository.listSessions()
+        let persisted = indices.first(where: { $0.id == endedSession.id })
+        XCTAssertEqual(persisted?.title, "Calendar Planning")
+
         withExtendedLifetime(_controller) {}
     }
 


### PR DESCRIPTION
Fixes #350

## Summary

- Show the matched Calendar event in the active meeting view while recording.
- Use the session metadata title or matched Calendar event title as the saved session title and transcript front matter title when no transcript-derived topic exists.
- Add integration coverage for finalizing a manually-started session with a Calendar event title.

## Context

This builds on Yazin's work in #349, which made Calendar authorization and current/upcoming events visible in Settings. This follow-up keeps Settings unchanged and carries the same Calendar context into the recording experience, so users can see which event was matched and get a useful saved title afterward. This also means exported transcript metadata gets the Calendar title fallback instead of an empty/generated-less title when topic detection has not produced one.


## Follow-up Direction

Longer term, it may be better to present the Calendar-derived title as a suggestion that the user can confirm or edit before it becomes the saved session title. This PR is meant as a small first step that makes the matched event visible and preserves a useful fallback title; input from @yazinsai and others on the ideal confirmation UX would be welcome.

## Screenshot

![Calendar event title shown during recording](https://gist.githubusercontent.com/kkarimi/2a32fbb097865e328cba9948788488c0/raw/295c255ece31fe0cae22c5d3ee49a978846cce09/openoats-calendar-event-title.png)

## Test Plan

- `swift test --package-path OpenOats --filter AppCoordinatorIntegrationTests/testFinalizationFallsBackToCalendarEventTitle`
- Ran a local signed build from `use-calendar-event-title` and verified the Calendar event banner appears while recording.
