### PR TITLE
Fix past-meeting rename flow in Notes

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -5,7 +5,7 @@ struct NotesView: View {
     @Bindable var settings: AppSettings
     @Environment(AppCoordinator.self) private var coordinator
     @State private var notesController: NotesController?
-    @State private var renamingSession: SessionIndex?
+    @State private var renamingSessionID: String?
     @State private var renameText: String = ""
     @FocusState private var renameFieldFocused: Bool
     @State private var sessionToDelete: String?
@@ -73,8 +73,15 @@ struct NotesView: View {
                 detailViewMode = .notes
             }
         }
-        .sheet(item: $renamingSession) { session in
-            renameSessionSheet(controller: controller, session: session)
+        .sheet(
+            isPresented: Binding(
+                get: { renamingSessionID != nil },
+                set: { if !$0 { cancelRename() } }
+            )
+        ) {
+            if let sessionID = renamingSessionID {
+                renameSessionSheet(controller: controller, sessionID: sessionID)
+            }
         }
     }
 
@@ -193,7 +200,7 @@ struct NotesView: View {
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                 }
-                Text(renamePlaceholder(for: session))
+                Text(sessionTitle(for: session))
                     .font(.system(size: 13, weight: .medium))
                     .lineLimit(1)
                     .accessibilityIdentifier("notes.sessionTitle.\(session.id)")
@@ -239,12 +246,12 @@ struct NotesView: View {
     }
 
     @ViewBuilder
