### PR TITLE
Show upcoming meetings from multiple calendars

### DIFF
--- a/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
+++ b/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
@@ -48,10 +48,39 @@ struct CalendarEvent: Sendable, Hashable, Codable, Identifiable {
     let title: String
     let startDate: Date
     let endDate: Date
+    let calendarID: String?
+    let calendarTitle: String?
+    let calendarColorHex: String?
     let organizer: String?
     let participants: [Participant]
     let isOnlineMeeting: Bool
     let meetingURL: URL?
+
+    init(
+        id: String,
+        title: String,
+        startDate: Date,
+        endDate: Date,
+        calendarID: String? = nil,
+        calendarTitle: String? = nil,
+        calendarColorHex: String? = nil,
+        organizer: String?,
+        participants: [Participant],
+        isOnlineMeeting: Bool,
+        meetingURL: URL?
+    ) {
+        self.id = id
+        self.title = title
+        self.startDate = startDate
+        self.endDate = endDate
+        self.calendarID = calendarID
+        self.calendarTitle = calendarTitle
+        self.calendarColorHex = calendarColorHex
+        self.organizer = organizer
+        self.participants = participants
+        self.isOnlineMeeting = isOnlineMeeting
+        self.meetingURL = meetingURL
+    }
 }
 
 /// A meeting participant from a calendar event.

--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -1,3 +1,4 @@
+import AppKit
 import EventKit
 import Foundation
 
