### PR TITLE
Improve knowledge base indexing progress and failure states

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -20,7 +20,7 @@ final class LiveSessionState {
     var batchIsImporting: Bool = false
     var lastEndedSession: SessionIndex? = nil
     var lastSessionHasNotes: Bool = false
-    var kbIndexingProgress: String = ""
+    var kbIndexingStatus: KnowledgeBaseIndexingStatus = .idle
     var statusMessage: String? = nil
     var errorMessage: String? = nil
     var matchedCalendarEvent: CalendarEvent? = nil
@@ -89,6 +89,7 @@ final class LiveSessionController {
         while !Task.isCancelled {
             let isActive = coordinator.transcriptionEngine?.isRunning == true
                 || coordinator.batchStatus != .idle
+                || coordinator.knowledgeBase?.indexingStatus.isVisible == true
             try? await Task.sleep(for: isActive ? .milliseconds(250) : .seconds(2))
 
             // Poll batch engine status (actor-isolated)
@@ -173,6 +174,9 @@ final class LiveSessionController {
     func indexKBIfNeeded(settings: AppSettings) {
         guard let url = settings.kbFolderURL, let kb = coordinator.knowledgeBase else { return }
         Task {
+            // TODO: Coalesce repeated startup/settings-triggered reindex requests into a
+            // single in-flight task. Today ContentView startup, kbFolderPath changes, and
+            // Voyage key changes can all arrive close together and redo the same cold-start scan.
             kb.clear()
             await kb.index(folderURL: url)
         }
@@ -561,7 +565,7 @@ final class LiveSessionController {
         set(\.batchIsImporting, coordinator.batchIsImporting)
         if state.lastEndedSession?.id != lastEndedSession?.id { state.lastEndedSession = lastEndedSession }
         set(\.lastSessionHasNotes, lastSessionHasNotes)
-        set(\.kbIndexingProgress, coordinator.knowledgeBase?.indexingProgress ?? "")
+        set(\.kbIndexingStatus, coordinator.knowledgeBase?.indexingStatus ?? .idle)
         set(\.statusMessage, coordinator.transcriptionEngine?.assetStatus)
         set(\.errorMessage, coordinator.transcriptionEngine?.lastError)
         set(\.matchedCalendarEvent, matchedCalendarEvent)

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -89,7 +89,7 @@ final class LiveSessionController {
         while !Task.isCancelled {
             let isActive = coordinator.transcriptionEngine?.isRunning == true
                 || coordinator.batchStatus != .idle
-                || coordinator.knowledgeBase?.indexingStatus.isVisible == true
+                || coordinator.knowledgeBase?.indexingStatus.needsFrequentPolling == true
             try? await Task.sleep(for: isActive ? .milliseconds(250) : .seconds(2))
 
             // Poll batch engine status (actor-isolated)

--- a/OpenOats/Sources/OpenOats/Intelligence/KnowledgeBase.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/KnowledgeBase.swift
@@ -42,6 +42,97 @@ private struct KBCache: Codable, Sendable {
     var embeddingConfigFingerprint: String?
 }
 
+enum KnowledgeBaseIndexingStatus: Equatable, Sendable {
+    case idle
+    case scanning
+    case embedding(completed: Int, total: Int, activeRange: ClosedRange<Int>?)
+    case completed(total: Int)
+    case blocked(message: String)
+    case failed(message: String)
+
+    var isVisible: Bool {
+        self != .idle
+    }
+
+    var title: String {
+        switch self {
+        case .idle:
+            return ""
+        case .scanning:
+            return "Preparing knowledge base..."
+        case .embedding:
+            return "Indexing knowledge base..."
+        case .completed:
+            return "Knowledge base ready"
+        case .blocked:
+            return "Knowledge base indexing paused"
+        case .failed:
+            return "Knowledge base indexing failed"
+        }
+    }
+
+    var detailText: String? {
+        switch self {
+        case .scanning:
+            return "Scanning files and checking cached chunks"
+        case .embedding(let completed, let total, let activeRange):
+            if completed == 0 {
+                if let activeRange {
+                    return "Processing chunks \(activeRange.lowerBound.formatted())-\(activeRange.upperBound.formatted()) of \(total.formatted())"
+                }
+                return "\(total.formatted()) chunks queued"
+            }
+            return "\(completed.formatted()) of \(total.formatted()) chunks"
+        case .completed(let total):
+            return "\(total.formatted()) chunks indexed"
+        case .blocked(let message), .failed(let message):
+            return message
+        case .idle:
+            return nil
+        }
+    }
+
+    var progress: Double? {
+        guard case .embedding(let completed, let total, _) = self, total > 0, completed > 0 else {
+            return nil
+        }
+
+        return min(max(Double(completed) / Double(total), 0), 1)
+    }
+
+    var percentText: String? {
+        guard case .embedding(let completed, let total, _) = self, total > 0 else {
+            return nil
+        }
+
+        if completed <= 0 {
+            return nil
+        }
+
+        let progress = Double(completed) / Double(total)
+        if progress < 0.01 {
+            return "<1%"
+        }
+
+        return "\(Int(progress * 100))%"
+    }
+
+    var helpText: String {
+        switch self {
+        case .idle:
+            return ""
+        case .scanning:
+            return "OpenOats is scanning your Knowledge Base folder so it can prepare meeting context."
+        case .embedding:
+            return "OpenOats is indexing your Knowledge Base folder so it can surface relevant context during meetings."
+        case .completed:
+            return "OpenOats finished indexing your Knowledge Base folder and can use it during meetings."
+        case .blocked(let message), .failed(let message):
+            return message
+        }
+    }
+}
+
 /// Embedding-based knowledge base search using Voyage AI or Ollama.
 @Observable
 @MainActor
@@ -64,10 +155,10 @@ final class KnowledgeBase {
         set { withMutation(keyPath: \.fileCount) { _fileCount = newValue } }
     }
 
-    @ObservationIgnored nonisolated(unsafe) private var _indexingProgress = ""
-    private(set) var indexingProgress: String {
-        get { access(keyPath: \.indexingProgress); return _indexingProgress }
-        set { withMutation(keyPath: \.indexingProgress) { _indexingProgress = newValue } }
+    @ObservationIgnored nonisolated(unsafe) private var _indexingStatus: KnowledgeBaseIndexingStatus = .idle
+    private(set) var indexingStatus: KnowledgeBaseIndexingStatus {
+        get { access(keyPath: \.indexingStatus); return _indexingStatus }
+        set { withMutation(keyPath: \.indexingStatus) { _indexingStatus = newValue } }
     }
 
     private let settings: AppSettings
@@ -91,12 +182,12 @@ final class KnowledgeBase {
         // Validate credentials based on provider
         if provider == .voyageAI {
             guard !settings.voyageApiKey.isEmpty else {
-                indexingProgress = "No Voyage AI API key"
+                indexingStatus = .blocked(message: "Add a Voyage AI API key in Settings to index your knowledge base.")
                 return
             }
         }
 
-        indexingProgress = "Scanning files..."
+        indexingStatus = .scanning
 
         // Load existing cache; invalidate if embedding config changed
         let fingerprint = embeddingConfigFingerprint()
@@ -112,13 +203,13 @@ final class KnowledgeBase {
         }.value
 
         guard !scanResult.fileURLs.isEmpty else {
-            indexingProgress = ""
+            indexingStatus = .idle
             isIndexed = true
             return
         }
 
         var allChunks = scanResult.cachedChunks
-        var filesToEmbed = scanResult.filesToEmbed
+        let filesToEmbed = scanResult.filesToEmbed
 
         // Embed new/changed files in batches
         if !filesToEmbed.isEmpty {
@@ -130,44 +221,41 @@ final class KnowledgeBase {
                 }
             }
 
-            indexingProgress = "Embedding \(allTextsToEmbed.count) chunks..."
+            indexingStatus = .embedding(completed: 0, total: allTextsToEmbed.count, activeRange: nil)
 
             let result = await embedInBatches(texts: allTextsToEmbed)
-            let embeddings = result.embeddings
-
-            if embeddings == nil, let errMsg = result.error {
-                indexingProgress = "Embed error: \(errMsg)"
+            guard let embeddings = result.embeddings else {
+                failIndexing(message: result.error ?? "Embedding failed before any chunks were indexed.")
+                return
             }
 
-            if let embeddings {
-                var offset = 0
-                for entry in filesToEmbed {
-                    var fileChunks: [KBChunk] = []
-                    for chunk in entry.chunks {
-                        let embedding = embeddings[offset]
-                        let fileName = entry.key.components(separatedBy: ":").first ?? ""
-                        let kbChunk = KBChunk(
-                            text: chunk.text,
-                            sourceFile: fileName,
-                            headerContext: chunk.header,
-                            embedding: Self.normalizeEmbedding(embedding),
-                            relativePath: entry.relativePath,
-                            folderBreadcrumb: entry.folderBreadcrumb,
-                            documentTitle: entry.documentTitle
-                        )
-                        fileChunks.append(kbChunk)
-                        offset += 1
-                    }
-                    cache.entries[entry.key] = fileChunks
-                    allChunks.append(contentsOf: fileChunks)
+            var offset = 0
+            for entry in filesToEmbed {
+                var fileChunks: [KBChunk] = []
+                for chunk in entry.chunks {
+                    let embedding = embeddings[offset]
+                    let fileName = entry.key.components(separatedBy: ":").first ?? ""
+                    let kbChunk = KBChunk(
+                        text: chunk.text,
+                        sourceFile: fileName,
+                        headerContext: chunk.header,
+                        embedding: Self.normalizeEmbedding(embedding),
+                        relativePath: entry.relativePath,
+                        folderBreadcrumb: entry.folderBreadcrumb,
+                        documentTitle: entry.documentTitle
+                    )
+                    fileChunks.append(kbChunk)
+                    offset += 1
                 }
-
-                // Prune stale cache entries using pre-computed keys
-                let allRelevantKeys = Set(filesToEmbed.map(\.key)).union(scanResult.currentCacheKeys)
-                cache.entries = cache.entries.filter { allRelevantKeys.contains($0.key) }
-
-                saveCache(cache)
+                cache.entries[entry.key] = fileChunks
+                allChunks.append(contentsOf: fileChunks)
             }
+
+            // Prune stale cache entries using pre-computed keys
+            let allRelevantKeys = Set(filesToEmbed.map(\.key)).union(scanResult.currentCacheKeys)
+            cache.entries = cache.entries.filter { allRelevantKeys.contains($0.key) }
+
+            saveCache(cache)
         } else {
             // All files were cached — still prune stale entries
             if cache.entries.keys.count != scanResult.currentCacheKeys.count {
@@ -176,10 +264,7 @@ final class KnowledgeBase {
             }
         }
 
-        self.chunks = allChunks
-        self.fileCount = scanResult.fileCount
-        self.isIndexed = true
-        self.indexingProgress = ""
+        finishIndexing(chunks: allChunks, fileCount: scanResult.fileCount)
     }
 
     // MARK: - Background File Scanning
@@ -356,7 +441,7 @@ final class KnowledgeBase {
         chunks.removeAll()
         isIndexed = false
         fileCount = 0
-        indexingProgress = ""
+        indexingStatus = .idle
     }
 
     // MARK: - File Collection
@@ -565,6 +650,28 @@ final class KnowledgeBase {
 
     // MARK: - Embedding Batches
 
+    func finishIndexing(chunks: [KBChunk], fileCount: Int) {
+        self.chunks = chunks
+        self.fileCount = fileCount
+        self.isIndexed = true
+        showCompletedStatus(total: chunks.count)
+    }
+
+    func failIndexing(message: String) {
+        indexingStatus = .failed(message: message)
+    }
+
+    private func showCompletedStatus(total: Int) {
+        let completedStatus = KnowledgeBaseIndexingStatus.completed(total: total)
+        indexingStatus = completedStatus
+
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(3))
+            guard let self, self.indexingStatus == completedStatus else { return }
+            self.indexingStatus = .idle
+        }
+    }
+
     private func embedInBatches(texts: [String]) async -> (embeddings: [[Float]]?, error: String?) {
         let batchSize = 32
         let batches = stride(from: 0, to: texts.count, by: batchSize).map { start in
@@ -581,7 +688,9 @@ final class KnowledgeBase {
     }
 
     private func embedBatchesConcurrently(_ batches: [[String]], total: Int) async -> (embeddings: [[Float]]?, error: String?) {
-        indexingProgress = "Embedding \(total) chunks..."
+        if total > 0 {
+            indexingStatus = .embedding(completed: 0, total: total, activeRange: 1...min(32, total))
+        }
         typealias Indexed = (order: Int, embeddings: [[Float]]?)
         let results: [Indexed] = await withTaskGroup(of: Indexed.self) { group in
             for (i, batch) in batches.enumerated() {
@@ -596,7 +705,14 @@ final class KnowledgeBase {
                 }
             }
             var collected: [Indexed] = []
-            for await r in group { collected.append(r) }
+            var completed = 0
+            for await r in group {
+                collected.append(r)
+                if let embeddings = r.embeddings {
+                    completed += embeddings.count
+                    indexingStatus = .embedding(completed: min(completed, total), total: total, activeRange: nil)
+                }
+            }
             return collected.sorted { $0.order < $1.order }
         }
         guard !results.contains(where: { $0.embeddings == nil }) else {
@@ -609,13 +725,16 @@ final class KnowledgeBase {
         var allEmbeddings: [[Float]] = []
         var offset = 0
         for batch in batches {
-            let end = offset + batch.count
-            indexingProgress = "Embedding \(offset + 1)-\(end) of \(total)..."
+            let rangeStart = offset + 1
+            let rangeEnd = offset + batch.count
+            indexingStatus = .embedding(completed: offset, total: total, activeRange: rangeStart...rangeEnd)
             var retried = false
             while true {
                 do {
                     let embeddings = try await embedTexts(batch, inputType: "document")
                     allEmbeddings.append(contentsOf: embeddings)
+                    offset += embeddings.count
+                    indexingStatus = .embedding(completed: min(offset, total), total: total, activeRange: nil)
                     break
                 } catch {
                     if !retried {
@@ -626,7 +745,6 @@ final class KnowledgeBase {
                     return (nil, error.localizedDescription)
                 }
             }
-            offset = end
         }
         return (allEmbeddings, nil)
     }

--- a/OpenOats/Sources/OpenOats/Intelligence/KnowledgeBase.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/KnowledgeBase.swift
@@ -54,6 +54,15 @@ enum KnowledgeBaseIndexingStatus: Equatable, Sendable {
         self != .idle
     }
 
+    var needsFrequentPolling: Bool {
+        switch self {
+        case .scanning, .embedding, .completed:
+            return true
+        case .idle, .blocked, .failed:
+            return false
+        }
+    }
+
     var title: String {
         switch self {
         case .idle:
@@ -225,7 +234,11 @@ final class KnowledgeBase {
 
             let result = await embedInBatches(texts: allTextsToEmbed)
             guard let embeddings = result.embeddings else {
-                failIndexing(message: result.error ?? "Embedding failed before any chunks were indexed.")
+                failIndexing(
+                    message: result.error ?? "Embedding failed before any chunks were indexed.",
+                    availableChunks: allChunks,
+                    fileCount: scanResult.fileCount
+                )
                 return
             }
 
@@ -657,7 +670,19 @@ final class KnowledgeBase {
         showCompletedStatus(total: chunks.count)
     }
 
-    func failIndexing(message: String) {
+    func failIndexing(message: String, availableChunks: [KBChunk] = [], fileCount: Int? = nil) {
+        if let fileCount {
+            self.fileCount = fileCount
+        }
+
+        if availableChunks.isEmpty {
+            chunks.removeAll()
+            isIndexed = false
+        } else {
+            chunks = availableChunks
+            isIndexed = true
+        }
+
         indexingStatus = .failed(message: message)
     }
 

--- a/OpenOats/Sources/OpenOats/Intelligence/VoyageClient.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/VoyageClient.swift
@@ -77,6 +77,29 @@ actor VoyageClient {
 
     // MARK: - HTTP
 
+    nonisolated static func describeHTTPError(statusCode: Int, data: Data) -> (message: String, retryable: Bool) {
+        let detail = extractErrorDetail(from: data)
+        let normalized = detail?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lowercased = normalized?.lowercased() ?? ""
+
+        if statusCode == 429 {
+            if lowercased.contains("payment method") || lowercased.contains("billing") || lowercased.contains("balance") {
+                return ("Add a payment method in Voyage AI billing to enable knowledge base indexing.", false)
+            }
+            return ("Voyage AI is rate limiting requests. Try again in a moment.", true)
+        }
+
+        if statusCode == 401 || statusCode == 403 {
+            return ("Check your Voyage AI API key and account access.", false)
+        }
+
+        if let normalized, !normalized.isEmpty {
+            return (normalized, false)
+        }
+
+        return ("Unknown error", false)
+    }
+
     private func post<T: Encodable>(
         path: String,
         apiKey: String,
@@ -96,17 +119,26 @@ actor VoyageClient {
             throw VoyageError.httpError(-1, "No HTTP response")
         }
 
-        if http.statusCode == 429, retryOn429 {
+        let errorInfo = Self.describeHTTPError(statusCode: http.statusCode, data: data)
+
+        if http.statusCode == 429, retryOn429, errorInfo.retryable {
             try await Task.sleep(for: .seconds(20))
             return try await post(path: path, apiKey: apiKey, body: body, retryOn429: false)
         }
 
         guard (200...299).contains(http.statusCode) else {
-            let msg = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw VoyageError.httpError(http.statusCode, msg)
+            throw VoyageError.httpError(http.statusCode, errorInfo.message)
         }
 
         return data
+    }
+
+    private nonisolated static func extractErrorDetail(from data: Data) -> String? {
+        if let response = try? JSONDecoder().decode(APIErrorResponse.self, from: data) {
+            return response.detail ?? response.message ?? response.error
+        }
+
+        return String(data: data, encoding: .utf8)
     }
 
     // MARK: - Request/Response Types
@@ -141,5 +173,11 @@ actor VoyageClient {
             let index: Int
             let relevance_score: Double
         }
+    }
+
+    private struct APIErrorResponse: Decodable {
+        let detail: String?
+        let message: String?
+        let error: String?
     }
 }

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -38,14 +38,6 @@ struct ContentView: View {
 
                 Spacer()
 
-                // KB indexing status (subtle, read-only)
-                if !controllerState.kbIndexingProgress.isEmpty {
-                    Text(controllerState.kbIndexingProgress)
-                        .font(.system(size: 10))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-
                 Button {
                     openWindow(id: "notes")
                 } label: {
@@ -585,6 +577,7 @@ private struct IsolatedControlBarWrapper: View {
             isMicMuted: state.isMicMuted,
             modelDisplayName: state.modelDisplayName,
             transcriptionPrompt: state.transcriptionPrompt,
+            kbIndexingStatus: state.kbIndexingStatus,
             statusMessage: state.statusMessage,
             errorMessage: state.errorMessage,
             needsDownload: state.needsDownload,

--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -6,6 +6,7 @@ struct ControlBar: View {
     let isMicMuted: Bool
     let modelDisplayName: String
     let transcriptionPrompt: String
+    let kbIndexingStatus: KnowledgeBaseIndexingStatus
     let statusMessage: String?
     let errorMessage: String?
     let needsDownload: Bool
@@ -45,40 +46,15 @@ struct ControlBar: View {
                 .padding(.vertical, 8)
             }
 
-            // Status message (model loading / downloading)
-            if let status = statusMessage, status != "Ready" {
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack(spacing: 6) {
-                        if downloadProgress == nil {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
-                        Text(status)
-                            .font(.system(size: 12))
-                            .foregroundStyle(.secondary)
-                            .accessibilityIdentifier("app.controlBar.status")
+            if shouldShowStatusArea {
+                VStack(alignment: .leading, spacing: 8) {
+                    if let status = statusMessage, status != "Ready" {
+                        modelStatusSection(status: status)
                     }
-                    if let progress = downloadProgress {
-                        ProgressView(value: progress)
-                            .progressViewStyle(.linear)
-                            .accessibilityIdentifier("app.controlBar.downloadProgress")
 
-                        if let detail = downloadDetail {
-                            HStack(spacing: 8) {
-                                if let sizeText = detail.sizeText {
-                                    Text(sizeText)
-                                }
-                                if let speedText = detail.speedText {
-                                    Text(speedText)
-                                }
-                                if let etaText = detail.etaText {
-                                    Spacer()
-                                    Text(etaText)
-                                }
-                            }
-                            .font(.system(size: 10))
-                            .foregroundStyle(.tertiary)
-                        }
+                    if kbIndexingStatus.isVisible {
+                        KnowledgeBaseStatusView(status: kbIndexingStatus)
+                            .accessibilityIdentifier("app.controlBar.kbStatus")
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -154,6 +130,47 @@ struct ControlBar: View {
         }
     }
 
+    private var shouldShowStatusArea: Bool {
+        (statusMessage != nil && statusMessage != "Ready") || kbIndexingStatus.isVisible
+    }
+
+    @ViewBuilder
+    private func modelStatusSection(status: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                if downloadProgress == nil {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                Text(status)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("app.controlBar.status")
+            }
+            if let progress = downloadProgress {
+                ProgressView(value: progress)
+                    .progressViewStyle(.linear)
+                    .accessibilityIdentifier("app.controlBar.downloadProgress")
+
+                if let detail = downloadDetail {
+                    HStack(spacing: 8) {
+                        if let sizeText = detail.sizeText {
+                            Text(sizeText)
+                        }
+                        if let speedText = detail.speedText {
+                            Text(speedText)
+                        }
+                        if let etaText = detail.etaText {
+                            Spacer()
+                            Text(etaText)
+                        }
+                    }
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                }
+            }
+        }
+    }
 }
 
 /// Mini audio level visualizer — a few bars that react to mic input.
@@ -170,5 +187,54 @@ struct AudioLevelView: View {
             }
         }
         .animation(.easeOut(duration: 0.08), value: level)
+    }
+}
+
+private struct KnowledgeBaseStatusView: View {
+    let status: KnowledgeBaseIndexingStatus
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                if case .scanning = status {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if case .embedding(let completed, _, _) = status, completed == 0 {
+                    ProgressView()
+                        .controlSize(.small)
+                } else if case .completed = status {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.green)
+                } else if case .failed = status {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.orange)
+                } else if case .blocked = status {
+                    Image(systemName: "pause.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(status.title)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 8) {
+                Text(status.detailText ?? " ")
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer(minLength: 8)
+
+                Text(status.percentText ?? " ")
+                    .opacity(status.percentText == nil ? 0 : 1)
+            }
+            .font(.system(size: 10))
+            .foregroundStyle(.tertiary)
+            .monospacedDigit()
+        }
+        .help(status.helpText)
     }
 }

--- a/OpenOats/Tests/OpenOatsTests/KnowledgeBaseTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/KnowledgeBaseTests.swift
@@ -3,6 +3,80 @@ import XCTest
 
 final class KnowledgeBaseTests: XCTestCase {
 
+    @MainActor
+    private func makeSettings() -> AppSettings {
+        let suiteName = "com.openoats.kbtest.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let storage = AppSettingsStorage(
+            defaults: defaults,
+            secretStore: .ephemeral,
+            defaultNotesDirectory: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("KnowledgeBaseTests"),
+            runMigrations: false
+        )
+        return AppSettings(storage: storage)
+    }
+
+    // MARK: - KnowledgeBaseIndexingStatus
+
+    func testScanningStatusShowsStableDetailLine() {
+        let status = KnowledgeBaseIndexingStatus.scanning
+
+        XCTAssertEqual(status.title, "Preparing knowledge base...")
+        XCTAssertEqual(status.detailText, "Scanning files and checking cached chunks")
+        XCTAssertNil(status.percentText)
+    }
+
+    func testEmbeddingStatusFormatsCountsAndTinyPercent() {
+        let status = KnowledgeBaseIndexingStatus.embedding(completed: 32, total: 14_598, activeRange: nil)
+
+        XCTAssertEqual(status.title, "Indexing knowledge base...")
+        XCTAssertEqual(status.detailText, "32 of 14,598 chunks")
+        XCTAssertEqual(status.percentText, "<1%")
+        XCTAssertEqual(status.progress ?? -1, Double(32) / Double(14_598), accuracy: 0.0001)
+    }
+
+    func testInitialEmbeddingStatusShowsActiveFirstBatch() {
+        let status = KnowledgeBaseIndexingStatus.embedding(completed: 0, total: 128, activeRange: 1...32)
+
+        XCTAssertEqual(status.title, "Indexing knowledge base...")
+        XCTAssertNil(status.percentText)
+        XCTAssertEqual(status.detailText, "Processing chunks 1-32 of 128")
+        XCTAssertNil(status.progress)
+    }
+
+    func testCompletedStatusShowsIndexedChunkCount() {
+        let status = KnowledgeBaseIndexingStatus.completed(total: 14_634)
+
+        XCTAssertTrue(status.isVisible)
+        XCTAssertEqual(status.title, "Knowledge base ready")
+        XCTAssertEqual(status.detailText, "14,634 chunks indexed")
+        XCTAssertNil(status.progress)
+        XCTAssertNil(status.percentText)
+    }
+
+    @MainActor
+    func testFailedIndexingDoesNotMarkKnowledgeBaseReady() {
+        let kb = KnowledgeBase(settings: makeSettings())
+
+        kb.failIndexing(message: "One or more embedding batches failed")
+
+        XCTAssertEqual(kb.indexingStatus, .failed(message: "One or more embedding batches failed"))
+        XCTAssertFalse(kb.isIndexed)
+        XCTAssertTrue(kb.chunks.isEmpty)
+    }
+
+    func testBlockedStatusUsesActionableMessage() {
+        let status = KnowledgeBaseIndexingStatus.blocked(message: "Add a Voyage AI API key in Settings to index your knowledge base.")
+
+        XCTAssertTrue(status.isVisible)
+        XCTAssertEqual(status.title, "Knowledge base indexing paused")
+        XCTAssertEqual(status.detailText, "Add a Voyage AI API key in Settings to index your knowledge base.")
+        XCTAssertNil(status.progress)
+    }
+
     // MARK: - TextSimilarity.normalizedWords
 
     func testNormalizedWordsLowercases() {

--- a/OpenOats/Tests/OpenOatsTests/KnowledgeBaseTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/KnowledgeBaseTests.swift
@@ -57,6 +57,14 @@ final class KnowledgeBaseTests: XCTestCase {
         XCTAssertNil(status.percentText)
     }
 
+    func testOnlyActiveKBStatesNeedFrequentPolling() {
+        XCTAssertTrue(KnowledgeBaseIndexingStatus.scanning.needsFrequentPolling)
+        XCTAssertTrue(KnowledgeBaseIndexingStatus.embedding(completed: 0, total: 128, activeRange: 1...32).needsFrequentPolling)
+        XCTAssertTrue(KnowledgeBaseIndexingStatus.completed(total: 128).needsFrequentPolling)
+        XCTAssertFalse(KnowledgeBaseIndexingStatus.blocked(message: "missing key").needsFrequentPolling)
+        XCTAssertFalse(KnowledgeBaseIndexingStatus.failed(message: "boom").needsFrequentPolling)
+    }
+
     @MainActor
     func testFailedIndexingDoesNotMarkKnowledgeBaseReady() {
         let kb = KnowledgeBase(settings: makeSettings())
@@ -66,6 +74,28 @@ final class KnowledgeBaseTests: XCTestCase {
         XCTAssertEqual(kb.indexingStatus, .failed(message: "One or more embedding batches failed"))
         XCTAssertFalse(kb.isIndexed)
         XCTAssertTrue(kb.chunks.isEmpty)
+    }
+
+    @MainActor
+    func testFailedIndexingPreservesAvailableCachedChunks() {
+        let kb = KnowledgeBase(settings: makeSettings())
+        let cachedChunk = KBChunk(
+            text: "Cached text",
+            sourceFile: "notes.md",
+            headerContext: "Section",
+            embedding: [0.1, 0.2, 0.3]
+        )
+
+        kb.failIndexing(
+            message: "One or more embedding batches failed",
+            availableChunks: [cachedChunk],
+            fileCount: 3
+        )
+
+        XCTAssertEqual(kb.indexingStatus, .failed(message: "One or more embedding batches failed"))
+        XCTAssertTrue(kb.isIndexed)
+        XCTAssertEqual(kb.fileCount, 3)
+        XCTAssertEqual(kb.chunks.map(\.text), ["Cached text"])
     }
 
     func testBlockedStatusUsesActionableMessage() {

--- a/OpenOats/Tests/OpenOatsTests/VoyageClientTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/VoyageClientTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class VoyageClientTests: XCTestCase {
+    func testDescribeHTTPErrorMapsBilling429ToActionableMessage() {
+        let data = #"{"detail":"You have not yet added your payment method in the billing page and will not be able to make requests"}"#
+            .data(using: .utf8)!
+
+        let error = VoyageClient.describeHTTPError(statusCode: 429, data: data)
+
+        XCTAssertEqual(error.message, "Add a payment method in Voyage AI billing to enable knowledge base indexing.")
+        XCTAssertFalse(error.retryable)
+    }
+
+    func testDescribeHTTPErrorKeepsGeneric429Retryable() {
+        let data = #"{"detail":"Rate limit exceeded"}"#.data(using: .utf8)!
+
+        let error = VoyageClient.describeHTTPError(statusCode: 429, data: data)
+
+        XCTAssertEqual(error.message, "Voyage AI is rate limiting requests. Try again in a moment.")
+        XCTAssertTrue(error.retryable)
+    }
+
+    func testDescribeHTTPErrorParsesJSONDetailWithoutRawBlob() {
+        let data = #"{"detail":"Bad request payload"}"#.data(using: .utf8)!
+
+        let error = VoyageClient.describeHTTPError(statusCode: 400, data: data)
+
+        XCTAssertEqual(error.message, "Bad request payload")
+        XCTAssertFalse(error.retryable)
+    }
+}


### PR DESCRIPTION
Fixes #353

## Summary

This improves knowledge base indexing feedback during app startup and indexing.

- moves KB indexing status out of the truncated header label and into the bottom control-bar status area
- replaces raw KB progress strings with structured indexing state for scanning, active indexing, completion, blocked, and failed states
- keeps the status tray layout stable so the title row does not jump between one-line and two-line states
- shows active first-batch progress more clearly and keeps a short visible completion state
- preserves embedding failures instead of incorrectly falling through to a fake `Knowledge base ready / 0 chunks indexed` state
- maps Voyage billing and rate-limit failures to shorter actionable messages

## Why

Before this change, KB indexing feedback was hard to trust:

- the header text was truncated and looked like internal implementation detail
- indexing progress could look stuck even when the first batch was in flight
- the status layout changed height across phases
- completion could disappear too quickly to notice
- failed Voyage embedding runs could surface as raw JSON or be overwritten by a misleading success state

## Impact

Users now get a native-feeling status area that explains KB indexing progress and failures more clearly, especially during first-run indexing or Voyage account setup issues.

## Validation

- `swift test --package-path OpenOats --filter KnowledgeBaseTests`
- `swift test --package-path OpenOats --filter VoyageClientTests`
- `swift test --package-path OpenOats --filter LiveSessionControllerTests/testPollingDoesNotReadVoyageKeyWhenKnowledgeBaseFolderUnset`
- local signed dev build run to verify scanning, progress, completion, and Voyage billing failure states

## Screenshots

Progress state:

![Knowledge base indexing progress](https://raw.githubusercontent.com/kkarimi/OpenOats/pr-assets-knowledge-base-indexing-status/pr-assets/kb-indexing-progress.png)

Ready state:

![Knowledge base indexing ready](https://raw.githubusercontent.com/kkarimi/OpenOats/pr-assets-knowledge-base-indexing-status/pr-assets/kb-indexing-ready.png)