-    private func renameSessionSheet(controller: NotesController, session: SessionIndex) -> some View {
+    private func renameSessionSheet(controller: NotesController, sessionID: String) -> some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("Rename Meeting")
                 .font(.headline)
 
-            TextField(renamePlaceholder(for: session), text: $renameText)
+            TextField(renamePlaceholder(for: sessionID, controller: controller), text: $renameText)
                 .textFieldStyle(.roundedBorder)
                 .focused($renameFieldFocused)
                 .accessibilityIdentifier("notes.renameSheet.field")
@@ -252,7 +259,7 @@ struct NotesView: View {
                     renameFieldFocused = true
                 }
                 .onSubmit {
-                    commitRename(controller: controller, sessionID: session.id)
+                    commitRename(controller: controller, sessionID: sessionID)
                 }
 
             HStack {
@@ -263,7 +270,7 @@ struct NotesView: View {
                 .keyboardShortcut(.cancelAction)
 
                 Button("Rename") {
-                    commitRename(controller: controller, sessionID: session.id)
+                    commitRename(controller: controller, sessionID: sessionID)
                 }
                 .keyboardShortcut(.defaultAction)
                 .accessibilityIdentifier("notes.renameSheet.saveButton")
@@ -276,8 +283,7 @@ struct NotesView: View {
 
     private func beginRenaming(_ session: SessionIndex) {
         renameText = session.title ?? ""
-        renamingSession = session
-        renameFieldFocused = true
+        renamingSessionID = session.id
     }
 
     private func commitRename(controller: NotesController, sessionID: String) {
@@ -287,16 +293,22 @@ struct NotesView: View {
     }
 
     private func cancelRename() {
-        renamingSession = nil
+        renamingSessionID = nil
         renameFieldFocused = false
         renameText = ""
     }
 
-    private func renamePlaceholder(for session: SessionIndex) -> String {
-        if let title = session.title, !title.isEmpty {
-            return title
-        }
-        return "Untitled"
+    private func sessionTitle(for session: SessionIndex) -> String {
+        let title = session.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return (title?.isEmpty == false ? title : nil) ?? "Untitled"
+    }
+
+    private func renamePlaceholder(for sessionID: String, controller: NotesController) -> String {
+        let title = controller.state.sessionHistory
+            .first(where: { $0.id == sessionID })?
+            .title?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (title?.isEmpty == false ? title : nil) ?? "Untitled"
     }
 
     // MARK: - Tag Filter Bar

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -5,8 +5,9 @@ struct NotesView: View {
     @Bindable var settings: AppSettings
     @Environment(AppCoordinator.self) private var coordinator
     @State private var notesController: NotesController?
-    @State private var renamingSessionID: String?
+    @State private var renamingSession: SessionIndex?
     @State private var renameText: String = ""
+    @FocusState private var renameFieldFocused: Bool
     @State private var sessionToDelete: String?
     @State private var showDeleteConfirmation = false
     @State private var bulkDeleteMode = false
@@ -72,6 +73,9 @@ struct NotesView: View {
                 detailViewMode = .notes
             }
         }
+        .sheet(item: $renamingSession) { session in
+            renameSessionSheet(controller: controller, session: session)
+        }
     }
 
     // MARK: - Sidebar
@@ -126,8 +130,7 @@ struct NotesView: View {
                     sessionRow(controller: controller, session: session)
                         .contextMenu {
                             Button("Rename...") {
-                                renameText = session.title ?? ""
-                                renamingSessionID = session.id
+                                beginRenaming(session)
                             }
                             Button("Edit Tags...") {
                                 editingTags = session.tags ?? []
@@ -190,21 +193,10 @@ struct NotesView: View {
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                 }
-                if renamingSessionID == session.id {
-                    TextField("Title", text: $renameText, onCommit: {
-                        controller.renameSession(sessionID: session.id, newTitle: renameText)
-                        renamingSessionID = nil
-                    })
+                Text(renamePlaceholder(for: session))
                     .font(.system(size: 13, weight: .medium))
-                    .textFieldStyle(.plain)
-                    .onExitCommand {
-                        renamingSessionID = nil
-                    }
-                } else {
-                    Text(session.title ?? "Untitled")
-                        .font(.system(size: 13, weight: .medium))
-                        .lineLimit(1)
-                }
+                    .lineLimit(1)
+                    .accessibilityIdentifier("notes.sessionTitle.\(session.id)")
                 Spacer()
                 if controller.isGenerating(sessionID: session.id) {
                     ProgressView().controlSize(.mini).scaleEffect(0.7)
@@ -244,6 +236,67 @@ struct NotesView: View {
         }
         .padding(.vertical, 2)
         .accessibilityIdentifier("notes.session.\(session.id)")
+    }
+
+    @ViewBuilder
+    private func renameSessionSheet(controller: NotesController, session: SessionIndex) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Rename Meeting")
+                .font(.headline)
+
+            TextField(renamePlaceholder(for: session), text: $renameText)
+                .textFieldStyle(.roundedBorder)
+                .focused($renameFieldFocused)
+                .accessibilityIdentifier("notes.renameSheet.field")
+                .onAppear {
+                    renameFieldFocused = true
+                }
+                .onSubmit {
+                    commitRename(controller: controller, sessionID: session.id)
+                }
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    cancelRename()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Rename") {
+                    commitRename(controller: controller, sessionID: session.id)
+                }
+                .keyboardShortcut(.defaultAction)
+                .accessibilityIdentifier("notes.renameSheet.saveButton")
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+        .accessibilityIdentifier("notes.renameSheet")
+    }
+
+    private func beginRenaming(_ session: SessionIndex) {
+        renameText = session.title ?? ""
+        renamingSession = session
+        renameFieldFocused = true
+    }
+
+    private func commitRename(controller: NotesController, sessionID: String) {
+        let trimmedTitle = renameText.trimmingCharacters(in: .whitespacesAndNewlines)
+        controller.renameSession(sessionID: sessionID, newTitle: trimmedTitle)
+        cancelRename()
+    }
+
+    private func cancelRename() {
+        renamingSession = nil
+        renameFieldFocused = false
+        renameText = ""
+    }
+
+    private func renamePlaceholder(for session: SessionIndex) -> String {
+        if let title = session.title, !title.isEmpty {
+            return title
+        }
+        return "Untitled"
     }
 
     // MARK: - Tag Filter Bar

--- a/UITests/OpenOatsUITests/SmokeTests.swift
+++ b/UITests/OpenOatsUITests/SmokeTests.swift
@@ -64,6 +64,32 @@ final class SmokeTests: XCTestCase {
         XCTAssertTrue(element(in: app, identifier: "notes.renderedMarkdown").waitForExistence(timeout: 5))
     }
 
+    func testNotesSmokeSupportsRenamingFromContextMenu() async {
+        let app = launchApp(scenario: "notesSmoke")
+
+        let deepLink = URL(string: "openoats://notes?sessionID=session_ui_test_notes")!
+        await openDeepLink(deepLink)
+
+        let sessionRow = element(in: app, identifier: "notes.session.session_ui_test_notes")
+        XCTAssertTrue(sessionRow.waitForExistence(timeout: 5))
+
+        sessionRow.rightClick()
+
+        let renameMenuItem = app.menuItems["Rename..."]
+        XCTAssertTrue(renameMenuItem.waitForExistence(timeout: 5))
+        renameMenuItem.click()
+
+        let renameField = app.textFields.firstMatch
+        XCTAssertTrue(renameField.waitForExistence(timeout: 5))
+        renameField.click()
+        renameField.typeKey("a", modifierFlags: .command)
+        renameField.typeText("Renamed Discovery Call")
+        app.typeKey(XCUIKeyboardKey.return.rawValue, modifierFlags: [])
+
+        let titleLabel = app.staticTexts["Renamed Discovery Call"]
+        XCTAssertTrue(titleLabel.waitForExistence(timeout: 5))
+    }
+
     private func launchApp(scenario: String) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["OPENOATS_UI_TEST"] = "1"


### PR DESCRIPTION
Fixes #355

## Summary
- replace the dead inline sidebar rename field with a focused rename sheet
- keep the existing right-click `Rename...` entry point, but make the input obvious and commit on Return/default action
- add a Notes UI smoke test that covers the context-menu rename flow end to end

## Why
The previous interaction just swapped the row to a tiny inline `Title` field in the sidebar, which made the rename path look broken and easy to miss. A small sheet is a more idiomatic macOS rename flow here and is much easier to focus and verify.

## Screenshot
![Rename Meeting sheet](https://raw.githubusercontent.com/kkarimi/OpenOats/pr-assets-notes-rename-context-menu/pr-assets/notes-rename-sheet.png)

## Testing
- `xcodebuild -project UITests/OpenOatsUITestHost.xcodeproj -scheme OpenOatsUITestHost -destination 'platform=macOS' -derivedDataPath .build/ui-smoke/DerivedData -clonedSourcePackagesDirPath .build/ui-smoke/SourcePackages ONLY_ACTIVE_ARCH=YES AD_HOC_CODE_SIGNING_ALLOWED=YES -only-testing:OpenOatsUITests/SmokeTests/testNotesSmokeSupportsRenamingFromContextMenu build-for-testing test-without-building`
