### PR TITLE
Add an idle Coming up dashboard to the main window

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -7,8 +7,6 @@ struct ContentView: View {
         case confirmDownload
     }
 
-    private let compactHeaderVerticalPadding: CGFloat = 10
-
     @Bindable var settings: AppSettings
     @Environment(AppContainer.self) private var container
     @Environment(AppCoordinator.self) private var coordinator
@@ -21,7 +19,6 @@ struct ContentView: View {
     @State private var showOnboarding = false
     @State private var showConsentSheet = false
     @State private var pendingControlBarAction: ControlBarAction?
-    @State private var windowChromeTopInset: CGFloat = 0
 
     var body: some View {
         bodyWithModifiers
@@ -67,7 +64,7 @@ struct ContentView: View {
                 .accessibilityIdentifier("app.settingsButton")
             }
             .padding(.horizontal, 16)
-            .padding(.vertical, compactHeaderVerticalPadding)
+            .padding(.vertical, 10)
 
             Divider()
 
@@ -190,56 +187,55 @@ struct ContentView: View {
                 Divider()
             }
 
-            Spacer(minLength: 0)
+            if controllerState.isRunning {
+                Spacer(minLength: 0)
 
-            // Collapsible transcript (hidden when live transcript is disabled)
-            if controllerState.showLiveTranscript {
-                DisclosureGroup(isExpanded: $isTranscriptExpanded) {
-                    IsolatedTranscriptWrapper(state: controllerState)
-                        .frame(height: 150)
-                } label: {
-                    HStack(spacing: 6) {
-                        Text("Transcript")
-                            .font(.system(size: 12, weight: .medium))
-                        if !controllerState.liveTranscript.isEmpty {
-                            Text("(\(controllerState.liveTranscript.count))")
-                                .font(.system(size: 11))
-                                .foregroundStyle(.tertiary)
-                        }
-                        Spacer()
-                        if isTranscriptExpanded && !controllerState.liveTranscript.isEmpty {
-                            Button {
-                                openWindow(id: "transcript")
-                            } label: {
-                                Image(systemName: "arrow.up.left.and.arrow.down.right")
+                // Collapsible transcript (hidden when live transcript is disabled)
+                if controllerState.showLiveTranscript {
+                    DisclosureGroup(isExpanded: $isTranscriptExpanded) {
+                        IsolatedTranscriptWrapper(state: controllerState)
+                            .frame(height: 150)
+                    } label: {
+                        HStack(spacing: 6) {
+                            Text("Transcript")
+                                .font(.system(size: 12, weight: .medium))
+                            if !controllerState.liveTranscript.isEmpty {
+                                Text("(\(controllerState.liveTranscript.count))")
                                     .font(.system(size: 11))
-                                    .foregroundStyle(.secondary)
-                                    .padding(4)
-                                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                                    .foregroundStyle(.tertiary)
                             }
-                            .buttonStyle(.plain)
-                            .help("Open transcript in separate window")
+                            Spacer()
+                            if isTranscriptExpanded && !controllerState.liveTranscript.isEmpty {
+                                Button {
+                                    openWindow(id: "transcript")
+                                } label: {
+                                    Image(systemName: "arrow.up.left.and.arrow.down.right")
+                                        .font(.system(size: 11))
+                                        .foregroundStyle(.secondary)
+                                        .padding(4)
+                                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                                }
+                                .buttonStyle(.plain)
+                                .help("Open transcript in separate window")
 
-                            Button {
-                                copyTranscript()
-                            } label: {
-                                Image(systemName: "doc.on.doc")
-                                    .font(.system(size: 11))
-                                    .foregroundStyle(.secondary)
-                                    .padding(4)
-                                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                                Button {
+                                    copyTranscript()
+                                } label: {
+                                    Image(systemName: "doc.on.doc")
+                                        .font(.system(size: 11))
+                                        .foregroundStyle(.secondary)
+                                        .padding(4)
+                                        .clipShape(RoundedRectangle(cornerRadius: 4))
+                                }
+                                .buttonStyle(.plain)
+                                .help("Copy transcript")
                             }
-                            .buttonStyle(.plain)
-                            .help("Copy transcript")
                         }
                     }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
-            }
 
-            // Collapsible scratchpad during live session
-            if controllerState.isRunning {
                 Divider()
                 ScratchpadSection(
                     text: Binding(
@@ -247,6 +243,9 @@ struct ContentView: View {
                         set: { liveSessionController?.updateScratchpad($0) }
                     )
                 )
+            } else {
+                IdleHomeDashboardView(settings: settings)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
 
             Divider()
@@ -265,7 +264,6 @@ struct ContentView: View {
                 }
             )
         }
-        .padding(.top, max(windowChromeTopInset - compactHeaderVerticalPadding, 0))
     }
 
     private var bodyWithModifiers: some View {
@@ -274,9 +272,6 @@ struct ContentView: View {
 
     private var sizedRootContent: some View {
         rootContent
-            .background {
-                WindowChromeTopInsetReader(topInset: $windowChromeTopInset)
-            }
             .frame(minWidth: 360, maxWidth: 600, minHeight: 400)
             .background(.ultraThinMaterial)
     }
@@ -490,30 +485,6 @@ struct ContentView: View {
             }
         case .confirmDownload:
             liveSessionController?.downloadModelOnly(settings: settings)
-        }
-    }
-}
-
-private struct WindowChromeTopInsetReader: NSViewRepresentable {
-    @Binding var topInset: CGFloat
-
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        updateTopInset(for: view)
-        return view
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        updateTopInset(for: nsView)
-    }
-
-    private func updateTopInset(for view: NSView) {
-        let binding = _topInset
-        DispatchQueue.main.async { [weak view] in
-            guard let window = view?.window else { return }
-            let chromeHeight = max(window.frame.height - window.contentLayoutRect.height, 0)
-            guard abs(binding.wrappedValue - chromeHeight) > 0.5 else { return }
-            binding.wrappedValue = chromeHeight
         }
     }
 }

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -1,0 +1,302 @@
+import AppKit
+import SwiftUI
+
+struct IdleHomeDashboardView: View {
+    @Bindable var settings: AppSettings
+    @Environment(AppContainer.self) private var container
+
+    @State private var events: [CalendarEvent] = []
+    @State private var refreshTick = 0
+
+    var body: some View {
+        let accessState = currentAccessState
+
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Coming up")
+                .font(.system(size: 24, weight: .semibold))
+
+            comingUpCard(accessState: accessState)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(.horizontal, 20)
+        .padding(.top, 10)
+        .padding(.bottom, 8)
+        .task(id: refreshTaskID(for: accessState)) {
+            await refresh()
+            try? await Task.sleep(for: refreshInterval(for: accessState))
+            refreshTick &+= 1
+        }
+        .onChange(of: settings.calendarIntegrationEnabled) {
+            refreshTick &+= 1
+        }
+    }
+
+    @ViewBuilder
+    private func comingUpCard(accessState: CalendarManager.AccessState) -> some View {
+        Group {
+            if !settings.calendarIntegrationEnabled {
+                disabledCalendarCard
+            } else {
+                switch accessState {
+                case .authorized:
+                    if events.isEmpty {
+                        emptyStateCard(
+                            title: "No upcoming meetings",
+                            description: "OpenOats will show your next calendar meetings here."
+                        )
+                    } else {
+                        upcomingMeetingsCard
+                    }
+                case .denied:
+                    deniedCalendarCard
+                case .notDetermined:
+                    emptyStateCard(
+                        title: "Waiting for calendar access",
+                        description: "OpenOats will show your upcoming meetings once Calendar access is granted."
+                    )
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 18)
+                .fill(Color(nsColor: .windowBackgroundColor).opacity(0.72))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .strokeBorder(.quaternary, lineWidth: 1)
+        )
+    }
+
+    private var disabledCalendarCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Calendar integration is off", systemImage: "calendar.badge.exclamationmark")
+                .font(.system(size: 14, weight: .medium))
+            Text("Enable Calendar integration to see the meetings OpenOats can prepare for.")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+            SettingsLink {
+                Label("Open Settings", systemImage: "gearshape")
+                    .font(.system(size: 13, weight: .medium))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.regular)
+        }
+    }
+
+    private var deniedCalendarCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Calendar access denied", systemImage: "exclamationmark.triangle.fill")
+                .font(.system(size: 14, weight: .medium))
+                .foregroundStyle(.orange)
+            Text("Grant Calendar access in System Settings to see upcoming meetings here.")
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+            Button {
+                openCalendarPrivacySettings()
+            } label: {
+                Label("Open Privacy Settings", systemImage: "lock.shield")
+                    .font(.system(size: 13, weight: .medium))
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.regular)
+        }
+    }
+
+    private var upcomingMeetingsCard: some View {
+        let groups = UpcomingCalendarGrouping.groups(for: events)
+        return VStack(alignment: .leading, spacing: 14) {
+            ForEach(Array(groups.enumerated()), id: \.element.id) { index, group in
+                ComingUpDayGroupView(group: group)
+                if index < groups.count - 1 {
+                    Divider()
+                        .padding(.top, 2)
+                }
+            }
+        }
+    }
+
+    private func emptyStateCard(title: String, description: String) -> some View {
+        ContentUnavailableView {
+            Label(title, systemImage: "calendar")
+        } description: {
+            Text(description)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+    }
+
+    @MainActor
+    private func refresh() async {
+        guard settings.calendarIntegrationEnabled, let manager = container.calendarManager else {
+            events = []
+            return
+        }
+
+        guard manager.accessState == .authorized else {
+            events = []
+            return
+        }
+
+        let now = Date()
+        let currentEvent = manager.currentEvent(at: now)
+        let upcomingEvents = manager.upcomingEvents(
+            from: now,
+            within: 7 * 24 * 60 * 60,
+            limit: 6
+        )
+
+        var combined: [CalendarEvent] = []
+        if let currentEvent {
+            combined.append(currentEvent)
+        }
+        combined.append(contentsOf: upcomingEvents.filter { $0.id != currentEvent?.id })
+        events = Array(combined.prefix(6))
+    }
+
+    private var currentAccessState: CalendarManager.AccessState {
+        guard settings.calendarIntegrationEnabled else { return .notDetermined }
+        return container.calendarManager?.accessState ?? .notDetermined
+    }
+
+    private func refreshTaskID(for accessState: CalendarManager.AccessState) -> String {
+        "\(settings.calendarIntegrationEnabled)-\(accessStateTag(for: accessState))-\(refreshTick)"
+    }
+
+    private func accessStateTag(for accessState: CalendarManager.AccessState) -> String {
+        switch accessState {
+        case .authorized:
+            return "authorized"
+        case .denied:
+            return "denied"
+        case .notDetermined:
+            return "not-determined"
+        }
+    }
+
+    private func refreshInterval(for accessState: CalendarManager.AccessState) -> Duration {
+        switch accessState {
+        case .authorized:
+            return .seconds(60)
+        case .denied:
+            return .seconds(300)
+        case .notDetermined:
+            return .seconds(1)
+        }
+    }
+
+    private func openCalendarPrivacySettings() {
+        let urls = [
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars",
+            "x-apple.systempreferences:com.apple.preference.security?Privacy",
+        ]
+        for urlString in urls {
+            guard let url = URL(string: urlString) else { continue }
+            if NSWorkspace.shared.open(url) { return }
+        }
+    }
+}
+
+private struct ComingUpDayGroupView: View {
+    let group: UpcomingCalendarGrouping.DayGroup
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(group.sectionTitle)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .textCase(.uppercase)
+
+            VStack(alignment: .leading, spacing: 10) {
+                ForEach(group.events) { event in
+                    HStack(alignment: .top, spacing: 10) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .fill(Color.accentColor)
+                            .frame(width: 4, height: 34)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(event.title)
+                                .font(.system(size: 15, weight: .medium))
+                                .lineLimit(1)
+                            Text(CalendarEventDisplay.timeRange(for: event))
+                                .font(.system(size: 13))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+        }
+    }
+}
+
+enum UpcomingCalendarGrouping {
+    struct DayGroup: Identifiable, Equatable {
+        let date: Date
+        let events: [CalendarEvent]
+
+        var id: Date { date }
+
+        var dayNumber: String {
+            Self.dayNumberFormatter.string(from: date)
+        }
+
+        var monthText: String {
+            Self.monthFormatter.string(from: date)
+        }
+
+        var weekdayText: String {
+            Self.weekdayFormatter.string(from: date)
+        }
+
+        var sectionTitle: String {
+            let calendar = Calendar.current
+            if calendar.isDateInToday(date) {
+                return "Today"
+            }
+            if calendar.isDateInTomorrow(date) {
+                return "Tomorrow"
+            }
+            return "\(weekdayText), \(dayNumber) \(monthText)"
+        }
+
+        private static let dayNumberFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "d"
+            return formatter
+        }()
+
+        private static let monthFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "MMM"
+            return formatter
+        }()
+
+        private static let weekdayFormatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.dateFormat = "EEE"
+            return formatter
+        }()
+    }
+
+    static func groups(
+        for events: [CalendarEvent],
+        calendar: Calendar = .current
+    ) -> [DayGroup] {
+        let grouped = Dictionary(grouping: events) { event in
+            calendar.startOfDay(for: event.startDate)
+        }
+
+        return grouped.keys.sorted().map { day in
+            DayGroup(
+                date: day,
+                events: grouped[day, default: []]
+                    .sorted { $0.startDate < $1.startDate }
+            )
+        }
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class UpcomingCalendarGroupingTests: XCTestCase {
+    func testSectionTitleUsesTodayAndTomorrowLabels() {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: today)!
+
+        let todayGroup = UpcomingCalendarGrouping.DayGroup(
+            date: today,
+            events: [makeEvent(id: "today", title: "Demo Day", start: today)]
+        )
+        let tomorrowGroup = UpcomingCalendarGrouping.DayGroup(
+            date: tomorrow,
+            events: [makeEvent(id: "tomorrow", title: "Planning", start: tomorrow)]
+        )
+
+        XCTAssertEqual(todayGroup.sectionTitle, "Today")
+        XCTAssertEqual(tomorrowGroup.sectionTitle, "Tomorrow")
+    }
+
+    func testGroupsEventsByDayAndSortsWithinEachDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let morning = makeDate(year: 2026, month: 4, day: 20, hour: 9, minute: 45, calendar: calendar)
+        let midday = makeDate(year: 2026, month: 4, day: 20, hour: 11, minute: 30, calendar: calendar)
+        let nextDay = makeDate(year: 2026, month: 4, day: 21, hour: 14, minute: 30, calendar: calendar)
+
+        let events = [
+            makeEvent(id: "later", title: "Product Planning", start: midday),
+            makeEvent(id: "next", title: "Platform Feedback", start: nextDay),
+            makeEvent(id: "first", title: "Payment Ops", start: morning),
+        ]
+
+        let groups = UpcomingCalendarGrouping.groups(for: events, calendar: calendar)
+
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertEqual(groups[0].events.map(\.id), ["first", "later"])
+        XCTAssertEqual(groups[1].events.map(\.id), ["next"])
+    }
+
+    func testGroupDateUsesStartOfDay() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let eventDate = makeDate(year: 2026, month: 4, day: 22, hour: 9, minute: 45, calendar: calendar)
+        let groups = UpcomingCalendarGrouping.groups(
+            for: [makeEvent(id: "event", title: "Payment Ops", start: eventDate)],
+            calendar: calendar
+        )
+
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups[0].date, calendar.startOfDay(for: eventDate))
+    }
+
+    private func makeEvent(id: String, title: String, start: Date) -> CalendarEvent {
+        CalendarEvent(
+            id: id,
+            title: title,
+            startDate: start,
+            endDate: start.addingTimeInterval(30 * 60),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+    }
+
+    private func makeDate(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int,
+        minute: Int,
+        calendar: Calendar
+    ) -> Date {
+        calendar.date(from: DateComponents(
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute
+        ))!
+    }
+}


### PR DESCRIPTION
Fixes #363

## Summary
- add a read-only `Coming up` dashboard to the idle state of the main window
- reuse Calendar integration to show upcoming meetings grouped by day
- keep the live-session transcript and scratchpad layout unchanged
- handle Calendar disabled, denied, not-yet-authorized, and empty states explicitly

## Screenshot
![Idle Coming up dashboard](https://raw.githubusercontent.com/kkarimi/OpenOats/pr-assets-idle-coming-up-dashboard/pr-assets/idle-coming-up-dashboard.png)

## Tests
- `swift test --package-path OpenOats --filter UpcomingCalendarGroupingTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
