### PR TITLE
Add folders and subfolders in Notes

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -50,6 +50,12 @@ struct SessionSourceGroup: Identifiable {
     let sessions: [SessionIndex]
 }
 
+struct SessionFolderGroup: Identifiable {
+    let id: String
+    let title: String
+    let sessions: [SessionIndex]
+}
+
 // MARK: - Controller
 
 /// Owns all notes/history business logic previously embedded in NotesView.
@@ -448,9 +454,47 @@ final class NotesController {
         return groups.count > 1 || groups.first?.id != "openoats"
     }
 
+    var rootFolderSessions: [SessionIndex] {
+        guard showsFolderSections else { return [] }
+        return filteredSessions.filter { Self.normalizedFolderPath(for: $0)?.isEmpty != false }
+    }
+
+    var folderGroups: [SessionFolderGroup] {
+        let grouped = Dictionary(
+            grouping: filteredSessions.compactMap { session -> (String, SessionIndex)? in
+                guard let folderPath = Self.normalizedFolderPath(for: session), !folderPath.isEmpty else {
+                    return nil
+                }
+                return (folderPath, session)
+            },
+            by: \.0
+        )
+        let orderedKeys = grouped.keys.sorted {
+            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
+        }
+        return orderedKeys.map { key in
+            SessionFolderGroup(
+                id: key,
+                title: Self.folderDisplayName(for: key),
+                sessions: (grouped[key] ?? []).map(\.1)
+            )
+        }
+    }
+
+    var showsFolderSections: Bool {
+        filteredSessions.contains { Self.normalizedFolderPath(for: $0)?.isEmpty == false }
+    }
+
     func updateSessionTags(sessionID: String, tags: [String]) {
         Task {
             await coordinator.sessionRepository.updateSessionTags(sessionID: sessionID, tags: tags)
+            await loadHistory()
+        }
+    }
+
+    func updateSessionFolder(sessionID: String, folderPath: String?) {
+        Task {
+            await coordinator.sessionRepository.updateSessionFolder(sessionID: sessionID, folderPath: folderPath)
             await loadHistory()
         }
     }
