### PR TITLE
Make upcoming meetings actionable

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -16,6 +16,16 @@ import Observation
 @Observable
 @MainActor
 final class AppCoordinator {
+    struct NotesNavigationRequest: Equatable {
+        enum Target: Equatable {
+            case session(String)
+            case clearSelection
+        }
+
+        let id = UUID()
+        let target: Target
+    }
+
     @ObservationIgnored private let _sessionRepository: SessionRepository
     nonisolated var sessionRepository: SessionRepository { _sessionRepository }
 
@@ -49,10 +59,10 @@ final class AppCoordinator {
         set { withMutation(keyPath: \.pendingExternalCommand) { _pendingExternalCommand = newValue } }
     }
 
-    @ObservationIgnored nonisolated(unsafe) private var _requestedSessionSelectionID: String?
-    var requestedSessionSelectionID: String? {
-        get { access(keyPath: \.requestedSessionSelectionID); return _requestedSessionSelectionID }
-        set { withMutation(keyPath: \.requestedSessionSelectionID) { _requestedSessionSelectionID = newValue } }
+    @ObservationIgnored nonisolated(unsafe) private var _requestedNotesNavigation: NotesNavigationRequest?
+    var requestedNotesNavigation: NotesNavigationRequest? {
+        get { access(keyPath: \.requestedNotesNavigation); return _requestedNotesNavigation }
+        set { withMutation(keyPath: \.requestedNotesNavigation) { _requestedNotesNavigation = newValue } }
     }
 
     var isRecording: Bool {
@@ -218,12 +228,16 @@ final class AppCoordinator {
     }
 
     func queueSessionSelection(_ sessionID: String?) {
-        requestedSessionSelectionID = sessionID
+        if let sessionID {
+            requestedNotesNavigation = NotesNavigationRequest(target: .session(sessionID))
+        } else {
+            requestedNotesNavigation = NotesNavigationRequest(target: .clearSelection)
+        }
     }
 
-    func consumeRequestedSessionSelection() -> String? {
-        defer { requestedSessionSelectionID = nil }
-        return requestedSessionSelectionID
+    func consumeRequestedSessionSelection() -> NotesNavigationRequest.Target? {
+        defer { requestedNotesNavigation = nil }
+        return requestedNotesNavigation?.target
     }
 
     // MARK: - Detection Event Loop

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -96,8 +96,14 @@ final class NotesController {
         await loadHistory()
 
         if let requested = coordinator.consumeRequestedSessionSelection() {
-            selectSession(requested)
-            return true
+            switch requested {
+            case .session(let sessionID):
+                selectSession(sessionID)
+                return true
+            case .clearSelection:
+                selectSession(nil)
+                return true
+            }
         } else if let last = coordinator.lastEndedSession {
             selectSession(last.id)
         }
@@ -116,7 +122,12 @@ final class NotesController {
     /// Returns true if a request was consumed (caller may want to switch to notes tab).
     func handleRequestedSessionSelection() -> Bool {
         if let requested = coordinator.consumeRequestedSessionSelection() {
-            selectSession(requested)
+            switch requested {
+            case .session(let sessionID):
+                selectSession(sessionID)
+            case .clearSelection:
+                selectSession(nil)
+            }
             return true
         }
         return false

--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -109,6 +109,11 @@ final class CalendarManager {
 
 extension CalendarEvent {
     init(from event: EKEvent) {
+        let meetingURL = CalendarMeetingLinkResolver.meetingURL(
+            rawURL: event.url,
+            notes: event.notes,
+            location: event.location
+        )
         self.init(
             id: event.eventIdentifier ?? UUID().uuidString,
             title: event.title ?? "Untitled Event",
@@ -116,16 +121,13 @@ extension CalendarEvent {
             endDate: event.endDate,
             organizer: event.organizer?.name,
             participants: (event.attendees ?? []).map { Participant(from: $0) },
-            isOnlineMeeting: event.url != nil || Self.looksLikeOnlineMeeting(event),
-            meetingURL: event.url
+            isOnlineMeeting: CalendarMeetingLinkResolver.isOnlineMeeting(
+                rawURL: event.url,
+                notes: event.notes,
+                location: event.location
+            ),
+            meetingURL: meetingURL
         )
-    }
-
-    private static func looksLikeOnlineMeeting(_ event: EKEvent) -> Bool {
-        let notes = (event.notes ?? "").lowercased()
-        let location = (event.location ?? "").lowercased()
-        let keywords = ["zoom.us", "teams.microsoft", "meet.google", "facetime", "webex"]
-        return keywords.contains { notes.contains($0) || location.contains($0) }
     }
 }
 
@@ -136,5 +138,85 @@ extension Participant {
             email: attendee.url.absoluteString
                 .replacingOccurrences(of: "mailto:", with: "")
         )
+    }
+}
+
+enum CalendarMeetingLinkResolver {
+    private static let hostHints = [
+        "zoom.us",
+        "teams.microsoft",
+        "teams.live",
+        "meet.google",
+        "webex",
+        "whereby.com",
+        "around.co",
+        "jitsi",
+        "chime.aws",
+        "gotomeeting",
+        "bluejeans",
+        "facetime",
+    ]
+
+    private static let textHints = [
+        "zoom",
+        "teams",
+        "meet",
+        "webex",
+        "facetime",
+        "join",
+    ]
+
+    static func meetingURL(rawURL: URL?, notes: String?, location: String?) -> URL? {
+        if let rawURL {
+            return rawURL
+        }
+
+        let candidates = detectedURLs(in: notes) + detectedURLs(in: location)
+
+        if let preferred = candidates.first(where: isLikelyMeetingURL) {
+            return preferred
+        }
+
+        return nil
+    }
+
+    static func isOnlineMeeting(rawURL: URL?, notes: String?, location: String?) -> Bool {
+        if meetingURL(rawURL: rawURL, notes: notes, location: location) != nil {
+            return true
+        }
+
+        let haystack = "\(notes ?? "")\n\(location ?? "")".lowercased()
+        return textHints.contains { haystack.contains($0) }
+    }
+
+    private static func detectedURLs(in text: String?) -> [URL] {
+        guard let text, !text.isEmpty else { return [] }
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return []
+        }
+
+        let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        return detector.matches(in: text, options: [], range: nsRange).compactMap { match in
+            guard let url = match.url else { return nil }
+            guard let scheme = url.scheme?.lowercased() else { return nil }
+            guard scheme == "http" || scheme == "https" || scheme == "facetime" else {
+                return nil
+            }
+            return url
+        }
+    }
+
+    private static func isLikelyMeetingURL(_ url: URL) -> Bool {
+        if url.scheme?.lowercased() == "facetime" {
+            return true
+        }
+
+        let host = url.host?.lowercased() ?? ""
+        if hostHints.contains(where: host.contains) {
+            return true
+        }
+
+        let absolute = url.absoluteString.lowercased()
+        return textHints.contains(where: absolute.contains)
     }
 }

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 struct IdleHomeDashboardView: View {
     @Bindable var settings: AppSettings
     @Environment(AppContainer.self) private var container
+    @Environment(AppCoordinator.self) private var coordinator
+    @Environment(\.openWindow) private var openWindow
 
     @State private var events: [CalendarEvent] = []
     @State private var refreshTick = 0
@@ -109,7 +111,11 @@ struct IdleHomeDashboardView: View {
         let groups = UpcomingCalendarGrouping.groups(for: events)
         return VStack(alignment: .leading, spacing: 14) {
             ForEach(Array(groups.enumerated()), id: \.element.id) { index, group in
-                ComingUpDayGroupView(group: group)
+                ComingUpDayGroupView(
+                    group: group,
+                    onJoinEvent: joinMeeting(for:),
+                    onOpenRelatedNotes: openRelatedNotes(for:)
+                )
                 if index < groups.count - 1 {
                     Divider()
                         .padding(.top, 2)
@@ -197,10 +203,32 @@ struct IdleHomeDashboardView: View {
             if NSWorkspace.shared.open(url) { return }
         }
     }
+
+    private func joinMeeting(for event: CalendarEvent) {
+        guard let url = event.meetingURL else { return }
+        _ = NSWorkspace.shared.open(url)
+    }
+
+    private func openRelatedNotes(for event: CalendarEvent) {
+        Task {
+            await coordinator.loadHistory()
+            let matchedSession = UpcomingMeetingActionResolver.bestSessionMatch(
+                for: event,
+                sessionHistory: coordinator.sessionHistory
+            )
+
+            await MainActor.run {
+                coordinator.queueSessionSelection(matchedSession?.id)
+                openWindow(id: "notes")
+            }
+        }
+    }
 }
 
 private struct ComingUpDayGroupView: View {
     let group: UpcomingCalendarGrouping.DayGroup
+    let onJoinEvent: (CalendarEvent) -> Void
+    let onOpenRelatedNotes: (CalendarEvent) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -211,26 +239,112 @@ private struct ComingUpDayGroupView: View {
 
             VStack(alignment: .leading, spacing: 10) {
                 ForEach(group.events) { event in
-                    HStack(alignment: .top, spacing: 10) {
-                        RoundedRectangle(cornerRadius: 2)
-                            .fill(Color.accentColor)
-                            .frame(width: 4, height: 34)
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(event.title)
-                                .font(.system(size: 15, weight: .medium))
-                                .lineLimit(1)
-                            Text(CalendarEventDisplay.timeRange(for: event))
-                                .font(.system(size: 13))
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                        }
-
-                        Spacer(minLength: 0)
-                    }
+                    ComingUpEventRow(
+                        event: event,
+                        onJoinEvent: onJoinEvent,
+                        onOpenRelatedNotes: onOpenRelatedNotes
+                    )
                 }
             }
         }
+    }
+}
+
+private struct ComingUpEventRow: View {
+    let event: CalendarEvent
+    let onJoinEvent: (CalendarEvent) -> Void
+    let onOpenRelatedNotes: (CalendarEvent) -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Button(action: {
+                onOpenRelatedNotes(event)
+            }) {
+                HStack(alignment: .top, spacing: 10) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(Color.accentColor)
+                        .frame(width: 4, height: 34)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(event.title)
+                            .font(.system(size: 15, weight: .medium))
+                            .lineLimit(1)
+                        Text(CalendarEventDisplay.timeRange(for: event))
+                            .font(.system(size: 13))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 2)
+                }
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(isHovering ? Color.primary.opacity(0.05) : .clear)
+                )
+                .contentShape(RoundedRectangle(cornerRadius: 10))
+            }
+            .buttonStyle(.plain)
+            .onHover { hovering in
+                isHovering = hovering
+            }
+            .help("Open related notes")
+            .accessibilityIdentifier("idle.comingUp.event.\(event.id)")
+
+            if event.meetingURL != nil {
+                Button(action: {
+                    onJoinEvent(event)
+                }) {
+                    Image(systemName: "video.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 28, height: 28)
+                        .background(
+                            RoundedRectangle(cornerRadius: 8)
+                                .fill(Color.primary.opacity(0.05))
+                        )
+                }
+                .buttonStyle(.plain)
+                .help("Join meeting")
+                .accessibilityIdentifier("idle.comingUp.join.\(event.id)")
+            }
+        }
+    }
+}
+
+enum UpcomingMeetingActionResolver {
+    static func bestSessionMatch(for event: CalendarEvent, sessionHistory: [SessionIndex]) -> SessionIndex? {
+        let normalizedEventTitle = normalizedTitle(event.title)
+        guard !normalizedEventTitle.isEmpty else { return nil }
+
+        return sessionHistory
+            .filter { normalizedTitle($0.title ?? "") == normalizedEventTitle }
+            .sorted { lhs, rhs in
+                if lhs.hasNotes != rhs.hasNotes {
+                    return lhs.hasNotes && !rhs.hasNotes
+                }
+                return lhs.startedAt > rhs.startedAt
+            }
+            .first
+    }
+
+    static func normalizedTitle(_ title: String) -> String {
+        let folded = title
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .unicodeScalars
+            .map { CharacterSet.alphanumerics.contains($0) ? Character($0) : " " }
+        return String(folded)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .lowercased()
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -46,10 +46,16 @@ struct NotesView: View {
             // to ensure @State detailViewMode update happens in the same
             // transaction as session selection (matches pre-Phase 6 behavior).
             if let requested = coordinator.consumeRequestedSessionSelection() {
-                controller.selectSession(requested)
-                // Show Transcript tab for imported sessions (no notes generated yet)
-                let isImported = controller.state.sessionHistory.first(where: { $0.id == requested })?.source == "imported"
-                detailViewMode = isImported ? .transcript : .notes
+                switch requested {
+                case .session(let sessionID):
+                    controller.selectSession(sessionID)
+                    // Show Transcript tab for imported sessions (no notes generated yet)
+                    let isImported = controller.state.sessionHistory.first(where: { $0.id == sessionID })?.source == "imported"
+                    detailViewMode = isImported ? .transcript : .notes
+                case .clearSelection:
+                    controller.selectSession(nil)
+                    detailViewMode = .notes
+                }
             } else if let last = coordinator.lastEndedSession {
                 controller.selectSession(last.id)
             }
@@ -72,7 +78,7 @@ struct NotesView: View {
         .onChange(of: coordinator.sessionHistory.count) {
             Task { await controller.loadHistory() }
         }
-        .onChange(of: coordinator.requestedSessionSelectionID) {
+        .onChange(of: coordinator.requestedNotesNavigation?.id) {
             if controller.handleRequestedSessionSelection() {
                 detailViewMode = .notes
             }

--- a/OpenOats/Tests/OpenOatsTests/CalendarMeetingLinkResolverTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/CalendarMeetingLinkResolverTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class CalendarMeetingLinkResolverTests: XCTestCase {
+    func testMeetingURLPrefersRawEventURL() {
+        let rawURL = URL(string: "https://meet.google.com/raw-room")!
+
+        let resolved = CalendarMeetingLinkResolver.meetingURL(
+            rawURL: rawURL,
+            notes: "Join on Zoom: https://zoom.us/j/123456",
+            location: nil
+        )
+
+        XCTAssertEqual(resolved, rawURL)
+    }
+
+    func testMeetingURLExtractsConferenceLinkFromNotes() {
+        let resolved = CalendarMeetingLinkResolver.meetingURL(
+            rawURL: nil,
+            notes: "Agenda doc https://docs.example.com/agenda\nJoin here https://teams.microsoft.com/l/meetup-join/abc",
+            location: nil
+        )
+
+        XCTAssertEqual(resolved?.host, "teams.microsoft.com")
+    }
+
+    func testMeetingURLExtractsConferenceLinkFromLocation() {
+        let resolved = CalendarMeetingLinkResolver.meetingURL(
+            rawURL: nil,
+            notes: nil,
+            location: "https://zoom.us/j/123456789?pwd=xyz"
+        )
+
+        XCTAssertEqual(resolved?.host, "zoom.us")
+    }
+
+    func testMeetingURLReturnsNilForNonMeetingLinksOnly() {
+        let resolved = CalendarMeetingLinkResolver.meetingURL(
+            rawURL: nil,
+            notes: "Agenda: https://docs.example.com/agenda",
+            location: "Office 3B"
+        )
+
+        XCTAssertNil(resolved)
+    }
+
+    func testIsOnlineMeetingReturnsTrueForMeetingHintsWithoutURL() {
+        XCTAssertTrue(
+            CalendarMeetingLinkResolver.isOnlineMeeting(
+                rawURL: nil,
+                notes: "Teams call",
+                location: nil
+            )
+        )
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/ExternalCommandTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/ExternalCommandTests.swift
@@ -33,7 +33,7 @@ final class ExternalCommandTests: XCTestCase {
     func testOpenNotesQueuesSessionSelection() {
         let coordinator = AppCoordinator()
         coordinator.queueSessionSelection("session_abc")
-        XCTAssertEqual(coordinator.requestedSessionSelectionID, "session_abc")
+        XCTAssertEqual(coordinator.requestedNotesNavigation?.target, .session("session_abc"))
     }
 
     func testConsumeRequestedSessionSelectionClearsAfterRead() {
@@ -41,8 +41,15 @@ final class ExternalCommandTests: XCTestCase {
         coordinator.queueSessionSelection("session_abc")
 
         let consumed = coordinator.consumeRequestedSessionSelection()
-        XCTAssertEqual(consumed, "session_abc")
-        XCTAssertNil(coordinator.requestedSessionSelectionID)
+        XCTAssertEqual(consumed, .session("session_abc"))
+        XCTAssertNil(coordinator.requestedNotesNavigation)
+    }
+
+    func testQueueNilSessionSelectionRequestsClearSelection() {
+        let coordinator = AppCoordinator()
+        coordinator.queueSessionSelection(nil)
+
+        XCTAssertEqual(coordinator.requestedNotesNavigation?.target, .clearSelection)
     }
 
     func testConsumeRequestedSessionSelectionReturnsNilWhenEmpty() {

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -204,7 +204,7 @@ final class LiveSessionControllerTests: XCTestCase {
 
         XCTAssertTrue(notesOpened)
         XCTAssertNil(coordinator.pendingExternalCommand)
-        XCTAssertEqual(coordinator.requestedSessionSelectionID, "test_session")
+        XCTAssertEqual(coordinator.requestedNotesNavigation?.target, .session("test_session"))
     }
 
     func testRunningStateChangeCallbackFires() async {

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -295,6 +295,20 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(controller.state.selectedSessionID, sessionID)
     }
 
+    func testOpenNotesCanExplicitlyClearSelection() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_clear_selection"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID)
+        coordinator.queueSessionSelection(nil)
+
+        await controller.onAppear()
+
+        XCTAssertNil(controller.state.selectedSessionID)
+        XCTAssertTrue(controller.state.loadedTranscript.isEmpty)
+    }
+
     func testGenerateNotesPreservesGeneratedTopHeading() async {
         let (root, notes) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)

--- a/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
@@ -55,6 +55,104 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
         XCTAssertEqual(groups[0].date, calendar.startOfDay(for: eventDate))
     }
 
+    func testBestSessionMatchPrefersMostRecentNotesBearingSession() {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let event = makeEvent(id: "evt", title: "Payment Ops", start: startedAt)
+        let sessions = [
+            SessionIndex(
+                id: "older-notes",
+                startedAt: startedAt.addingTimeInterval(-10_000),
+                endedAt: nil,
+                templateSnapshot: nil,
+                title: "Payment Ops",
+                utteranceCount: 10,
+                hasNotes: true,
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                tags: nil,
+                source: nil
+            ),
+            SessionIndex(
+                id: "newer-no-notes",
+                startedAt: startedAt.addingTimeInterval(-1_000),
+                endedAt: nil,
+                templateSnapshot: nil,
+                title: "Payment Ops",
+                utteranceCount: 8,
+                hasNotes: false,
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                tags: nil,
+                source: nil
+            ),
+            SessionIndex(
+                id: "newest-notes",
+                startedAt: startedAt.addingTimeInterval(-100),
+                endedAt: nil,
+                templateSnapshot: nil,
+                title: "Payment Ops",
+                utteranceCount: 12,
+                hasNotes: true,
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                tags: nil,
+                source: nil
+            ),
+        ]
+
+        let matched = UpcomingMeetingActionResolver.bestSessionMatch(for: event, sessionHistory: sessions)
+        XCTAssertEqual(matched?.id, "newest-notes")
+    }
+
+    func testBestSessionMatchNormalizesTitlePunctuationAndWhitespace() {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let event = makeEvent(id: "evt", title: "Payment Ops / Merchant stand up", start: startedAt)
+        let sessions = [
+            SessionIndex(
+                id: "match",
+                startedAt: startedAt.addingTimeInterval(-100),
+                endedAt: nil,
+                templateSnapshot: nil,
+                title: "  Payment Ops Merchant   stand-up ",
+                utteranceCount: 12,
+                hasNotes: true,
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                tags: nil,
+                source: nil
+            ),
+        ]
+
+        let matched = UpcomingMeetingActionResolver.bestSessionMatch(for: event, sessionHistory: sessions)
+        XCTAssertEqual(matched?.id, "match")
+    }
+
+    func testBestSessionMatchReturnsNilWithoutTitleMatch() {
+        let event = makeEvent(id: "evt", title: "Design Review", start: Date())
+        let sessions = [
+            SessionIndex(
+                id: "other",
+                startedAt: Date().addingTimeInterval(-100),
+                endedAt: nil,
+                templateSnapshot: nil,
+                title: "Weekly Sync",
+                utteranceCount: 5,
+                hasNotes: true,
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                tags: nil,
+                source: nil
+            ),
+        ]
+
+        XCTAssertNil(UpcomingMeetingActionResolver.bestSessionMatch(for: event, sessionHistory: sessions))
+    }
+
     private func makeEvent(id: String, title: String, start: Date) -> CalendarEvent {
         CalendarEvent(
             id: id,


### PR DESCRIPTION
Fixes #370

## Summary
- make `Coming up` rows open related notes/history instead of acting like passive list items
- add a dedicated join button for meetings with a detected meeting URL
- detect meeting URLs from calendar notes and location, not just `EKEvent.url`
- support explicit empty Notes selection when there is no related session match

## Validation
- `swift test --filter CalendarMeetingLinkResolverTests --filter UpcomingCalendarGroupingTests --filter NotesControllerTests --filter ExternalCommandTests --filter LiveSessionControllerTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`

## Screenshot
![Coming up row actions](https://raw.githubusercontent.com/kkarimi/OpenOats/pr-assets-coming-up-row-actions/.github/pr-assets/coming-up-row-actions.png)