### PR TITLE
Hide internal Granola tags and group Notes imports by source

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -43,6 +43,12 @@ enum GenerationStatus: Equatable {
     case error(String)
 }
 
+struct SessionSourceGroup: Identifiable {
+    let id: String
+    let title: String
+    let sessions: [SessionIndex]
+}
+
 // MARK: - Controller
 
 /// Owns all notes/history business logic previously embedded in NotesView.
@@ -400,8 +406,35 @@ final class NotesController {
     var filteredSessions: [SessionIndex] {
         guard let filter = state.tagFilter else { return state.sessionHistory }
         return state.sessionHistory.filter { session in
-            session.tags?.contains(where: { $0.localizedCaseInsensitiveCompare(filter) == .orderedSame }) ?? false
+            Self.visibleTags(for: session).contains {
+                $0.localizedCaseInsensitiveCompare(filter) == .orderedSame
+            }
         }
+    }
+
+    var sessionSourceGroups: [SessionSourceGroup] {
+        let grouped = Dictionary(grouping: filteredSessions, by: Self.sourceGroupKey(for:))
+        let orderedKeys = grouped.keys.sorted { lhs, rhs in
+            let lhsOrder = Self.sourceGroupSortOrder(for: lhs)
+            let rhsOrder = Self.sourceGroupSortOrder(for: rhs)
+            if lhsOrder != rhsOrder { return lhsOrder < rhsOrder }
+            return Self.sourceDisplayName(for: lhs).localizedCaseInsensitiveCompare(
+                Self.sourceDisplayName(for: rhs)
+            ) == .orderedAscending
+        }
+        return orderedKeys.map { key in
+            SessionSourceGroup(
+                id: key,
+                title: Self.sourceDisplayName(for: key),
+                sessions: grouped[key] ?? []
+            )
+        }
+    }
+
+    var showsSourceSections: Bool {
+        let groups = sessionSourceGroups
+        guard !groups.isEmpty else { return false }
+        return groups.count > 1 || groups.first?.id != "openoats"
     }
 
     func updateSessionTags(sessionID: String, tags: [String]) {
@@ -416,7 +449,49 @@ final class NotesController {
     }
 
     func allTags() async -> [String] {
-        await coordinator.sessionRepository.allTags()
+        await coordinator.sessionRepository.allTags().filter(Self.isUserVisibleSessionTag(_:))
+    }
+
+    static func visibleTags(for session: SessionIndex) -> [String] {
+        visibleTags(from: session.tags)
+    }
+
+    static func visibleTags(from tags: [String]?) -> [String] {
+        (tags ?? []).filter(isUserVisibleSessionTag)
+    }
+
+    static func isUserVisibleSessionTag(_ tag: String) -> Bool {
+        !tag.lowercased().hasPrefix("granola:")
+    }
+
+    static func sourceGroupKey(for session: SessionIndex) -> String {
+        guard let rawSource = session.source?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawSource.isEmpty else {
+            return "openoats"
+        }
+        return rawSource.lowercased()
+    }
+
+    static func sourceDisplayName(for sourceKey: String) -> String {
+        switch sourceKey {
+        case "openoats":
+            "OpenOats"
+        case "granola":
+            "Granola"
+        default:
+            sourceKey.replacingOccurrences(of: "-", with: " ").capitalized
+        }
+    }
+
+    private static func sourceGroupSortOrder(for sourceKey: String) -> Int {
+        switch sourceKey {
+        case "openoats":
+            0
+        case "granola":
+            1
+        default:
+            2
+        }
     }
 
     // MARK: - Accessors

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -690,11 +690,13 @@ actor SessionRepository {
     }
 
     func updateSessionTags(sessionID: String, tags: [String]) {
-        let normalized = Self.normalizeTags(tags)
+        let normalizedVisibleTags = Self.normalizeUserVisibleTags(tags)
 
         // Try canonical first
         if var meta = loadSessionMetadataFile(sessionID: sessionID) {
-            meta.tags = normalized.isEmpty ? nil : normalized
+            let preservedInternalTags = Self.internalSessionTags(from: meta.tags ?? [])
+            let combinedTags = preservedInternalTags + normalizedVisibleTags
+            meta.tags = combinedTags.isEmpty ? nil : combinedTags
             writeSessionMetadata(meta, sessionID: sessionID)
             return
         }
@@ -712,7 +714,8 @@ actor SessionRepository {
             language: index.language,
             meetingApp: index.meetingApp,
             engine: index.engine,
-            tags: normalized.isEmpty ? nil : normalized
+            tags: normalizedVisibleTags.isEmpty ? nil : normalizedVisibleTags,
+            source: index.source
         )
         let dir = sessionDirectory(for: sessionID)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -723,8 +726,10 @@ actor SessionRepository {
     func updateSessionSource(sessionID: String, source: String, tags: [String]) {
         guard var meta = loadSessionMetadataFile(sessionID: sessionID) else { return }
         meta.source = source
-        let existing = meta.tags ?? []
-        meta.tags = Self.normalizeTags(existing + tags)
+        let existingVisibleTags = Self.userVisibleSessionTags(from: meta.tags ?? [])
+        let preservedInternalTags = Self.normalizeInternalSessionTags((meta.tags ?? []) + tags)
+        let combinedTags = preservedInternalTags + Self.normalizeUserVisibleTags(existingVisibleTags)
+        meta.tags = combinedTags.isEmpty ? nil : combinedTags
         writeSessionMetadata(meta, sessionID: sessionID)
     }
 
@@ -759,6 +764,34 @@ actor SessionRepository {
             if result.count >= 5 { break }
         }
         return result
+    }
+
+    private static func normalizeUserVisibleTags(_ tags: [String]) -> [String] {
+        normalizeTags(userVisibleSessionTags(from: tags))
+    }
+
+    private static func normalizeInternalSessionTags(_ tags: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for tag in internalSessionTags(from: tags) {
+            let key = tag.lowercased()
+            guard !seen.contains(key) else { continue }
+            seen.insert(key)
+            result.append(tag)
+        }
+        return result
+    }
+
+    private static func userVisibleSessionTags(from tags: [String]) -> [String] {
+        tags.filter { !isInternalSessionTag($0) }
+    }
+
+    private static func internalSessionTags(from tags: [String]) -> [String] {
+        tags.filter(isInternalSessionTag)
+    }
+
+    private static func isInternalSessionTag(_ tag: String) -> Bool {
+        tag.lowercased().hasPrefix("granola:")
     }
 
     func deleteSession(sessionID: String) {

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -124,8 +124,20 @@ struct NotesView: View {
             }
 
             if bulkDeleteMode {
-                List(controller.filteredSessions, selection: $bulkDeleteSelection) { session in
-                    sessionRow(controller: controller, session: session)
+                List(selection: $bulkDeleteSelection) {
+                    if controller.showsSourceSections {
+                        ForEach(controller.sessionSourceGroups) { group in
+                            Section(group.title) {
+                                ForEach(group.sessions) { session in
+                                    sessionRow(controller: controller, session: session)
+                                }
+                            }
+                        }
+                    } else {
+                        ForEach(controller.filteredSessions) { session in
+                            sessionRow(controller: controller, session: session)
+                        }
+                    }
                 }
                 .listStyle(.sidebar)
             } else {
@@ -133,37 +145,78 @@ struct NotesView: View {
                     get: { state.selectedSessionID },
                     set: { controller.selectSession($0) }
                 )
-                List(controller.filteredSessions, selection: selectedBinding) { session in
-                    sessionRow(controller: controller, session: session)
-                        .contextMenu {
-                            Button("Rename...") {
-                                beginRenaming(session)
-                            }
-                            Button("Edit Tags...") {
-                                editingTags = session.tags ?? []
-                                newTagText = ""
-                                editingTagsSessionID = session.id
-                                Task {
-                                    availableTags = await controller.allTags()
+                List(selection: selectedBinding) {
+                    if controller.showsSourceSections {
+                        ForEach(controller.sessionSourceGroups) { group in
+                            Section(group.title) {
+                                ForEach(group.sessions) { session in
+                                    sessionRow(controller: controller, session: session)
+                                        .contextMenu {
+                                            Button("Rename...") {
+                                                beginRenaming(session)
+                                            }
+                                            Button("Edit Tags...") {
+                                                editingTags = NotesController.visibleTags(for: session)
+                                                newTagText = ""
+                                                editingTagsSessionID = session.id
+                                                Task {
+                                                    availableTags = await controller.allTags()
+                                                }
+                                            }
+                                            Divider()
+                                            Button("Select Multiple...") {
+                                                bulkDeleteMode = true
+                                                bulkDeleteSelection = [session.id]
+                                            }
+                                            Divider()
+                                            Button("Delete", role: .destructive) {
+                                                sessionToDelete = session.id
+                                                showDeleteConfirmation = true
+                                            }
+                                        }
+                                        .popover(isPresented: Binding(
+                                            get: { editingTagsSessionID == session.id },
+                                            set: { if !$0 { editingTagsSessionID = nil } }
+                                        )) {
+                                            tagEditorPopover(controller: controller, sessionID: session.id)
+                                        }
                                 }
                             }
-                            Divider()
-                            Button("Select Multiple...") {
-                                bulkDeleteMode = true
-                                bulkDeleteSelection = [session.id]
-                            }
-                            Divider()
-                            Button("Delete", role: .destructive) {
-                                sessionToDelete = session.id
-                                showDeleteConfirmation = true
-                            }
                         }
-                        .popover(isPresented: Binding(
-                            get: { editingTagsSessionID == session.id },
-                            set: { if !$0 { editingTagsSessionID = nil } }
-                        )) {
-                            tagEditorPopover(controller: controller, sessionID: session.id)
+                    } else {
+                        ForEach(controller.filteredSessions) { session in
+                            sessionRow(controller: controller, session: session)
+                                .contextMenu {
+                                    Button("Rename...") {
+                                        beginRenaming(session)
+                                    }
+                                    Button("Edit Tags...") {
+                                        editingTags = NotesController.visibleTags(for: session)
+                                        newTagText = ""
+                                        editingTagsSessionID = session.id
+                                        Task {
+                                            availableTags = await controller.allTags()
+                                        }
+                                    }
+                                    Divider()
+                                    Button("Select Multiple...") {
+                                        bulkDeleteMode = true
+                                        bulkDeleteSelection = [session.id]
+                                    }
+                                    Divider()
+                                    Button("Delete", role: .destructive) {
+                                        sessionToDelete = session.id
+                                        showDeleteConfirmation = true
+                                    }
+                                }
+                                .popover(isPresented: Binding(
+                                    get: { editingTagsSessionID == session.id },
+                                    set: { if !$0 { editingTagsSessionID = nil } }
+                                )) {
+                                    tagEditorPopover(controller: controller, sessionID: session.id)
+                                }
                         }
+                    }
                 }
                 .listStyle(.sidebar)
             }
@@ -193,6 +246,7 @@ struct NotesView: View {
 
     @ViewBuilder
     private func sessionRow(controller: NotesController, session: SessionIndex) -> some View {
+        let visibleTags = NotesController.visibleTags(for: session)
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 6) {
                 if let snap = session.templateSnapshot {
@@ -227,9 +281,9 @@ struct NotesView: View {
             .font(.system(size: 11))
             .foregroundStyle(.tertiary)
 
-            if let tags = session.tags, !tags.isEmpty {
+            if !visibleTags.isEmpty {
                 HStack(spacing: 4) {
-                    ForEach(tags, id: \.self) { tag in
+                    ForEach(visibleTags, id: \.self) { tag in
                         Text(tag)
                             .font(.system(size: 10))
                             .padding(.horizontal, 5)
@@ -349,7 +403,7 @@ struct NotesView: View {
         var seen = Set<String>()
         var result: [String] = []
         for session in sessions {
-            for tag in session.tags ?? [] {
+            for tag in NotesController.visibleTags(for: session) {
                 let key = tag.lowercased()
                 if !seen.contains(key) {
                     seen.insert(key)

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -340,4 +340,56 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertFalse(controller.state.freshlyGeneratedSessionIDs.contains(sessionID), "Should clear the fresh badge when selected")
         XCTAssertNotNil(controller.state.loadedNotes, "Should load the generated notes")
     }
+
+    func testAllTagsHidesGranolaImportMetadataTags() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+
+        await seedSession(coordinator: coordinator, sessionID: "session_local", title: "Local")
+        await coordinator.sessionRepository.updateSessionTags(
+            sessionID: "session_local",
+            tags: ["follow-up"]
+        )
+
+        await seedSession(coordinator: coordinator, sessionID: "session_granola", title: "Imported")
+        await coordinator.sessionRepository.updateSessionSource(
+            sessionID: "session_granola",
+            source: "granola",
+            tags: ["granola:not_123"]
+        )
+        await coordinator.sessionRepository.updateSessionTags(
+            sessionID: "session_granola",
+            tags: ["customer"]
+        )
+
+        await controller.loadHistory()
+
+        let tags = await controller.allTags()
+
+        XCTAssertEqual(tags, ["customer", "follow-up"])
+        XCTAssertFalse(tags.contains(where: { $0.hasPrefix("granola:") }))
+    }
+
+    func testSessionSourceGroupsKeepGranolaSeparateFromOpenOats() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+
+        await seedSession(coordinator: coordinator, sessionID: "session_local", title: "Local")
+
+        await seedSession(coordinator: coordinator, sessionID: "session_granola", title: "Imported")
+        await coordinator.sessionRepository.updateSessionSource(
+            sessionID: "session_granola",
+            source: "granola",
+            tags: ["granola:not_456"]
+        )
+
+        await controller.loadHistory()
+
+        let groups = controller.sessionSourceGroups
+
+        XCTAssertEqual(groups.map(\.title), ["OpenOats", "Granola"])
+        XCTAssertEqual(groups.first?.sessions.map(\.id), ["session_local"])
+        XCTAssertEqual(groups.last?.sessions.map(\.id), ["session_granola"])
+        XCTAssertTrue(controller.showsSourceSections)
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -483,6 +483,30 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    func testUpdateSessionTagsPreservesInternalGranolaTag() async {
+        let sessionID = "session_granola_tags"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Live", timestamp: Date())],
+            startedAt: Date()
+        )
+
+        await repo.updateSessionSource(
+            sessionID: sessionID,
+            source: "granola",
+            tags: ["granola:not_123"]
+        )
+        await repo.updateSessionTags(sessionID: sessionID, tags: ["team", "follow-up"])
+
+        let sessions = await repo.listSessions()
+        let saved = sessions.first(where: { $0.id == sessionID })
+
+        XCTAssertEqual(saved?.source, "granola")
+        XCTAssertEqual(saved?.tags ?? [], ["granola:not_123", "team", "follow-up"])
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
     func testInitRetainsRecentBatchAudioForRerunWindow() async throws {
         let sessionID = "session_recent_batch_audio"
         let sessionDir = try makeSessionWithBatchAudio(sessionID: sessionID)


### PR DESCRIPTION
Fixes #361

## Summary

- hide internal `granola:<note-id>` sync tags from the Notes tag bar, tag chips, and tag autocomplete
- preserve those hidden Granola tags when a user edits visible session tags
- group the Notes sidebar by session source so imported Granola meetings appear together in a native sectioned list

## Why

Granola import ids are implementation detail, not user-facing organization. Exposing them in the Notes UI makes the app feel like it is leaking raw import metadata, and imported sessions are harder to scan because they are not grouped together.

## Validation

- `swift test --package-path OpenOats --filter SessionRepositoryTests`
- `swift test --package-path OpenOats --filter NotesControllerTests`