@@ -473,6 +517,17 @@ final class NotesController {
 
     static func isUserVisibleSessionTag(_ tag: String) -> Bool {
         !tag.lowercased().hasPrefix("granola:")
+    }
+
+    static func normalizedFolderPath(for session: SessionIndex) -> String? {
+        NotesFolderDefinition.normalizePath(session.folderPath ?? "")
+    }
+
+    static func folderDisplayName(for folderPath: String) -> String {
+        folderPath
+            .split(separator: "/")
+            .map(String.init)
+            .joined(separator: " › ")
     }
 
     static func sourceGroupKey(for session: SessionIndex) -> String {

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -358,6 +358,8 @@ struct SessionIndex: Identifiable, Codable, Sendable {
     var engine: String?
     /// User-assigned tags for session organization.
     var tags: [String]?
+    /// Optional slash-separated folder path used to organize sessions in the Notes UI.
+    var folderPath: String? = nil
     /// How the session was created (nil for live sessions, "imported" for imported audio).
     var source: String?
 }

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -812,6 +812,17 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _notesFolders: [NotesFolderDefinition]
+    var notesFolders: [NotesFolderDefinition] {
+        get { access(keyPath: \.notesFolders); return _notesFolders }
+        set {
+            withMutation(keyPath: \.notesFolders) {
+                _notesFolders = Self.normalizeNotesFolders(newValue)
+                defaults.set(Self.encodeNotesFolders(_notesFolders), forKey: "notesFolders")
+            }
+        }
+    }
+
     /// Save a security-scoped bookmark for the user-selected notes folder.
     func saveNotesFolderBookmark(from url: URL) {
         do {
@@ -1028,6 +1039,7 @@ final class SettingsStore {
         }
         let defaultNotesPath = storage.defaultNotesDirectory.path
         self._notesFolderPath = defaults.string(forKey: "notesFolderPath") ?? defaultNotesPath
+        self._notesFolders = Self.decodeNotesFolders(defaults.data(forKey: "notesFolders")) ?? []
         self._kbFolderPath = defaults.string(forKey: "kbFolderPath") ?? ""
         self._hasSeenLaunchAtLoginSuggestion = defaults.bool(forKey: "hasSeenLaunchAtLoginSuggestion")
 
@@ -1130,6 +1142,29 @@ final class SettingsStore {
     private static func decodePersonas(_ data: Data?) -> [SidecastPersona]? {
         guard let data else { return nil }
         return try? JSONDecoder().decode([SidecastPersona].self, from: data)
+    }
+
+    private static func encodeNotesFolders(_ folders: [NotesFolderDefinition]) -> Data? {
+        let encoder = JSONEncoder()
+        return try? encoder.encode(folders)
+    }
+
+    private static func decodeNotesFolders(_ data: Data?) -> [NotesFolderDefinition]? {
+        guard let data else { return nil }
+        return try? JSONDecoder().decode([NotesFolderDefinition].self, from: data)
+    }
+
+    private static func normalizeNotesFolders(_ folders: [NotesFolderDefinition]) -> [NotesFolderDefinition] {
+        var seen = Set<String>()
+        var result: [NotesFolderDefinition] = []
+        for folder in folders {
+            guard let normalizedPath = NotesFolderDefinition.normalizePath(folder.path) else { continue }
+            let key = normalizedPath.lowercased()
+            guard !seen.contains(key) else { continue }
+            seen.insert(key)
+            result.append(NotesFolderDefinition(id: folder.id, path: normalizedPath, color: folder.color))
+        }
+        return result.sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -1,5 +1,55 @@
 import Foundation
 
+enum NotesFolderColor: String, CaseIterable, Identifiable, Codable {
+    case gray
+    case orange
+    case gold
+    case purple
+    case blue
+    case teal
+    case green
+    case red
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        rawValue.capitalized
+    }
+}
+
+struct NotesFolderDefinition: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    var path: String
+    var color: NotesFolderColor
+
+    init(id: UUID = UUID(), path: String, color: NotesFolderColor) {
+        self.id = id
+        self.path = Self.normalizePath(path) ?? path
+        self.color = color
+    }
+
+    var displayName: String {
+        path.split(separator: "/").last.map(String.init) ?? path
+    }
+
+    var breadcrumb: String? {
+        let parts = path.split(separator: "/").map(String.init)
+        guard parts.count > 1 else { return nil }
+        return parts.dropLast().joined(separator: " › ")
+    }
+
+    static func normalizePath(_ rawPath: String) -> String? {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let components = trimmed
+            .split(separator: "/")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && $0 != "." && $0 != ".." }
+        guard !components.isEmpty else { return nil }
+        return components.joined(separator: "/")
+    }
+}
+
 /// Controls how eagerly the suggestion engine surfaces talking points.
 enum SuggestionVerbosity: String, CaseIterable, Identifiable {
     /// Mostly silent — surfaces suggestions only when highly relevant (current default behavior).

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -125,6 +125,7 @@ struct SessionMetadata: Codable, Sendable {
     var meetingApp: String?
     var engine: String?
     var tags: [String]?
+    var folderPath: String? = nil
     /// How the session was created (nil for live sessions, "imported" for imported audio).
     var source: String?
     var calendarEvent: CalendarEvent?
@@ -500,6 +501,7 @@ actor SessionRepository {
                 meetingApp: meta.meetingApp,
                 engine: meta.engine,
                 tags: meta.tags,
+                folderPath: meta.folderPath,
                 source: meta.source
             )
             writeSessionMetadata(refreshedMeta, sessionID: sessionID)
@@ -620,6 +622,7 @@ actor SessionRepository {
                         meetingApp: meta.meetingApp,
                         engine: meta.engine,
                         tags: meta.tags,
+                        folderPath: meta.folderPath,
                         source: meta.source
                     ))
                     continue
@@ -657,6 +660,7 @@ actor SessionRepository {
                 meetingApp: meta.meetingApp,
                 engine: meta.engine,
                 tags: meta.tags,
+                folderPath: meta.folderPath,
                 source: meta.source
             )
 
@@ -758,6 +762,37 @@ actor SessionRepository {
             meetingApp: index.meetingApp,
             engine: index.engine,
             tags: normalizedVisibleTags.isEmpty ? nil : normalizedVisibleTags,
+            folderPath: index.folderPath,
+            source: index.source
+        )
+        let dir = sessionDirectory(for: sessionID)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        writeSessionMetadata(meta, sessionID: sessionID)
+    }
+
+    func updateSessionFolder(sessionID: String, folderPath: String?) {
+        let normalizedFolderPath = Self.normalizeSessionFolderPath(folderPath)
+
+        if var meta = loadSessionMetadataFile(sessionID: sessionID) {
+            meta.folderPath = normalizedFolderPath
+            writeSessionMetadata(meta, sessionID: sessionID)
+            return
+        }
+
+        let index = LegacySessionReader.loadIndex(sessionID: sessionID, sessionsDirectory: sessionsDirectory)
+        let meta = SessionMetadata(
+            id: index.id,
+            startedAt: index.startedAt,
+            endedAt: index.endedAt,
+            templateSnapshot: index.templateSnapshot,
+            title: index.title,
+            utteranceCount: index.utteranceCount,
+            hasNotes: index.hasNotes,
+            language: index.language,
+            meetingApp: index.meetingApp,
+            engine: index.engine,
+            tags: index.tags,
+            folderPath: normalizedFolderPath,
             source: index.source
         )
         let dir = sessionDirectory(for: sessionID)
@@ -831,6 +866,10 @@ actor SessionRepository {
 
     private static func internalSessionTags(from tags: [String]) -> [String] {
         tags.filter(isInternalSessionTag)
+    }
+
+    private static func normalizeSessionFolderPath(_ folderPath: String?) -> String? {
+        NotesFolderDefinition.normalizePath(folderPath ?? "")
     }
 
     private static func isInternalSessionTag(_ tag: String) -> Bool {
@@ -1346,6 +1385,7 @@ actor SessionRepository {
             meetingApp: meta?.meetingApp,
             engine: meta?.engine,
             tags: meta?.tags,
+            folderPath: meta?.folderPath,
             source: meta?.source
         )
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -140,8 +140,14 @@ struct NotesView: View {
             if bulkDeleteMode {
                 List(selection: $bulkDeleteSelection) {
                     if controller.showsFolderSections {
-                        ForEach(controller.rootFolderSessions) { session in
-                            sessionRow(controller: controller, session: session)
+                        if !controller.rootFolderSessions.isEmpty {
+                            Section {
+                                ForEach(controller.rootFolderSessions) { session in
+                                    sessionRow(controller: controller, session: session)
+                                }
+                            } header: {
+                                rootFolderSectionHeader()
+                            }
                         }
                         ForEach(controller.folderGroups) { group in
                             Section {
@@ -174,8 +180,14 @@ struct NotesView: View {
                 )
                 List(selection: selectedBinding) {
                     if controller.showsFolderSections {
-                        ForEach(controller.rootFolderSessions) { session in
-                            sessionListEntry(controller: controller, session: session)
+                        if !controller.rootFolderSessions.isEmpty {
+                            Section {
+                                ForEach(controller.rootFolderSessions) { session in
+                                    sessionListEntry(controller: controller, session: session)
+                                }
+                            } header: {
+                                rootFolderSectionHeader()
+                            }
                         }
                         ForEach(controller.folderGroups) { group in
                             Section {
@@ -555,6 +567,16 @@ struct NotesView: View {
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(folderColor(for: group.id))
             Text(group.title)
+        }
+    }
+
+    @ViewBuilder
+    private func rootFolderSectionHeader() -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "folder")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(.secondary)
+            Text("My notes")
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -8,6 +8,10 @@ struct NotesView: View {
     @State private var renamingSessionID: String?
     @State private var renameText: String = ""
     @FocusState private var renameFieldFocused: Bool
+    @State private var creatingFolderForSessionID: String?
+    @State private var newFolderPath: String = ""
+    @State private var newFolderColor: NotesFolderColor = .orange
+    @FocusState private var newFolderFieldFocused: Bool
     @State private var sessionToDelete: String?
     @State private var showDeleteConfirmation = false
     @State private var bulkDeleteMode = false
@@ -83,6 +87,16 @@ struct NotesView: View {
                 renameSessionSheet(controller: controller, sessionID: sessionID)
             }
         }
+        .sheet(
+            isPresented: Binding(
+                get: { creatingFolderForSessionID != nil },
+                set: { if !$0 { cancelCreateFolder() } }
+            )
+        ) {
+            if let sessionID = creatingFolderForSessionID {
+                newFolderSheet(controller: controller, sessionID: sessionID)
+            }
+        }
     }
 
     // MARK: - Sidebar
@@ -125,7 +139,20 @@ struct NotesView: View {
 
             if bulkDeleteMode {
                 List(selection: $bulkDeleteSelection) {
-                    if controller.showsSourceSections {
+                    if controller.showsFolderSections {
+                        ForEach(controller.rootFolderSessions) { session in
+                            sessionRow(controller: controller, session: session)
+                        }
+                        ForEach(controller.folderGroups) { group in
+                            Section {
+                                ForEach(group.sessions) { session in
+                                    sessionRow(controller: controller, session: session)
+                                }
+                            } header: {
+                                folderSectionHeader(group)
+                            }
+                        }
+                    } else if controller.showsSourceSections {
                         ForEach(controller.sessionSourceGroups) { group in
                             Section(group.title) {
                                 ForEach(group.sessions) { session in
@@ -146,75 +173,30 @@ struct NotesView: View {
                     set: { controller.selectSession($0) }
                 )
                 List(selection: selectedBinding) {
-                    if controller.showsSourceSections {
+                    if controller.showsFolderSections {
+                        ForEach(controller.rootFolderSessions) { session in
+                            sessionListEntry(controller: controller, session: session)
+                        }
+                        ForEach(controller.folderGroups) { group in
+                            Section {
+                                ForEach(group.sessions) { session in
+                                    sessionListEntry(controller: controller, session: session)
+                                }
+                            } header: {
+                                folderSectionHeader(group)
+                            }
+                        }
+                    } else if controller.showsSourceSections {
                         ForEach(controller.sessionSourceGroups) { group in
                             Section(group.title) {
                                 ForEach(group.sessions) { session in
-                                    sessionRow(controller: controller, session: session)
-                                        .contextMenu {
-                                            Button("Rename...") {
-                                                beginRenaming(session)
-                                            }
-                                            Button("Edit Tags...") {
-                                                editingTags = NotesController.visibleTags(for: session)
-                                                newTagText = ""
-                                                editingTagsSessionID = session.id
-                                                Task {
-                                                    availableTags = await controller.allTags()
-                                                }
-                                            }
-                                            Divider()
-                                            Button("Select Multiple...") {
-                                                bulkDeleteMode = true
-                                                bulkDeleteSelection = [session.id]
-                                            }
-                                            Divider()
-                                            Button("Delete", role: .destructive) {
-                                                sessionToDelete = session.id
-                                                showDeleteConfirmation = true
-                                            }
-                                        }
-                                        .popover(isPresented: Binding(
-                                            get: { editingTagsSessionID == session.id },
-                                            set: { if !$0 { editingTagsSessionID = nil } }
-                                        )) {
-                                            tagEditorPopover(controller: controller, sessionID: session.id)
-                                        }
+                                    sessionListEntry(controller: controller, session: session)
                                 }
                             }
                         }
                     } else {
                         ForEach(controller.filteredSessions) { session in
-                            sessionRow(controller: controller, session: session)
-                                .contextMenu {
-                                    Button("Rename...") {
-                                        beginRenaming(session)
-                                    }
-                                    Button("Edit Tags...") {
-                                        editingTags = NotesController.visibleTags(for: session)
-                                        newTagText = ""
-                                        editingTagsSessionID = session.id
-                                        Task {
-                                            availableTags = await controller.allTags()
-                                        }
-                                    }
-                                    Divider()
-                                    Button("Select Multiple...") {
-                                        bulkDeleteMode = true
-                                        bulkDeleteSelection = [session.id]
-                                    }
-                                    Divider()
-                                    Button("Delete", role: .destructive) {
-                                        sessionToDelete = session.id
-                                        showDeleteConfirmation = true
-                                    }
-                                }
-                                .popover(isPresented: Binding(
-                                    get: { editingTagsSessionID == session.id },
-                                    set: { if !$0 { editingTagsSessionID = nil } }
-                                )) {
-                                    tagEditorPopover(controller: controller, sessionID: session.id)
-                                }
+                            sessionListEntry(controller: controller, session: session)
                         }
                     }
                 }
@@ -245,6 +227,48 @@ struct NotesView: View {
     }
 
     @ViewBuilder
+    private func sessionListEntry(controller: NotesController, session: SessionIndex) -> some View {
+        sessionRow(controller: controller, session: session)
+            .contextMenu {
+                sessionContextMenu(controller: controller, session: session)
+            }
+            .popover(isPresented: Binding(
+                get: { editingTagsSessionID == session.id },
+                set: { if !$0 { editingTagsSessionID = nil } }
+            )) {
+                tagEditorPopover(controller: controller, sessionID: session.id)
+            }
+    }
+
+    @ViewBuilder
+    private func sessionContextMenu(controller: NotesController, session: SessionIndex) -> some View {
+        Button("Rename...") {
+            beginRenaming(session)
+        }
+        Menu("Move to Folder") {
+            folderAssignmentMenu(controller: controller, session: session)
+        }
+        Button("Edit Tags...") {
+            editingTags = NotesController.visibleTags(for: session)
+            newTagText = ""
+            editingTagsSessionID = session.id
+            Task {
+                availableTags = await controller.allTags()
+            }
+        }
+        Divider()
+        Button("Select Multiple...") {
+            bulkDeleteMode = true
+            bulkDeleteSelection = [session.id]
+        }
+        Divider()
+        Button("Delete", role: .destructive) {
+            sessionToDelete = session.id
+            showDeleteConfirmation = true
+        }
+    }
+
+    @ViewBuilder
     private func sessionRow(controller: NotesController, session: SessionIndex) -> some View {
         let visibleTags = NotesController.visibleTags(for: session)
         VStack(alignment: .leading, spacing: 4) {
@@ -270,6 +294,18 @@ struct NotesView: View {
                                 : Color.secondary
                         )
                 }
+                Menu {
+                    folderAssignmentMenu(controller: controller, session: session)
+                } label: {
+                    Image(systemName: session.folderPath == nil ? "folder" : "folder.fill")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(folderColor(for: session.folderPath))
+                        .frame(width: 18, height: 18)
+                }
+                .menuStyle(.borderlessButton)
+                .menuIndicator(.hidden)
+                .buttonStyle(.plain)
+                .help(session.folderPath.map { "Folder: \($0)" } ?? "Assign folder")
             }
 
             HStack(spacing: 6) {
@@ -352,9 +388,174 @@ struct NotesView: View {
         renameText = ""
     }
 
+    @ViewBuilder
+    private func newFolderSheet(controller: NotesController, sessionID: String) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("New Folder")
+                .font(.headline)
+
+            Text("Use `/` to create subfolders inside your Notes list.")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+
+            TextField("e.g. Work/1:1s", text: $newFolderPath)
+                .textFieldStyle(.roundedBorder)
+                .focused($newFolderFieldFocused)
+                .accessibilityIdentifier("notes.newFolderSheet.field")
+                .onAppear {
+                    newFolderFieldFocused = true
+                }
+                .onSubmit {
+                    commitCreateFolder(controller: controller, sessionID: sessionID)
+                }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Color")
+                    .font(.system(size: 12, weight: .medium))
+                LazyVGrid(columns: Array(repeating: GridItem(.fixed(28), spacing: 8), count: 4), spacing: 8) {
+                    ForEach(NotesFolderColor.allCases) { color in
+                        Button {
+                            newFolderColor = color
+                        } label: {
+                            ZStack {
+                                Circle()
+                                    .fill(folderColor(for: color))
+                                    .frame(width: 18, height: 18)
+                                if newFolderColor == color {
+                                    Image(systemName: "checkmark")
+                                        .font(.system(size: 8, weight: .bold))
+                                        .foregroundStyle(.white)
+                                }
+                            }
+                            .frame(width: 28, height: 28)
+                            .background(
+                                Circle()
+                                    .stroke(
+                                        newFolderColor == color ? Color.primary.opacity(0.35) : Color.secondary.opacity(0.15),
+                                        lineWidth: 1
+                                    )
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .help(color.displayName)
+                    }
+                }
+            }
+
+            HStack {
+                Spacer()
+
+                Button("Cancel") {
+                    cancelCreateFolder()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Create") {
+                    commitCreateFolder(controller: controller, sessionID: sessionID)
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(NotesFolderDefinition.normalizePath(newFolderPath) == nil)
+                .accessibilityIdentifier("notes.newFolderSheet.saveButton")
+            }
+        }
+        .padding(20)
+        .frame(width: 360)
+        .accessibilityIdentifier("notes.newFolderSheet")
+    }
+
+    @ViewBuilder
+    private func folderAssignmentMenu(controller: NotesController, session: SessionIndex) -> some View {
+        Button {
+            controller.updateSessionFolder(sessionID: session.id, folderPath: nil)
+        } label: {
+            HStack {
+                Image(systemName: "folder")
+                    .foregroundStyle(.secondary)
+                Text("My notes")
+                if session.folderPath == nil {
+                    Spacer()
+                    Image(systemName: "checkmark")
+                }
+            }
+        }
+
+        if !settings.notesFolders.isEmpty {
+            Divider()
+            ForEach(settings.notesFolders) { folder in
+                Button {
+                    controller.updateSessionFolder(sessionID: session.id, folderPath: folder.path)
+                } label: {
+                    HStack {
+                        Image(systemName: "folder.fill")
+                            .foregroundStyle(folderColor(for: folder.color))
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(folder.displayName)
+                            if let breadcrumb = folder.breadcrumb {
+                                Text(breadcrumb)
+                                    .font(.system(size: 10))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        if session.folderPath == folder.path {
+                            Spacer()
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+        }
+
+        Divider()
+
+        Button {
+            beginCreateFolder(for: session)
+        } label: {
+            HStack {
+                Image(systemName: "folder.badge.plus")
+                Text("New Folder…")
+            }
+        }
+    }
+
+    private func beginCreateFolder(for session: SessionIndex) {
+        newFolderPath = session.folderPath ?? ""
+        newFolderColor = folderDefinition(for: session.folderPath)?.color ?? .orange
+        creatingFolderForSessionID = session.id
+    }
+
+    private func commitCreateFolder(controller: NotesController, sessionID: String) {
+        guard let normalizedPath = NotesFolderDefinition.normalizePath(newFolderPath) else { return }
+        var folders = settings.notesFolders
+        if let existingIndex = folders.firstIndex(where: { $0.path.caseInsensitiveCompare(normalizedPath) == .orderedSame }) {
+            folders[existingIndex].color = newFolderColor
+        } else {
+            folders.append(NotesFolderDefinition(path: normalizedPath, color: newFolderColor))
+        }
+        settings.notesFolders = folders
+        controller.updateSessionFolder(sessionID: sessionID, folderPath: normalizedPath)
+        cancelCreateFolder()
+    }
+
+    private func cancelCreateFolder() {
+        creatingFolderForSessionID = nil
+        newFolderFieldFocused = false
+        newFolderPath = ""
+        newFolderColor = .orange
+    }
+
     private func sessionTitle(for session: SessionIndex) -> String {
         let title = session.title?.trimmingCharacters(in: .whitespacesAndNewlines)
         return (title?.isEmpty == false ? title : nil) ?? "Untitled"
+    }
+
+    @ViewBuilder
+    private func folderSectionHeader(_ group: SessionFolderGroup) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "folder.fill")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(folderColor(for: group.id))
+            Text(group.title)
+        }
     }
 
     private func renamePlaceholder(for sessionID: String, controller: NotesController) -> String {
@@ -412,6 +613,38 @@ struct NotesView: View {
             }
         }
         return result.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
+    }
+
+    private func folderDefinition(for folderPath: String?) -> NotesFolderDefinition? {
+        guard let folderPath else { return nil }
+        return settings.notesFolders.first {
+            $0.path.localizedCaseInsensitiveCompare(folderPath) == .orderedSame
+        }
+    }
+
+    private func folderColor(for folderPath: String?) -> Color {
+        folderColor(for: folderDefinition(for: folderPath)?.color ?? .gray)
+    }
+
+    private func folderColor(for color: NotesFolderColor) -> Color {
+        switch color {
+        case .gray:
+            return Color.secondary
+        case .orange:
+            return .orange
+        case .gold:
+            return Color(red: 0.74, green: 0.61, blue: 0.23)
+        case .purple:
+            return Color(red: 0.58, green: 0.48, blue: 0.86)
+        case .blue:
+            return .blue
+        case .teal:
+            return .teal
+        case .green:
+            return .green
+        case .red:
+            return .red
+        }
     }
 
     // MARK: - Tag Editor Popover

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -244,6 +244,23 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(renamedSession?.title, "New Title")
     }
 
+    func testFolderGroupsSessionsByPath() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+
+        await seedSession(coordinator: coordinator, sessionID: "session_root", title: "Inbox Meeting")
+        await seedSession(coordinator: coordinator, sessionID: "session_team", title: "Team Sync")
+        await seedSession(coordinator: coordinator, sessionID: "session_ones", title: "Bertie 1:1")
+        await coordinator.sessionRepository.updateSessionFolder(sessionID: "session_team", folderPath: "Work/Team")
+        await coordinator.sessionRepository.updateSessionFolder(sessionID: "session_ones", folderPath: "Work/1:1s")
+        await controller.loadHistory()
+
+        XCTAssertTrue(controller.showsFolderSections)
+        XCTAssertEqual(controller.rootFolderSessions.map(\.id), ["session_root"])
+        XCTAssertEqual(controller.folderGroups.map(\.id), ["Work/1:1s", "Work/Team"])
+        XCTAssertEqual(controller.folderGroups.map(\.title), ["Work › 1:1s", "Work › Team"])
+    }
+
     func testDeleteSessionRemovesFromHistory() async {
         let (root, _) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -297,6 +297,23 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    func testUpdateSessionFolderPersistsNormalizedPath() async {
+        let sessionID = "session_folder_test"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date()
+        )
+
+        await repo.updateSessionFolder(sessionID: sessionID, folderPath: " Work // 1:1s / ./ Bertie / ")
+
+        let sessions = await repo.listSessions()
+        let found = sessions.first(where: { $0.id == sessionID })
+        XCTAssertEqual(found?.folderPath, "Work/1:1s/Bertie")
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
     // MARK: - renameSession updates metadata
 
     func testRenameSessionUpdatesMetadata() async {

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -322,6 +322,32 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertFalse(store.showLiveTranscript)
     }
 
+    func testDefaultNotesFolders() {
+        let store = makeStore()
+        XCTAssertEqual(store.notesFolders, [])
+    }
+
+    func testNotesFoldersRoundTrip() {
+        let store = makeStore()
+        store.notesFolders = [
+            NotesFolderDefinition(path: "Work/1:1s", color: .orange),
+            NotesFolderDefinition(path: "Personal", color: .purple),
+        ]
+        XCTAssertEqual(store.notesFolders.map(\.path), ["Personal", "Work/1:1s"])
+        XCTAssertEqual(store.notesFolders.map(\.color), [.purple, .orange])
+    }
+
+    func testNotesFoldersNormalizeAndDedupePaths() {
+        let store = makeStore()
+        store.notesFolders = [
+            NotesFolderDefinition(path: " Work // 1:1s / Bertie / ", color: .teal),
+            NotesFolderDefinition(path: "work/1:1s/bertie", color: .orange),
+            NotesFolderDefinition(path: " / ./ ", color: .purple),
+        ]
+        XCTAssertEqual(store.notesFolders.map(\.path), ["Work/1:1s/Bertie"])
+        XCTAssertEqual(store.notesFolders.map(\.color), [.teal])
+    }
+
     func testKbFolderURLWhenEmpty() {
         let store = makeStore()
         XCTAssertNil(store.kbFolderURL)


### PR DESCRIPTION
Fixes #365

## Summary
- add per-session folder metadata with slash-separated subfolders
- group the Notes sidebar by folder path
- add a row-level folder picker for fast manual filing
- keep unfoldered sessions in a `My notes` bucket

## Screenshot
![Notes folders](https://raw.githubusercontent.com/kkarimi/OpenOats/pr-assets-notes-subfolders/pr-assets/notes-subfolders.png)

## Validation
- swift test --filter SessionRepositoryTests --filter NotesControllerTests --filter SettingsStoreTests
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh