### PR TITLE
Keep primary buttons visible in inactive windows

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -93,7 +93,7 @@ struct ContentView: View {
                             Label("Generate Notes", systemImage: "sparkles")
                                 .font(.system(size: 12))
                         }
-                        .buttonStyle(.borderedProminent)
+                        .buttonStyle(OpenOatsProminentButtonStyle())
                         .controlSize(.small)
                         .accessibilityIdentifier("app.generateNotesButton")
                     }

--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -38,7 +38,7 @@ struct ControlBar: View {
                     Button("Download Now") {
                         onConfirmDownload()
                     }
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(OpenOatsProminentButtonStyle())
                     .controlSize(.small)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }

--- a/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
+++ b/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
@@ -133,8 +133,7 @@ struct MenuBarPopoverView: View {
                     .font(.system(size: 13, weight: .medium))
                     .frame(maxWidth: .infinity)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(.red)
+            .buttonStyle(OpenOatsProminentButtonStyle(color: .red))
             .controlSize(.regular)
         } else {
             Button(action: {
@@ -148,7 +147,7 @@ struct MenuBarPopoverView: View {
                     .font(.system(size: 13, weight: .medium))
                     .frame(maxWidth: .infinity)
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(OpenOatsProminentButtonStyle())
             .controlSize(.regular)
         }
     }

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -998,7 +998,7 @@ struct NotesView: View {
                 Label("Clean Up", systemImage: "sparkles")
                     .font(.system(size: 12))
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(OpenOatsProminentButtonStyle())
             .disabled(state.loadedTranscript.isEmpty)
             .help("Remove filler words and fix punctuation")
 
@@ -1024,7 +1024,7 @@ struct NotesView: View {
                 Label("Clean Up", systemImage: "sparkles")
                     .font(.system(size: 12))
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(OpenOatsProminentButtonStyle())
             .help("Clean up remaining utterances")
 
             showOriginalButton(controller: controller, state: state)
@@ -1230,7 +1230,7 @@ struct NotesView: View {
                 } label: {
                     Label("Generate Notes", systemImage: "sparkles")
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(OpenOatsProminentButtonStyle())
                 .disabled(state.loadedTranscript.isEmpty || controller.isAnyGenerationInProgress)
                 .accessibilityIdentifier("notes.generateButton")
 

--- a/OpenOats/Sources/OpenOats/Views/OpenOatsProminentButtonStyle.swift
+++ b/OpenOats/Sources/OpenOats/Views/OpenOatsProminentButtonStyle.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct OpenOatsProminentButtonStyle: ButtonStyle {
+    var color: Color = .accentColor
+
+    func makeBody(configuration: Configuration) -> some View {
+        ProminentButtonBody(configuration: configuration, color: color)
+    }
+}
+
+private struct ProminentButtonBody: View {
+    let configuration: ButtonStyle.Configuration
+    let color: Color
+
+    @Environment(\.controlSize) private var controlSize
+    @Environment(\.isEnabled) private var isEnabled
+
+    var body: some View {
+        configuration.label
+            .foregroundStyle(.white)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(color)
+            )
+            .opacity(isEnabled ? (configuration.isPressed ? 0.88 : 1.0) : 0.5)
+            .scaleEffect(configuration.isPressed ? 0.985 : 1.0)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+
+    private var horizontalPadding: CGFloat {
+        switch controlSize {
+        case .mini:
+            return 8
+        case .small:
+            return 10
+        case .large:
+            return 14
+        case .regular, .extraLarge:
+            return 12
+        @unknown default:
+            return 12
+        }
+    }
+
+    private var verticalPadding: CGFloat {
+        switch controlSize {
+        case .mini:
+            return 4
+        case .small:
+            return 6
+        case .large:
+            return 9
+        case .regular, .extraLarge:
+            return 7
+        @unknown default:
+            return 7
+        }
+    }
+
+    private var cornerRadius: CGFloat {
+        switch controlSize {
+        case .mini:
+            return 6
+        case .small:
+            return 7
+        case .large:
+            return 10
+        case .regular, .extraLarge:
+            return 8
+        @unknown default:
+            return 8
+        }
+    }
+}


### PR DESCRIPTION
Fixes #378

## Summary
- add an explicit OpenOats primary button style instead of relying on macOS prominent bordered rendering
- apply it to the main app surfaces where the inactive-window issue was user-visible
- keep the visual hierarchy of Clean Up, Generate Notes, and related primary actions when the window is not frontmost

## Validation
- 	swift build -c debug
- 	SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh