### PR TITLE
fix: mirror transcript to notes folder on session finalization

### DIFF
--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -391,6 +391,8 @@ actor SessionRepository {
             calendarEvent: metadata.calendarEvent
         )
         writeSessionMetadata(sessionMeta, sessionID: sessionID)
+
+        scheduleMirror(sessionID: sessionID)
     }
 
     /// End a session without full finalization (discard path).


### PR DESCRIPTION
## Summary

Fixes #368.

- `finalizeSession()` did not call `scheduleMirror()`, so normal live sessions never wrote a markdown file to the user-configured notes folder
- Only `saveFinalTranscript()` (batch transcription / Granola import) and `saveNotes()` (LLM note generation) triggered the mirror
- Audio export worked because `AudioRecorder` writes directly to the configured folder via an independent code path
- Added the missing `scheduleMirror(sessionID:)` call at the end of `finalizeSession()` so every completed session mirrors its transcript to the notes folder immediately

## Test plan

- [x] All 25 `SessionRepositoryTests` pass (including `testSaveNotesMirrorsToNotesFolderPath`)
- [x] `swift build` succeeds
- [ ] Manual: start a session, end it without generating notes, verify a `.md` file appears in the configured notes folder
- [ ] Manual: start a session, end it, then generate notes — verify the `.md` file is updated with the notes section