@@ -42,6 +43,7 @@ final class CalendarManager {
     /// Returns nil if no event is found or access is not authorized.
     func currentEvent(at date: Date = Date()) -> CalendarEvent? {
         guard accessState == .authorized else { return nil }
+        let calendars = eventCalendars()
 
         // Look for events in a window: started up to 15 min ago through 15 min from now
         let windowStart = date.addingTimeInterval(-15 * 60)
@@ -50,7 +52,7 @@ final class CalendarManager {
         let predicate = store.predicateForEvents(
             withStart: windowStart,
             end: windowEnd,
-            calendars: nil
+            calendars: calendars
         )
         let events = store.events(matching: predicate)
 
@@ -76,12 +78,13 @@ final class CalendarManager {
         limit: Int = 5
     ) -> [CalendarEvent] {
         guard accessState == .authorized else { return [] }
+        let calendars = eventCalendars()
 
         let windowEnd = date.addingTimeInterval(window)
         let predicate = store.predicateForEvents(
             withStart: date,
             end: windowEnd,
-            calendars: nil
+            calendars: calendars
         )
         let events = store.events(matching: predicate)
             .filter { !$0.isAllDay && $0.startDate >= date }
@@ -92,6 +95,10 @@ final class CalendarManager {
     }
 
     // MARK: - Helpers
+
+    private func eventCalendars() -> [EKCalendar] {
+        store.calendars(for: .event)
+    }
 
     private static func currentAccessState() -> AccessState {
         switch EKEventStore.authorizationStatus(for: .event) {
@@ -119,6 +126,9 @@ extension CalendarEvent {
             title: event.title ?? "Untitled Event",
             startDate: event.startDate,
             endDate: event.endDate,
+            calendarID: event.calendar.calendarIdentifier,
+            calendarTitle: event.calendar.title,
+            calendarColorHex: CalendarColorCodec.hexString(from: event.calendar.cgColor),
             organizer: event.organizer?.name,
             participants: (event.attendees ?? []).map { Participant(from: $0) },
             isOnlineMeeting: CalendarMeetingLinkResolver.isOnlineMeeting(
@@ -218,5 +228,17 @@ enum CalendarMeetingLinkResolver {
 
         let absolute = url.absoluteString.lowercased()
         return textHints.contains(where: absolute.contains)
+    }
+}
+
+enum CalendarColorCodec {
+    static func hexString(from cgColor: CGColor?) -> String? {
+        guard let cgColor,
+              let nsColor = NSColor(cgColor: cgColor)?.usingColorSpace(.sRGB) else { return nil }
+
+        let red = Int(round(nsColor.redComponent * 255))
+        let green = Int(round(nsColor.greenComponent * 255))
+        let blue = Int(round(nsColor.blueComponent * 255))
+        return String(format: "#%02X%02X%02X", red, green, blue)
     }
 }

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -109,10 +109,13 @@ struct IdleHomeDashboardView: View {
 
     private var upcomingMeetingsCard: some View {
         let groups = UpcomingCalendarGrouping.groups(for: events)
+        let shouldShowCalendarTitle = UpcomingEventSelection.distinctCalendarCount(in: events) > 1
+
         return VStack(alignment: .leading, spacing: 14) {
             ForEach(Array(groups.enumerated()), id: \.element.id) { index, group in
                 ComingUpDayGroupView(
                     group: group,
+                    showCalendarTitle: shouldShowCalendarTitle,
                     onJoinEvent: joinMeeting(for:),
                     onOpenRelatedNotes: openRelatedNotes(for:)
                 )
@@ -151,15 +154,21 @@ struct IdleHomeDashboardView: View {
         let upcomingEvents = manager.upcomingEvents(
             from: now,
             within: 7 * 24 * 60 * 60,
-            limit: 6
+            limit: 24
         )
 
         var combined: [CalendarEvent] = []
         if let currentEvent {
             combined.append(currentEvent)
         }
-        combined.append(contentsOf: upcomingEvents.filter { $0.id != currentEvent?.id })
-        events = Array(combined.prefix(6))
+
+        let remainingLimit = max(0, 6 - combined.count)
+        let selectedUpcoming = UpcomingEventSelection.select(
+            from: upcomingEvents.filter { $0.id != currentEvent?.id },
+            limit: remainingLimit
+        )
+        combined.append(contentsOf: selectedUpcoming)
+        events = combined
     }
 
     private var currentAccessState: CalendarManager.AccessState {
@@ -227,6 +236,7 @@ struct IdleHomeDashboardView: View {
 
 private struct ComingUpDayGroupView: View {
     let group: UpcomingCalendarGrouping.DayGroup
+    let showCalendarTitle: Bool
     let onJoinEvent: (CalendarEvent) -> Void
     let onOpenRelatedNotes: (CalendarEvent) -> Void
 
@@ -241,6 +251,7 @@ private struct ComingUpDayGroupView: View {
                 ForEach(group.events) { event in
                     ComingUpEventRow(
                         event: event,
+                        showCalendarTitle: showCalendarTitle,
                         onJoinEvent: onJoinEvent,
                         onOpenRelatedNotes: onOpenRelatedNotes
                     )
@@ -252,6 +263,7 @@ private struct ComingUpDayGroupView: View {
 
 private struct ComingUpEventRow: View {
     let event: CalendarEvent
+    let showCalendarTitle: Bool
     let onJoinEvent: (CalendarEvent) -> Void
     let onOpenRelatedNotes: (CalendarEvent) -> Void
 
@@ -264,14 +276,14 @@ private struct ComingUpEventRow: View {
             }) {
                 HStack(alignment: .top, spacing: 10) {
                     RoundedRectangle(cornerRadius: 2)
-                        .fill(Color.accentColor)
+                        .fill(calendarColor(for: event))
                         .frame(width: 4, height: 34)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text(event.title)
                             .font(.system(size: 15, weight: .medium))
                             .lineLimit(1)
-                        Text(CalendarEventDisplay.timeRange(for: event))
+                        Text(secondaryLine(for: event))
                             .font(.system(size: 13))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
@@ -317,6 +329,91 @@ private struct ComingUpEventRow: View {
                 .accessibilityIdentifier("idle.comingUp.join.\(event.id)")
             }
         }
+    }
+
+    private func secondaryLine(for event: CalendarEvent) -> String {
+        let time = CalendarEventDisplay.timeRange(for: event)
+        guard showCalendarTitle,
+              let calendarTitle = event.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !calendarTitle.isEmpty else {
+            return time
+        }
+        return "\(time)  •  \(calendarTitle)"
+    }
+
+    private func calendarColor(for event: CalendarEvent) -> Color {
+        guard let hex = event.calendarColorHex,
+              let color = CalendarColorCodec.color(from: hex) else {
+            return .accentColor
+        }
+        return color
+    }
+}
+
+extension CalendarColorCodec {
+    static func color(from hex: String) -> Color? {
+        let cleaned = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard cleaned.count == 7, cleaned.hasPrefix("#") else { return nil }
+
+        let start = cleaned.index(after: cleaned.startIndex)
+        let hexDigits = String(cleaned[start...])
+        guard let value = Int(hexDigits, radix: 16) else { return nil }
+
+        let red = Double((value >> 16) & 0xFF) / 255
+        let green = Double((value >> 8) & 0xFF) / 255
+        let blue = Double(value & 0xFF) / 255
+        return Color(red: red, green: green, blue: blue)
+    }
+}
+
+enum UpcomingEventSelection {
+    static func select(from events: [CalendarEvent], limit: Int) -> [CalendarEvent] {
+        guard limit > 0, events.count > limit else {
+            return Array(events.prefix(limit))
+        }
+
+        let sortedEvents = events.sorted { $0.startDate < $1.startDate }
+        var selectedIDs = Set<String>()
+        var selected: [CalendarEvent] = []
+
+        for event in earliestPerCalendar(in: sortedEvents) {
+            guard selected.count < limit else { break }
+            guard selectedIDs.insert(event.id).inserted else { continue }
+            selected.append(event)
+        }
+
+        for event in sortedEvents {
+            guard selected.count < limit else { break }
+            guard selectedIDs.insert(event.id).inserted else { continue }
+            selected.append(event)
+        }
+
+        return selected.sorted { $0.startDate < $1.startDate }
+    }
+
+    static func distinctCalendarCount(in events: [CalendarEvent]) -> Int {
+        Set(events.map(calendarIdentity(for:))).count
+    }
+
+    private static func earliestPerCalendar(in events: [CalendarEvent]) -> [CalendarEvent] {
+        var firstByCalendar: [String: CalendarEvent] = [:]
+        for event in events {
+            let identity = calendarIdentity(for: event)
+            if firstByCalendar[identity] == nil {
+                firstByCalendar[identity] = event
+            }
+        }
+        return firstByCalendar.values.sorted { $0.startDate < $1.startDate }
+    }
+
+    private static func calendarIdentity(for event: CalendarEvent) -> String {
+        if let calendarID = event.calendarID, !calendarID.isEmpty {
+            return calendarID
+        }
+        if let calendarTitle = event.calendarTitle, !calendarTitle.isEmpty {
+            return "title:\(calendarTitle)"
+        }
+        return "event:\(event.id)"
     }
 }
 

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -12,6 +12,9 @@ final class SessionRepositoryTests: XCTestCase {
             title: "Customer Sync",
             startDate: Date(timeIntervalSince1970: 1_700_000_000),
             endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            calendarID: "calendar-123",
+            calendarTitle: "Customer Meetings",
+            calendarColorHex: "#3366FF",
             organizer: "Aly",
             participants: [
                 Participant(name: "Aly", email: "aly@example.com"),
@@ -145,6 +148,9 @@ final class SessionRepositoryTests: XCTestCase {
 
         let session = await repo.loadSession(id: sessionID)
         XCTAssertEqual(session.calendarEvent?.title, "Customer Sync")
+        XCTAssertEqual(session.calendarEvent?.calendarID, "calendar-123")
+        XCTAssertEqual(session.calendarEvent?.calendarTitle, "Customer Meetings")
+        XCTAssertEqual(session.calendarEvent?.calendarColorHex, "#3366FF")
         XCTAssertEqual(session.calendarEvent?.participants.count, 2)
 
         await repo.deleteSession(sessionID: sessionID)

--- a/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
@@ -153,12 +153,47 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
         XCTAssertNil(UpcomingMeetingActionResolver.bestSessionMatch(for: event, sessionHistory: sessions))
     }
 
-    private func makeEvent(id: String, title: String, start: Date) -> CalendarEvent {
+    func testSelectionPrefersCalendarCoverageBeforeFillingRemainingSlots() {
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        let events = [
+            makeEvent(id: "a1", title: "Alpha 1", start: base.addingTimeInterval(60), calendarID: "A", calendarTitle: "Work"),
+            makeEvent(id: "a2", title: "Alpha 2", start: base.addingTimeInterval(120), calendarID: "A", calendarTitle: "Work"),
+            makeEvent(id: "a3", title: "Alpha 3", start: base.addingTimeInterval(180), calendarID: "A", calendarTitle: "Work"),
+            makeEvent(id: "b1", title: "Beta 1", start: base.addingTimeInterval(240), calendarID: "B", calendarTitle: "Personal"),
+            makeEvent(id: "c1", title: "Gamma 1", start: base.addingTimeInterval(300), calendarID: "C", calendarTitle: "Side"),
+        ]
+
+        let selected = UpcomingEventSelection.select(from: events, limit: 4)
+
+        XCTAssertEqual(selected.map(\.id), ["a1", "a2", "b1", "c1"])
+    }
+
+    func testDistinctCalendarCountUsesCalendarIdentity() {
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
+        let events = [
+            makeEvent(id: "a1", title: "Alpha 1", start: base, calendarID: "A", calendarTitle: "Work"),
+            makeEvent(id: "a2", title: "Alpha 2", start: base.addingTimeInterval(60), calendarID: "A", calendarTitle: "Work"),
+            makeEvent(id: "b1", title: "Beta 1", start: base.addingTimeInterval(120), calendarID: "B", calendarTitle: "Personal"),
+        ]
+
+        XCTAssertEqual(UpcomingEventSelection.distinctCalendarCount(in: events), 2)
+    }
+
+    private func makeEvent(
+        id: String,
+        title: String,
+        start: Date,
+        calendarID: String? = nil,
+        calendarTitle: String? = nil
+    ) -> CalendarEvent {
         CalendarEvent(
             id: id,
             title: title,
             startDate: start,
             endDate: start.addingTimeInterval(30 * 60),
+            calendarID: calendarID,
+            calendarTitle: calendarTitle,
+            calendarColorHex: nil,
             organizer: nil,
             participants: [],
             isOnlineMeeting: false,


### PR DESCRIPTION
Fixes #373

## Summary
- carry calendar identity and color through `CalendarEvent`
- query EventKit with the full visible event-calendar set
- show calendar titles in the Coming up dashboard when multiple calendars are represented
- balance the visible upcoming list so one busy calendar does not crowd out the others

## Testing
- `swift test --filter UpcomingCalendarGroupingTests --filter SessionRepositoryTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`

## Screenshot
![Coming up multi-calendar dashboard](https://raw.githubusercontent.com/kkarimi/OpenOats/pr-assets-coming-up-calendar-identity/.github/pr-assets/coming-up-calendar-identity.png)