### PR TITLE
Fix batch transcript metadata and preserve rerun assets

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -448,7 +448,8 @@ final class LiveSessionController {
                         micStartDate: anchorsData.micStartDate,
                         sysStartDate: anchorsData.sysStartDate,
                         micAnchors: anchorsData.micAnchors,
-                        sysAnchors: anchorsData.sysAnchors
+                        sysAnchors: anchorsData.sysAnchors,
+                        sysEffectiveSampleRate: anchorsData.sysEffectiveSampleRate
                     )
                 )
 
@@ -463,7 +464,8 @@ final class LiveSessionController {
                         micStartDate: sealed.micStartDate,
                         sysStartDate: sealed.sysStartDate,
                         micAnchors: sealed.micAnchors,
-                        sysAnchors: sealed.sysAnchors
+                        sysAnchors: sealed.sysAnchors,
+                        sysEffectiveSampleRate: sealed.sysEffectiveSampleRate
                     )
                 )
             } else if wantsExport {

--- a/OpenOats/Sources/OpenOats/Audio/AudioRecorder.swift
+++ b/OpenOats/Sources/OpenOats/Audio/AudioRecorder.swift
@@ -223,10 +223,21 @@ final class AudioRecorder: @unchecked Sendable {
     func timingAnchors() -> (
         micStartDate: Date?, sysStartDate: Date?,
         micAnchors: [(frame: Int64, date: Date)],
-        sysAnchors: [(frame: Int64, date: Date)]
+        sysAnchors: [(frame: Int64, date: Date)],
+        sysEffectiveSampleRate: Double?
     ) {
         lock.withLock {
-            (micStartDate, sysStartDate, micAnchors, sysAnchors)
+            (
+                micStartDate,
+                sysStartDate,
+                micAnchors,
+                sysAnchors,
+                Self.effectiveSystemSampleRate(
+                    startDate: sysStartDate,
+                    endDate: sysEndDate,
+                    endFrame: sysEndFrame
+                )
+            )
         }
     }
 
@@ -236,7 +247,8 @@ final class AudioRecorder: @unchecked Sendable {
         mic: URL?, sys: URL?,
         micStartDate: Date?, sysStartDate: Date?,
         micAnchors: [(frame: Int64, date: Date)],
-        sysAnchors: [(frame: Int64, date: Date)]
+        sysAnchors: [(frame: Int64, date: Date)],
+        sysEffectiveSampleRate: Double?
     ) {
         lock.withLock {
             micFile = nil
@@ -244,7 +256,13 @@ final class AudioRecorder: @unchecked Sendable {
             let result = (
                 mic: micTempURL, sys: sysTempURL,
                 micStartDate: self.micStartDate, sysStartDate: self.sysStartDate,
-                micAnchors: self.micAnchors, sysAnchors: self.sysAnchors
+                micAnchors: self.micAnchors,
+                sysAnchors: self.sysAnchors,
+                sysEffectiveSampleRate: Self.effectiveSystemSampleRate(
+                    startDate: self.sysStartDate,
+                    endDate: self.sysEndDate,
+                    endFrame: self.sysEndFrame
+                )
             )
             micTempURL = nil
             sysTempURL = nil
@@ -294,14 +312,11 @@ final class AudioRecorder: @unchecked Sendable {
 
     private func mergeAndEncode() {
         let (micURL, sysURL, dir, timestamp, sysEffectiveRate, dirIsSecurityScoped) = lock.withLock {
-            // Effective sample rate: corrects for process tap delivering at lower rate than declared.
-            var effectiveRate: Double? = nil
-            if let start = sysStartDate, let end = sysEndDate, sysEndFrame > 0 {
-                let wallClockSeconds = end.timeIntervalSince(start)
-                if wallClockSeconds > 1.0 {
-                    effectiveRate = Double(sysEndFrame) / wallClockSeconds
-                }
-            }
+            let effectiveRate = Self.effectiveSystemSampleRate(
+                startDate: sysStartDate,
+                endDate: sysEndDate,
+                endFrame: sysEndFrame
+            )
             return (micTempURL, sysTempURL, outputDirectory, sessionTimestamp, effectiveRate, outputDirectoryIsSecurityScoped)
         }
 
@@ -501,5 +516,16 @@ final class AudioRecorder: @unchecked Sendable {
             for ch in 0..<channels { sum += data[ch][i] }
             return sum * scale
         }
+    }
+
+    private static func effectiveSystemSampleRate(
+        startDate: Date?,
+        endDate: Date?,
+        endFrame: Int64
+    ) -> Double? {
+        guard let startDate, let endDate, endFrame > 0 else { return nil }
+        let wallClockSeconds = endDate.timeIntervalSince(startDate)
+        guard wallClockSeconds > 1.0 else { return nil }
+        return Double(endFrame) / wallClockSeconds
     }
 }

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -103,6 +103,9 @@ struct SessionMetadata: Codable, Sendable {
 /// sessions/<id>/audio/
 /// ```
 actor SessionRepository {
+    /// Retain batch stems/metadata long enough to support true reruns and debugging.
+    private static let retainedBatchAudioLifetime: TimeInterval = 7 * 24 * 3600
+
     private let sessionsDirectory: URL
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
@@ -150,7 +153,7 @@ actor SessionRepository {
         try? FileManager.default.createDirectory(at: sessionsDirectory, withIntermediateDirectories: true)
         Self.dropMetadataNeverIndex(in: sessionsDirectory)
 
-        Self.cleanupOrphanedBatchAudio(in: sessionsDirectory)
+        Self.cleanupExpiredRetainedBatchAudio(in: sessionsDirectory)
     }
 
     // MARK: - Configuration
@@ -440,6 +443,24 @@ actor SessionRepository {
             try fm.moveItem(at: tempURL, to: finalURL)
         } catch {
             Log.sessionRepository.error("Failed to write final transcript: \(error, privacy: .public)")
+        }
+
+        if let meta = loadSessionMetadataFile(sessionID: sessionID) {
+            let refreshedMeta = SessionMetadata(
+                id: meta.id,
+                startedAt: records.first?.timestamp ?? meta.startedAt,
+                endedAt: records.last?.timestamp ?? meta.endedAt,
+                templateSnapshot: meta.templateSnapshot,
+                title: meta.title,
+                utteranceCount: records.count,
+                hasNotes: meta.hasNotes,
+                language: meta.language,
+                meetingApp: meta.meetingApp,
+                engine: meta.engine,
+                tags: meta.tags,
+                source: meta.source
+            )
+            writeSessionMetadata(refreshedMeta, sessionID: sessionID)
         }
 
         // Mirror to notesFolderPath
@@ -838,7 +859,8 @@ actor SessionRepository {
             micStartDate: anchors.micStartDate,
             sysStartDate: anchors.sysStartDate,
             micAnchors: anchors.micAnchors.map { .init(frame: $0.frame, date: $0.date) },
-            sysAnchors: anchors.sysAnchors.map { .init(frame: $0.frame, date: $0.date) }
+            sysAnchors: anchors.sysAnchors.map { .init(frame: $0.frame, date: $0.date) },
+            sysEffectiveSampleRate: anchors.sysEffectiveSampleRate
         )
         if let data = try? JSONEncoder.iso8601Encoder.encode(meta) {
             try? data.write(to: audioDir.appendingPathComponent("batch-meta.json"), options: .atomic)
@@ -1254,14 +1276,14 @@ actor SessionRepository {
 
     // MARK: - Orphan Cleanup
 
-    private static func cleanupOrphanedBatchAudio(in sessionsDirectory: URL) {
+    private static func cleanupExpiredRetainedBatchAudio(in sessionsDirectory: URL) {
         let fm = FileManager.default
         guard let contents = try? fm.contentsOfDirectory(
             at: sessionsDirectory,
             includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey]
         ) else { return }
 
-        let cutoff = Date().addingTimeInterval(-24 * 3600)
+        let cutoff = Date().addingTimeInterval(-retainedBatchAudioLifetime)
 
         for item in contents {
             guard let values = try? item.resourceValues(forKeys: [.isDirectoryKey, .contentModificationDateKey]),
@@ -1291,7 +1313,7 @@ actor SessionRepository {
                 try? fm.removeItem(at: micLegacy)
                 try? fm.removeItem(at: sysLegacy)
                 try? fm.removeItem(at: item.appendingPathComponent("batch-meta.json"))
-                Log.sessionRepository.info("Cleaned up orphaned batch audio in \(name, privacy: .public)")
+                Log.sessionRepository.info("Cleaned up expired retained batch audio in \(name, privacy: .public)")
             }
         }
     }
@@ -1305,6 +1327,7 @@ struct BatchAnchors: Sendable {
     let sysStartDate: Date?
     let micAnchors: [(frame: Int64, date: Date)]
     let sysAnchors: [(frame: Int64, date: Date)]
+    let sysEffectiveSampleRate: Double?
 }
 
 /// Codable batch metadata persisted as batch-meta.json.
@@ -1313,6 +1336,7 @@ struct BatchMeta: Codable, Sendable {
     let sysStartDate: Date?
     let micAnchors: [TimingAnchor]
     let sysAnchors: [TimingAnchor]
+    let sysEffectiveSampleRate: Double?
 
     struct TimingAnchor: Codable, Sendable {
         let frame: Int64

--- a/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
@@ -297,16 +297,14 @@ actor BatchAudioTranscriber {
 
         guard !allRecords.isEmpty else {
             Log.batchTranscription.warning("Batch transcription produced no records for \(sessionID, privacy: .public)")
-            await sessionRepository.cleanupBatchAudio(sessionID: sessionID)
             status = .completed(sessionID: sessionID)
             return
         }
 
         // Atomic write of final transcript + full markdown regeneration via mirroring
         await sessionRepository.saveFinalTranscript(sessionID: sessionID, records: allRecords)
-
-        // Cleanup audio files
-        await sessionRepository.cleanupBatchAudio(sessionID: sessionID)
+        // Retain batch stems/metadata for a bounded rerun/debug window.
+        // SessionRepository purges expired retained assets on startup.
 
         status = .completed(sessionID: sessionID)
         Log.batchTranscription.info("Batch transcription completed for \(sessionID, privacy: .public): \(allRecords.count, privacy: .public) records")
@@ -570,7 +568,7 @@ actor BatchAudioTranscriber {
             micStartDate: meta.micStartDate,
             sysStartDate: meta.sysStartDate,
             micSampleRate: nil,
-            sysSampleRate: nil
+            sysSampleRate: meta.sysEffectiveSampleRate
         )
     }
 

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -416,15 +416,17 @@ final class SessionRepositoryTests: XCTestCase {
 
     func testSaveFinalTranscript() async {
         let sessionID = "session_final_test"
+        let initialStart = Date(timeIntervalSince1970: 100)
         await repo.seedSession(
             id: sessionID,
-            records: [SessionRecord(speaker: .you, text: "Live", timestamp: Date())],
-            startedAt: Date()
+            records: [SessionRecord(speaker: .you, text: "Live", timestamp: initialStart)],
+            startedAt: initialStart
         )
 
+        let finalStart = Date(timeIntervalSince1970: 200)
         let finalRecords = [
-            SessionRecord(speaker: .you, text: "Final A", timestamp: Date()),
-            SessionRecord(speaker: .them, text: "Final B", timestamp: Date()),
+            SessionRecord(speaker: .you, text: "Final A", timestamp: finalStart),
+            SessionRecord(speaker: .them, text: "Final B", timestamp: finalStart.addingTimeInterval(12)),
         ]
         await repo.saveFinalTranscript(sessionID: sessionID, records: finalRecords)
 
@@ -438,7 +440,81 @@ final class SessionRepositoryTests: XCTestCase {
         XCTAssertEqual(live.count, 1)
         XCTAssertEqual(live[0].text, "Live")
 
+        let sessions = await repo.listSessions()
+        let saved = sessions.first(where: { $0.id == sessionID })
+        XCTAssertEqual(saved?.utteranceCount, finalRecords.count)
+        XCTAssertEqual(saved?.startedAt, finalStart)
+        XCTAssertEqual(saved?.endedAt, finalStart.addingTimeInterval(12))
+
         await repo.deleteSession(sessionID: sessionID)
+    }
+
+    func testBatchMetaPersistsEffectiveSystemSampleRate() async {
+        let sessionID = "session_batch_meta"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Live", timestamp: Date())],
+            startedAt: Date()
+        )
+
+        let tempDir = rootDir.appendingPathComponent("batch_temp", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let micURL = tempDir.appendingPathComponent("mic.caf")
+        let sysURL = tempDir.appendingPathComponent("sys.caf")
+        FileManager.default.createFile(atPath: micURL.path, contents: Data())
+        FileManager.default.createFile(atPath: sysURL.path, contents: Data())
+
+        await repo.stashAudioForBatch(
+            sessionID: sessionID,
+            micURL: micURL,
+            sysURL: sysURL,
+            anchors: BatchAnchors(
+                micStartDate: Date(timeIntervalSince1970: 10),
+                sysStartDate: Date(timeIntervalSince1970: 20),
+                micAnchors: [(frame: 0, date: Date(timeIntervalSince1970: 10))],
+                sysAnchors: [(frame: 0, date: Date(timeIntervalSince1970: 20))],
+                sysEffectiveSampleRate: 24_000
+            )
+        )
+
+        let meta = await repo.loadBatchMeta(sessionID: sessionID)
+        XCTAssertEqual(meta?.sysEffectiveSampleRate, 24_000)
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
+    func testInitRetainsRecentBatchAudioForRerunWindow() async throws {
+        let sessionID = "session_recent_batch_audio"
+        let sessionDir = try makeSessionWithBatchAudio(sessionID: sessionID)
+        try setModificationDate(
+            Date().addingTimeInterval(-(6 * 24 * 3600)),
+            forSessionDirectory: sessionDir
+        )
+
+        let freshRepo = SessionRepository(rootDirectory: rootDir)
+        let urls = await freshRepo.batchAudioURLs(sessionID: sessionID)
+        let meta = await freshRepo.loadBatchMeta(sessionID: sessionID)
+
+        XCTAssertNotNil(urls.mic)
+        XCTAssertNotNil(urls.sys)
+        XCTAssertNotNil(meta)
+    }
+
+    func testInitCleansExpiredBatchAudioAfterRerunWindow() async throws {
+        let sessionID = "session_expired_batch_audio"
+        let sessionDir = try makeSessionWithBatchAudio(sessionID: sessionID)
+        try setModificationDate(
+            Date().addingTimeInterval(-(8 * 24 * 3600)),
+            forSessionDirectory: sessionDir
+        )
+
+        let freshRepo = SessionRepository(rootDirectory: rootDir)
+        let urls = await freshRepo.batchAudioURLs(sessionID: sessionID)
+        let meta = await freshRepo.loadBatchMeta(sessionID: sessionID)
+
+        XCTAssertNil(urls.mic)
+        XCTAssertNil(urls.sys)
+        XCTAssertNil(meta)
     }
 
     // MARK: - moveToRecentlyDeleted
@@ -455,6 +531,50 @@ final class SessionRepositoryTests: XCTestCase {
 
         let sessions = await repo.listSessions()
         XCTAssertFalse(sessions.contains(where: { $0.id == sessionID }))
+    }
+
+    private func makeSessionWithBatchAudio(sessionID: String) throws -> URL {
+        let sessionsDir = rootDir.appendingPathComponent("sessions", isDirectory: true)
+        let sessionDir = sessionsDir.appendingPathComponent(sessionID, isDirectory: true)
+        let audioDir = sessionDir.appendingPathComponent("audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+
+        let metadata = SessionMetadata(
+            id: sessionID,
+            startedAt: Date(timeIntervalSince1970: 10),
+            endedAt: Date(timeIntervalSince1970: 20),
+            templateSnapshot: nil,
+            title: "Batch Audio",
+            utteranceCount: 1,
+            hasNotes: false,
+            language: "en-GB",
+            meetingApp: nil,
+            engine: "parakeetV2",
+            tags: nil,
+            source: nil
+        )
+        let data = try JSONEncoder.iso8601Encoder.encode(metadata)
+        try data.write(to: sessionDir.appendingPathComponent("session.json"), options: .atomic)
+        try Data().write(to: sessionDir.appendingPathComponent("transcript.live.jsonl"), options: .atomic)
+
+        try Data("mic".utf8).write(to: audioDir.appendingPathComponent("mic.caf"), options: .atomic)
+        try Data("sys".utf8).write(to: audioDir.appendingPathComponent("sys.caf"), options: .atomic)
+
+        let batchMeta = BatchMeta(
+            micStartDate: Date(timeIntervalSince1970: 10),
+            sysStartDate: Date(timeIntervalSince1970: 20),
+            micAnchors: [.init(frame: 0, date: Date(timeIntervalSince1970: 10))],
+            sysAnchors: [.init(frame: 0, date: Date(timeIntervalSince1970: 20))],
+            sysEffectiveSampleRate: 24_000
+        )
+        let metaData = try JSONEncoder.iso8601Encoder.encode(batchMeta)
+        try metaData.write(to: audioDir.appendingPathComponent("batch-meta.json"), options: .atomic)
+
+        return sessionDir
+    }
+
+    private func setModificationDate(_ date: Date, forSessionDirectory sessionDir: URL) throws {
+        try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: sessionDir.path)
     }
 
     // MARK: - End session clears state


### PR DESCRIPTION
Fixes #359

## Summary

- refresh `session.json` from `transcript.final.jsonl` so the saved session metadata matches the batch transcript
- carry the recorder's effective system sample rate into batch metadata and use it when reconstructing system-audio timestamps
- retain batch stems and `batch-meta.json` for a bounded rerun/debug window instead of deleting them immediately after batch transcription

## Why

This fixes two concrete post-meeting issues:

- Notes/Past Meetings can show stale meeting times and `0 utterances` even though a final transcript exists
- completed sessions cannot be truly rerun/debugged because the original batch stems are deleted immediately

The sample-rate change also fixes a real timing bug in the batch path by reusing the recorder's drift correction during final transcript reconstruction.

## Validation

- `swift test --package-path OpenOats --filter SessionRepositoryTests`
- `swift test --package-path OpenOats --filter AudioRecorderTests`
