### PR TITLE
Add a meeting history view for upcoming meetings

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -19,6 +19,7 @@ final class AppCoordinator {
     struct NotesNavigationRequest: Equatable {
         enum Target: Equatable {
             case session(String)
+            case meetingHistory(CalendarEvent)
             case clearSelection
         }
 
@@ -233,6 +234,10 @@ final class AppCoordinator {
         } else {
             requestedNotesNavigation = NotesNavigationRequest(target: .clearSelection)
         }
+    }
+
+    func queueMeetingHistory(_ event: CalendarEvent) {
+        requestedNotesNavigation = NotesNavigationRequest(target: .meetingHistory(event))
     }
 
     func consumeRequestedSessionSelection() -> NotesNavigationRequest.Target? {

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -8,6 +8,8 @@ import Observation
 struct NotesState {
     var sessionHistory: [SessionIndex] = []
     var selectedSessionID: String?
+    var selectedMeetingHistory: MeetingHistorySelection?
+    var meetingHistoryEntries: [MeetingHistoryEntry] = []
     var loadedTranscript: [SessionRecord] = []
     var loadedNotes: GeneratedNotes?
     var loadedCalendarEvent: CalendarEvent?
@@ -56,6 +58,19 @@ struct SessionFolderGroup: Identifiable {
     let sessions: [SessionIndex]
 }
 
+struct MeetingHistorySelection: Equatable {
+    let event: CalendarEvent
+
+    var key: String { MeetingHistoryResolver.historyKey(for: event) }
+}
+
+struct MeetingHistoryEntry: Identifiable {
+    let session: SessionIndex
+    let notesPreview: String?
+
+    var id: String { session.id }
+}
+
 // MARK: - Controller
 
 /// Owns all notes/history business logic previously embedded in NotesView.
@@ -100,6 +115,9 @@ final class NotesController {
             case .session(let sessionID):
                 selectSession(sessionID)
                 return true
+            case .meetingHistory(let event):
+                showMeetingHistory(for: event)
+                return true
             case .clearSelection:
                 selectSession(nil)
                 return true
@@ -125,6 +143,8 @@ final class NotesController {
             switch requested {
             case .session(let sessionID):
                 selectSession(sessionID)
+            case .meetingHistory(let event):
+                showMeetingHistory(for: event)
             case .clearSelection:
                 selectSession(nil)
             }
@@ -137,6 +157,8 @@ final class NotesController {
 
     func selectSession(_ sessionID: String?) {
         state.selectedSessionID = sessionID
+        state.selectedMeetingHistory = nil
+        state.meetingHistoryEntries = []
         stopAudio()
 
         guard let sessionID else {
@@ -182,6 +204,28 @@ final class NotesController {
 
             let hasAny = data.transcript.contains { $0.cleanedText != nil }
             state.cleanupStatus = hasAny ? .completed : .idle
+        }
+    }
+
+    func showMeetingHistory(for event: CalendarEvent) {
+        state.selectedSessionID = nil
+        state.selectedMeetingHistory = MeetingHistorySelection(event: event)
+        state.meetingHistoryEntries = []
+        stopAudio()
+
+        state.loadedNotes = nil
+        state.loadedTranscript = []
+        state.loadedCalendarEvent = nil
+        state.selectedSessionDirectory = nil
+        state.audioFileURL = nil
+        state.showingOriginal = false
+        coordinator.batchTextCleaner.cancel()
+        syncCleanupStatus()
+
+        Task {
+            let entries = await loadMeetingHistoryEntries(for: event)
+            guard state.selectedMeetingHistory?.event.id == event.id else { return }
+            state.meetingHistoryEntries = entries
         }
     }
 
@@ -604,6 +648,9 @@ final class NotesController {
 
     func loadHistory() async {
         state.sessionHistory = await coordinator.sessionRepository.listSessions()
+        if let selection = state.selectedMeetingHistory {
+            state.meetingHistoryEntries = await loadMeetingHistoryEntries(for: selection.event)
+        }
     }
 
     static func normalizedNotesMarkdown(_ markdown: String, title: String?, date: Date) -> String {
@@ -635,6 +682,47 @@ final class NotesController {
             displayTitle = formatter.string(from: date)
         }
         return "# Meeting Notes: \(displayTitle)\n\n"
+    }
+
+    private func loadMeetingHistoryEntries(for event: CalendarEvent) async -> [MeetingHistoryEntry] {
+        let sessions = MeetingHistoryResolver.matchingSessions(for: event, sessionHistory: state.sessionHistory)
+        var entries: [MeetingHistoryEntry] = []
+        entries.reserveCapacity(sessions.count)
+
+        for session in sessions {
+            let preview: String?
+            if session.hasNotes, let notes = await coordinator.sessionRepository.loadNotes(sessionID: session.id) {
+                preview = Self.notesPreview(from: notes.markdown)
+            } else {
+                preview = nil
+            }
+            entries.append(MeetingHistoryEntry(session: session, notesPreview: preview))
+        }
+
+        return entries
+    }
+
+    static func notesPreview(from markdown: String) -> String? {
+        for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+            guard !line.hasPrefix("#") else { continue }
+            guard !line.hasPrefix("!") else { continue }
+            let sanitized = line
+                .replacingOccurrences(
+                    of: #"^([-*+]|[0-9]+\.)\s+"#,
+                    with: "",
+                    options: .regularExpression
+                )
+                .replacingOccurrences(of: "**", with: "")
+                .replacingOccurrences(of: "__", with: "")
+                .replacingOccurrences(of: "`", with: "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if !sanitized.isEmpty {
+                return sanitized
+            }
+        }
+        return nil
     }
 
     /// Maps engine observable state to our flat status enums.

--- a/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
+++ b/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
@@ -124,6 +124,38 @@ extension CalendarEvent {
     }
 }
 
+enum MeetingHistoryResolver {
+    static func historyKey(for event: CalendarEvent) -> String {
+        normalizedTitle(event.title)
+    }
+
+    static func historyKey(for title: String) -> String {
+        normalizedTitle(title)
+    }
+
+    static func matchingSessions(for event: CalendarEvent, sessionHistory: [SessionIndex]) -> [SessionIndex] {
+        matchingSessions(forHistoryKey: historyKey(for: event), sessionHistory: sessionHistory)
+    }
+
+    static func matchingSessions(forHistoryKey historyKey: String, sessionHistory: [SessionIndex]) -> [SessionIndex] {
+        guard !historyKey.isEmpty else { return [] }
+        return sessionHistory
+            .filter { normalizedTitle($0.title ?? "") == historyKey }
+            .sorted { $0.startedAt > $1.startedAt }
+    }
+
+    static func normalizedTitle(_ title: String) -> String {
+        let folded = title
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .unicodeScalars
+            .map { CharacterSet.alphanumerics.contains($0) ? Character($0) : " " }
+        return String(folded)
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+            .lowercased()
+    }
+}
+
 // MARK: - Meeting Metadata
 
 /// Metadata assembled during a meeting session (detection context + calendar info).

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -219,18 +219,8 @@ struct IdleHomeDashboardView: View {
     }
 
     private func openRelatedNotes(for event: CalendarEvent) {
-        Task {
-            await coordinator.loadHistory()
-            let matchedSession = UpcomingMeetingActionResolver.bestSessionMatch(
-                for: event,
-                sessionHistory: coordinator.sessionHistory
-            )
-
-            await MainActor.run {
-                coordinator.queueSessionSelection(matchedSession?.id)
-                openWindow(id: "notes")
-            }
-        }
+        coordinator.queueMeetingHistory(event)
+        openWindow(id: "notes")
     }
 }
 
@@ -308,7 +298,7 @@ private struct ComingUpEventRow: View {
             .onHover { hovering in
                 isHovering = hovering
             }
-            .help("Open related notes")
+            .help("Open meeting history")
             .accessibilityIdentifier("idle.comingUp.event.\(event.id)")
 
             if event.meetingURL != nil {
@@ -414,34 +404,6 @@ enum UpcomingEventSelection {
             return "title:\(calendarTitle)"
         }
         return "event:\(event.id)"
-    }
-}
-
-enum UpcomingMeetingActionResolver {
-    static func bestSessionMatch(for event: CalendarEvent, sessionHistory: [SessionIndex]) -> SessionIndex? {
-        let normalizedEventTitle = normalizedTitle(event.title)
-        guard !normalizedEventTitle.isEmpty else { return nil }
-
-        return sessionHistory
-            .filter { normalizedTitle($0.title ?? "") == normalizedEventTitle }
-            .sorted { lhs, rhs in
-                if lhs.hasNotes != rhs.hasNotes {
-                    return lhs.hasNotes && !rhs.hasNotes
-                }
-                return lhs.startedAt > rhs.startedAt
-            }
-            .first
-    }
-
-    static func normalizedTitle(_ title: String) -> String {
-        let folded = title
-            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
-            .unicodeScalars
-            .map { CharacterSet.alphanumerics.contains($0) ? Character($0) : " " }
-        return String(folded)
-            .split(whereSeparator: \.isWhitespace)
-            .joined(separator: " ")
-            .lowercased()
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -52,6 +52,9 @@ struct NotesView: View {
                     // Show Transcript tab for imported sessions (no notes generated yet)
                     let isImported = controller.state.sessionHistory.first(where: { $0.id == sessionID })?.source == "imported"
                     detailViewMode = isImported ? .transcript : .notes
+                case .meetingHistory(let event):
+                    controller.showMeetingHistory(for: event)
+                    detailViewMode = .notes
                 case .clearSelection:
                     controller.selectSession(nil)
                     detailViewMode = .notes
@@ -778,7 +781,9 @@ struct NotesView: View {
 
     @ViewBuilder
     private func detailContent(controller: NotesController, state: NotesState) -> some View {
-        if let sessionID = state.selectedSessionID {
+        if let selection = state.selectedMeetingHistory {
+            meetingHistoryDetail(controller: controller, state: state, selection: selection)
+        } else if let sessionID = state.selectedSessionID {
             VStack(spacing: 0) {
                 detailToolbar(controller: controller, state: state)
                 Divider()
@@ -802,6 +807,150 @@ struct NotesView: View {
         } else {
             ContentUnavailableView("Select a Session", systemImage: "doc.text", description: Text("Choose a session from the sidebar to view or generate notes."))
         }
+    }
+
+    @ViewBuilder
+    private func meetingHistoryDetail(
+        controller: NotesController,
+        state: NotesState,
+        selection: MeetingHistorySelection
+    ) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                meetingHistoryOverviewCard(selection: selection)
+
+                if state.meetingHistoryEntries.isEmpty {
+                    ContentUnavailableView(
+                        "No history yet",
+                        systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90",
+                        description: Text("OpenOats hasn’t saved any past meetings for this title yet.")
+                    )
+                    .frame(maxWidth: .infinity, minHeight: 220)
+                } else {
+                    meetingHistorySection(controller: controller, historyEntries: state.meetingHistoryEntries)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func meetingHistoryOverviewCard(selection: MeetingHistorySelection) -> some View {
+        let event = selection.event
+
+        return VStack(alignment: .leading, spacing: 10) {
+            Text(event.title)
+                .font(.system(size: 26, weight: .semibold))
+                .foregroundStyle(.primary)
+
+            HStack(spacing: 12) {
+                Text(CalendarEventDisplay.timeRange(for: event))
+                if let calendarTitle = event.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !calendarTitle.isEmpty {
+                    Text("Calendar: \(calendarTitle)")
+                }
+            }
+            .font(.system(size: 13))
+            .foregroundStyle(.secondary)
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .strokeBorder(.quaternary, lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private func meetingHistorySection(controller: NotesController, historyEntries: [MeetingHistoryEntry]) -> some View {
+        let notesCount = historyEntries.filter { $0.session.hasNotes }.count
+
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                Text("Previous meetings")
+                    .font(.system(size: 15, weight: .semibold))
+                Text("\(historyEntries.count) total")
+                Text("\(notesCount) with notes")
+            }
+            .font(.system(size: 13))
+            .foregroundStyle(.secondary)
+
+            VStack(spacing: 10) {
+                ForEach(historyEntries) { entry in
+                    Button {
+                        openSessionFromMeetingHistory(entry.session, controller: controller)
+                    } label: {
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                                Text(entry.session.startedAt, format: .dateTime.day().month(.abbreviated).year().hour().minute())
+                                    .font(.system(size: 15, weight: .semibold))
+                                    .foregroundStyle(.primary)
+
+                                Spacer(minLength: 0)
+
+                                if entry.session.hasNotes {
+                                    Image(systemName: "doc.text.fill")
+                                        .font(.system(size: 11, weight: .medium))
+                                        .foregroundStyle(.secondary)
+                                }
+
+                                if entry.session.folderPath != nil {
+                                    Image(systemName: "folder.fill")
+                                        .font(.system(size: 11, weight: .medium))
+                                        .foregroundStyle(folderColor(for: entry.session.folderPath))
+                                }
+                            }
+
+                            HStack(spacing: 8) {
+                                if entry.session.utteranceCount > 0 {
+                                    Text("\(entry.session.utteranceCount) utterances")
+                                } else {
+                                    Text("No transcript")
+                                }
+
+                                if let source = entry.session.source?.trimmingCharacters(in: .whitespacesAndNewlines),
+                                   !source.isEmpty {
+                                    Text("•")
+                                    Text(source.capitalized)
+                                }
+                            }
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+
+                            if let preview = entry.notesPreview {
+                                Text(preview)
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(2)
+                                    .multilineTextAlignment(.leading)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(14)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color(nsColor: .controlBackgroundColor))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .strokeBorder(.quaternary, lineWidth: 1)
+                        )
+                        .contentShape(RoundedRectangle(cornerRadius: 12))
+                    }
+                    .buttonStyle(.plain)
+                    .help("Open this meeting")
+                }
+            }
+        }
+    }
+
+    private func openSessionFromMeetingHistory(_ session: SessionIndex, controller: NotesController) {
+        controller.selectSession(session.id)
+        detailViewMode = session.hasNotes ? .notes : .transcript
     }
 
     private enum CleanupState {

--- a/OpenOats/Tests/OpenOatsTests/ExternalCommandTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/ExternalCommandTests.swift
@@ -52,6 +52,24 @@ final class ExternalCommandTests: XCTestCase {
         XCTAssertEqual(coordinator.requestedNotesNavigation?.target, .clearSelection)
     }
 
+    func testQueueMeetingHistoryRequestsHistoryTarget() {
+        let coordinator = AppCoordinator()
+        let event = CalendarEvent(
+            id: "evt",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        coordinator.queueMeetingHistory(event)
+
+        XCTAssertEqual(coordinator.requestedNotesNavigation?.target, .meetingHistory(event))
+    }
+
     func testConsumeRequestedSessionSelectionReturnsNilWhenEmpty() {
         let coordinator = AppCoordinator()
         let consumed = coordinator.consumeRequestedSessionSelection()

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -309,6 +309,31 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertTrue(controller.state.loadedTranscript.isEmpty)
     }
 
+    func testOnAppearCanOpenMeetingHistoryRequest() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        await seedSession(coordinator: coordinator, sessionID: "session_payment_ops", title: "Payment Ops")
+
+        let event = CalendarEvent(
+            id: "evt_history",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+        coordinator.queueMeetingHistory(event)
+
+        await controller.onAppear()
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertNil(controller.state.selectedSessionID)
+        XCTAssertEqual(controller.state.selectedMeetingHistory?.event.id, "evt_history")
+        XCTAssertEqual(controller.state.meetingHistoryEntries.map(\.session.id), ["session_payment_ops"])
+    }
+
     func testGenerateNotesPreservesGeneratedTopHeading() async {
         let (root, notes) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)
@@ -326,6 +351,50 @@ final class NotesControllerTests: XCTestCase {
         let markdown = controller.state.loadedNotes?.markdown ?? ""
         XCTAssertTrue(markdown.hasPrefix("# Test Notes\n\n"))
         XCTAssertFalse(markdown.contains("# Meeting Notes: Q4 Planning\n\n# Test Notes"))
+    }
+
+    func testShowMeetingHistoryLoadsMatchingSessionsAndNotePreviews() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+
+        await seedSession(coordinator: coordinator, sessionID: "older", title: "Payment Ops Merchant stand up")
+        await seedSession(coordinator: coordinator, sessionID: "newer", title: "Payment Ops / Merchant stand up")
+        await seedSession(coordinator: coordinator, sessionID: "other", title: "Design Review")
+
+        let template = coordinator.templateStore.snapshot(
+            of: coordinator.templateStore.template(for: TemplateStore.genericID) ?? TemplateStore.builtInTemplates.first!
+        )
+        let notes = GeneratedNotes(
+            template: template,
+            generatedAt: Date(),
+            markdown: "# Notes\n\n## Summary\nReviewed payout issues and next steps."
+        )
+        await coordinator.sessionRepository.saveNotes(sessionID: "newer", notes: notes)
+        await controller.loadHistory()
+
+        let event = CalendarEvent(
+            id: "evt_payment_ops",
+            title: "Payment Ops Merchant stand-up",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        controller.showMeetingHistory(for: event)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertEqual(controller.state.selectedMeetingHistory?.event.id, "evt_payment_ops")
+        XCTAssertNil(controller.state.selectedSessionID)
+        XCTAssertEqual(controller.state.meetingHistoryEntries.map(\.session.id), ["newer", "older"])
+        XCTAssertEqual(controller.state.meetingHistoryEntries.first?.notesPreview, "Reviewed payout issues and next steps.")
+    }
+
+    func testMeetingHistoryPreviewStripsBulletsAndMarkdownMarkers() {
+        let preview = NotesController.notesPreview(from: "# Notes\n\n- **Booking invoices page** - New interface for PMs")
+        XCTAssertEqual(preview, "Booking invoices page - New interface for PMs")
     }
 
     func testNormalizedNotesMarkdownPrependsFallbackHeadingWhenMissing() {

--- a/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
@@ -55,30 +55,16 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
         XCTAssertEqual(groups[0].date, calendar.startOfDay(for: eventDate))
     }
 
-    func testBestSessionMatchPrefersMostRecentNotesBearingSession() {
+    func testMeetingHistoryResolverMatchesNormalizedTitlesNewestFirst() {
         let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
-        let event = makeEvent(id: "evt", title: "Payment Ops", start: startedAt)
+        let event = makeEvent(id: "evt", title: "Payment Ops / Merchant stand up", start: startedAt)
         let sessions = [
             SessionIndex(
-                id: "older-notes",
-                startedAt: startedAt.addingTimeInterval(-10_000),
-                endedAt: nil,
-                templateSnapshot: nil,
-                title: "Payment Ops",
-                utteranceCount: 10,
-                hasNotes: true,
-                language: nil,
-                meetingApp: nil,
-                engine: nil,
-                tags: nil,
-                source: nil
-            ),
-            SessionIndex(
-                id: "newer-no-notes",
+                id: "older",
                 startedAt: startedAt.addingTimeInterval(-1_000),
                 endedAt: nil,
                 templateSnapshot: nil,
-                title: "Payment Ops",
+                title: "Payment Ops Merchant stand-up",
                 utteranceCount: 8,
                 hasNotes: false,
                 language: nil,
@@ -88,11 +74,11 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
                 source: nil
             ),
             SessionIndex(
-                id: "newest-notes",
+                id: "newer",
                 startedAt: startedAt.addingTimeInterval(-100),
                 endedAt: nil,
                 templateSnapshot: nil,
-                title: "Payment Ops",
+                title: "  Payment Ops Merchant   stand up  ",
                 utteranceCount: 12,
                 hasNotes: true,
                 language: nil,
@@ -103,35 +89,11 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
             ),
         ]
 
-        let matched = UpcomingMeetingActionResolver.bestSessionMatch(for: event, sessionHistory: sessions)
-        XCTAssertEqual(matched?.id, "newest-notes")
+        let matched = MeetingHistoryResolver.matchingSessions(for: event, sessionHistory: sessions)
+        XCTAssertEqual(matched.map(\.id), ["newer", "older"])
     }
 
-    func testBestSessionMatchNormalizesTitlePunctuationAndWhitespace() {
-        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
-        let event = makeEvent(id: "evt", title: "Payment Ops / Merchant stand up", start: startedAt)
-        let sessions = [
-            SessionIndex(
-                id: "match",
-                startedAt: startedAt.addingTimeInterval(-100),
-                endedAt: nil,
-                templateSnapshot: nil,
-                title: "  Payment Ops Merchant   stand-up ",
-                utteranceCount: 12,
-                hasNotes: true,
-                language: nil,
-                meetingApp: nil,
-                engine: nil,
-                tags: nil,
-                source: nil
-            ),
-        ]
-
-        let matched = UpcomingMeetingActionResolver.bestSessionMatch(for: event, sessionHistory: sessions)
-        XCTAssertEqual(matched?.id, "match")
-    }
-
-    func testBestSessionMatchReturnsNilWithoutTitleMatch() {
+    func testMeetingHistoryResolverReturnsEmptyWithoutTitleMatch() {
         let event = makeEvent(id: "evt", title: "Design Review", start: Date())
         let sessions = [
             SessionIndex(
@@ -150,7 +112,7 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
             ),
         ]
 
-        XCTAssertNil(UpcomingMeetingActionResolver.bestSessionMatch(for: event, sessionHistory: sessions))
+        XCTAssertTrue(MeetingHistoryResolver.matchingSessions(for: event, sessionHistory: sessions).isEmpty)
     }
 
     func testSelectionPrefersCalendarCoverageBeforeFillingRemainingSlots() {


### PR DESCRIPTION
Fixes #380

## Summary
- open a dedicated meeting history view when the user clicks an upcoming meeting row
- group prior sessions by normalized meeting title and show note preview snippets when notes exist
- keep direct session selection unchanged for now; this only affects the upcoming-meeting entry path

## Screenshot
![Meeting history view](https://raw.githubusercontent.com/kkarimi/OpenOats/pr-assets-meeting-history/pr-assets/meeting-history-view.png)

## Validation
- `swift test --filter NotesControllerTests`
- `swift test --filter ExternalCommandTests --filter UpcomingCalendarGroupingTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`