### PR TITLE
Add prep notes and recording actions to meeting history

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -48,6 +48,7 @@ final class LiveSessionController {
 
     private var downloadTask: Task<Void, Never>?
     private var scratchpadSaveTask: Task<Void, Never>?
+    private var pendingInitialScratchpad: String?
 
     // Tracked-change sentinels
     private var observedUtteranceCount = 0
@@ -124,12 +125,18 @@ final class LiveSessionController {
 
     // MARK: - Session Actions
 
-    func startSession(settings: AppSettings) {
+    func startSession(
+        settings: AppSettings,
+        calendarEventOverride: CalendarEvent? = nil,
+        initialScratchpad: String? = nil
+    ) {
+        guard !state.isRunning else { return }
         coordinator.suggestionEngine?.clear()
         coordinator.sidecastEngine?.clear()
-        let calEvent = settings.calendarIntegrationEnabled
+        let calEvent = calendarEventOverride ?? (settings.calendarIntegrationEnabled
             ? container.calendarManager?.currentEvent()
-            : nil
+            : nil)
+        pendingInitialScratchpad = initialScratchpad?.trimmingCharacters(in: .newlines)
         let metadata = MeetingMetadata.manual(calendarEvent: calEvent)
         coordinator.handle(.userStarted(metadata), settings: settings)
     }
@@ -189,11 +196,15 @@ final class LiveSessionController {
         let handled: Bool
 
         switch request.command {
-        case .startSession:
+        case .startSession(let calendarEvent, let scratchpadSeed):
             guard coordinator.transcriptionEngine != nil,
                   (coordinator.suggestionEngine != nil || coordinator.sidecastEngine != nil) else { return }
             if !state.isRunning {
-                startSession(settings: settings)
+                startSession(
+                    settings: settings,
+                    calendarEventOverride: calendarEvent,
+                    initialScratchpad: scratchpadSeed
+                )
             }
             handled = true
         case .stopSession:
@@ -308,7 +319,12 @@ final class LiveSessionController {
             )
         )
         _currentSessionID = handle.sessionID
-        state.scratchpadText = ""
+        let initialScratchpad = pendingInitialScratchpad?.trimmingCharacters(in: .whitespacesAndNewlines)
+        pendingInitialScratchpad = nil
+        state.scratchpadText = initialScratchpad ?? ""
+        if let initialScratchpad, !initialScratchpad.isEmpty {
+            await coordinator.sessionRepository.saveScratchpad(sessionID: handle.sessionID, text: initialScratchpad)
+        }
 
         if let settings {
             if settings.saveAudioRecording || settings.enableBatchRetranscription {

--- a/OpenOats/Sources/OpenOats/App/OpenOatsDeepLink.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsDeepLink.swift
@@ -15,7 +15,7 @@ enum OpenOatsDeepLink {
 
         switch host {
         case "start":
-            return .startSession
+            return .startSession()
         case "stop":
             return .stopSession
         case "notes":

--- a/OpenOats/Sources/OpenOats/Domain/ExternalCommand.swift
+++ b/OpenOats/Sources/OpenOats/Domain/ExternalCommand.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// A command issued to the app from outside (deep link, menu bar, global hotkey).
 enum ExternalCommand: Equatable {
-    case startSession
+    case startSession(calendarEvent: CalendarEvent? = nil, scratchpadSeed: String? = nil)
     case stopSession
     case openNotes(sessionID: String?)
 }

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -823,6 +823,32 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _meetingPrepNotesByKey: [String: String]
+    var meetingPrepNotesByKey: [String: String] {
+        get { access(keyPath: \.meetingPrepNotesByKey); return _meetingPrepNotesByKey }
+        set {
+            withMutation(keyPath: \.meetingPrepNotesByKey) {
+                _meetingPrepNotesByKey = Self.normalizeMeetingPrepNotes(newValue)
+                defaults.set(Self.encodeMeetingPrepNotes(_meetingPrepNotesByKey), forKey: "meetingPrepNotesByKey")
+            }
+        }
+    }
+
+    func meetingPrepNotes(for event: CalendarEvent) -> String {
+        meetingPrepNotesByKey[MeetingHistoryResolver.historyKey(for: event)] ?? ""
+    }
+
+    func setMeetingPrepNotes(_ text: String, for event: CalendarEvent) {
+        let key = MeetingHistoryResolver.historyKey(for: event)
+        var notes = meetingPrepNotesByKey
+        if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            notes.removeValue(forKey: key)
+        } else {
+            notes[key] = text
+        }
+        meetingPrepNotesByKey = notes
+    }
+
     /// Save a security-scoped bookmark for the user-selected notes folder.
     func saveNotesFolderBookmark(from url: URL) {
         do {
@@ -1040,6 +1066,7 @@ final class SettingsStore {
         let defaultNotesPath = storage.defaultNotesDirectory.path
         self._notesFolderPath = defaults.string(forKey: "notesFolderPath") ?? defaultNotesPath
         self._notesFolders = Self.decodeNotesFolders(defaults.data(forKey: "notesFolders")) ?? []
+        self._meetingPrepNotesByKey = Self.decodeMeetingPrepNotes(defaults.data(forKey: "meetingPrepNotesByKey")) ?? [:]
         self._kbFolderPath = defaults.string(forKey: "kbFolderPath") ?? ""
         self._hasSeenLaunchAtLoginSuggestion = defaults.bool(forKey: "hasSeenLaunchAtLoginSuggestion")
 
@@ -1165,6 +1192,27 @@ final class SettingsStore {
             result.append(NotesFolderDefinition(id: folder.id, path: normalizedPath, color: folder.color))
         }
         return result.sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
+    }
+
+    private static func encodeMeetingPrepNotes(_ notes: [String: String]) -> Data? {
+        let encoder = JSONEncoder()
+        return try? encoder.encode(notes)
+    }
+
+    private static func decodeMeetingPrepNotes(_ data: Data?) -> [String: String]? {
+        guard let data else { return nil }
+        return try? JSONDecoder().decode([String: String].self, from: data)
+    }
+
+    private static func normalizeMeetingPrepNotes(_ notes: [String: String]) -> [String: String] {
+        var result: [String: String] = [:]
+        for (rawKey, rawValue) in notes {
+            let normalizedKey = rawKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalizedKey.isEmpty else { continue }
+            guard !rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
+            result[normalizedKey] = rawValue
+        }
+        return result
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -1,9 +1,11 @@
+import AppKit
 import SwiftUI
 import UniformTypeIdentifiers
 
 struct NotesView: View {
     @Bindable var settings: AppSettings
     @Environment(AppCoordinator.self) private var coordinator
+    @Environment(\.openWindow) private var openWindow
     @State private var notesController: NotesController?
     @State private var renamingSessionID: String?
     @State private var renameText: String = ""
@@ -838,21 +840,72 @@ struct NotesView: View {
 
     private func meetingHistoryOverviewCard(selection: MeetingHistorySelection) -> some View {
         let event = selection.event
+        let prepNotes = Binding(
+            get: { settings.meetingPrepNotes(for: event) },
+            set: { settings.setMeetingPrepNotes($0, for: event) }
+        )
 
         return VStack(alignment: .leading, spacing: 10) {
-            Text(event.title)
-                .font(.system(size: 26, weight: .semibold))
-                .foregroundStyle(.primary)
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(event.title)
+                        .font(.system(size: 26, weight: .semibold))
+                        .foregroundStyle(.primary)
 
-            HStack(spacing: 12) {
-                Text(CalendarEventDisplay.timeRange(for: event))
-                if let calendarTitle = event.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-                   !calendarTitle.isEmpty {
-                    Text("Calendar: \(calendarTitle)")
+                    HStack(spacing: 12) {
+                        Text(CalendarEventDisplay.timeRange(for: event))
+                        if let calendarTitle = event.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+                           !calendarTitle.isEmpty {
+                            Text("Calendar: \(calendarTitle)")
+                        }
+                    }
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                HStack(spacing: 8) {
+                    if event.meetingURL != nil {
+                        Button {
+                            joinMeeting(for: event)
+                        } label: {
+                            Label("Join", systemImage: "video.fill")
+                                .font(.system(size: 12, weight: .medium))
+                        }
+                        .buttonStyle(.bordered)
+                    }
+
+                    Button {
+                        startRecording(for: event)
+                    } label: {
+                        Label("Start recording", systemImage: "mic.fill")
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(coordinator.isRecording)
                 }
             }
-            .font(.system(size: 13))
-            .foregroundStyle(.secondary)
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    Text("Prep notes")
+                        .font(.system(size: 12, weight: .medium))
+                    if !prepNotes.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                        Circle()
+                            .fill(Color.accentColor)
+                            .frame(width: 5, height: 5)
+                    }
+                }
+
+                TextEditor(text: prepNotes)
+                    .font(.system(size: 12))
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: 96)
+                    .padding(6)
+                    .background(Color(nsColor: .textBackgroundColor).opacity(0.65))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
         }
         .padding(18)
         .background(
@@ -951,6 +1004,23 @@ struct NotesView: View {
     private func openSessionFromMeetingHistory(_ session: SessionIndex, controller: NotesController) {
         controller.selectSession(session.id)
         detailViewMode = session.hasNotes ? .notes : .transcript
+    }
+
+    private func startRecording(for event: CalendarEvent) {
+        let prepNotes = settings.meetingPrepNotes(for: event)
+        coordinator.queueExternalCommand(
+            .startSession(
+                calendarEvent: event,
+                scratchpadSeed: prepNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : prepNotes
+            )
+        )
+        NSApp.activate(ignoringOtherApps: true)
+        openWindow(id: OpenOatsRootApp.mainWindowID)
+    }
+
+    private func joinMeeting(for event: CalendarEvent) {
+        guard let url = event.meetingURL else { return }
+        _ = NSWorkspace.shared.open(url)
     }
 
     private enum CleanupState {

--- a/OpenOats/Tests/OpenOatsTests/ExternalCommandTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/ExternalCommandTests.swift
@@ -8,9 +8,9 @@ final class ExternalCommandTests: XCTestCase {
         let coordinator = AppCoordinator()
         XCTAssertNil(coordinator.pendingExternalCommand)
 
-        coordinator.queueExternalCommand(.startSession)
+        coordinator.queueExternalCommand(.startSession())
         XCTAssertNotNil(coordinator.pendingExternalCommand)
-        XCTAssertEqual(coordinator.pendingExternalCommand?.command, .startSession)
+        XCTAssertEqual(coordinator.pendingExternalCommand?.command, .startSession())
     }
 
     func testCompleteExternalCommandClearsMatchingRequest() {
@@ -68,6 +68,27 @@ final class ExternalCommandTests: XCTestCase {
         coordinator.queueMeetingHistory(event)
 
         XCTAssertEqual(coordinator.requestedNotesNavigation?.target, .meetingHistory(event))
+    }
+
+    func testQueueExternalStartSessionCanCarryMeetingContextAndScratchpad() {
+        let coordinator = AppCoordinator()
+        let event = CalendarEvent(
+            id: "evt",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: true,
+            meetingURL: URL(string: "https://meet.example.com/payment-ops")
+        )
+
+        coordinator.queueExternalCommand(.startSession(calendarEvent: event, scratchpadSeed: "Follow up on fees"))
+
+        XCTAssertEqual(
+            coordinator.pendingExternalCommand?.command,
+            .startSession(calendarEvent: event, scratchpadSeed: "Follow up on fees")
+        )
     }
 
     func testConsumeRequestedSessionSelectionReturnsNilWhenEmpty() {

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -157,7 +157,7 @@ final class LiveSessionControllerTests: XCTestCase {
         coordinator.liveSessionController = controller
 
         // Queue a start command
-        coordinator.queueExternalCommand(.startSession)
+        coordinator.queueExternalCommand(.startSession())
 
         // Try handling - should not start because engines are not ready
         controller.handlePendingExternalCommandIfPossible(settings: settings, openNotesWindow: nil)
@@ -205,6 +205,70 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertTrue(notesOpened)
         XCTAssertNil(coordinator.pendingExternalCommand)
         XCTAssertEqual(coordinator.requestedNotesNavigation?.target, .session("test_session"))
+    }
+
+    func testExternalStartSessionSeedsCalendarEventAndScratchpad() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings,
+            scripted: [Utterance(text: "Hello", speaker: .you)]
+        )
+        let knowledgeBase = KnowledgeBase(settings: settings)
+        coordinator.setViewServices(
+            knowledgeBase: knowledgeBase,
+            suggestionEngine: SuggestionEngine(
+                transcriptStore: coordinator.transcriptStore,
+                knowledgeBase: knowledgeBase,
+                settings: settings
+            ),
+            sidecastEngine: SidecastEngine(
+                transcriptStore: coordinator.transcriptStore,
+                knowledgeBase: knowledgeBase,
+                settings: settings
+            )
+        )
+
+        let event = CalendarEvent(
+            id: "evt-123",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: true,
+            meetingURL: URL(string: "https://meet.example.com/payment-ops")
+        )
+
+        coordinator.queueExternalCommand(
+            .startSession(calendarEvent: event, scratchpadSeed: "Talk through merchant fees")
+        )
+
+        controller.handlePendingExternalCommandIfPossible(settings: settings, openNotesWindow: nil)
+
+        for _ in 0..<20 {
+            if coordinator.transcriptionEngine?.isRunning == true { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        let sessionID = await coordinator.sessionRepository.getCurrentSessionID()
+        let savedScratchpad: String?
+        if let sessionID {
+            savedScratchpad = await coordinator.sessionRepository.loadScratchpad(sessionID: sessionID)
+        } else {
+            savedScratchpad = nil
+        }
+
+        if case .recording(let metadata) = coordinator.state {
+            XCTAssertEqual(metadata.calendarEvent?.id, event.id)
+        } else {
+            XCTFail("Expected recording state after external start command")
+        }
+        XCTAssertEqual(controller.state.scratchpadText, "Talk through merchant fees")
+        XCTAssertEqual(savedScratchpad, "Talk through merchant fees")
+        XCTAssertNil(coordinator.pendingExternalCommand)
     }
 
     func testRunningStateChangeCallbackFires() async {

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -348,6 +348,29 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.notesFolders.map(\.color), [.teal])
     }
 
+    func testMeetingPrepNotesRoundTripAndClear() {
+        let store = makeStore()
+        let event = CalendarEvent(
+            id: "evt",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        XCTAssertEqual(store.meetingPrepNotes(for: event), "")
+
+        store.setMeetingPrepNotes("Follow up on merchant fees", for: event)
+        XCTAssertEqual(store.meetingPrepNotes(for: event), "Follow up on merchant fees")
+
+        store.setMeetingPrepNotes("   ", for: event)
+        XCTAssertEqual(store.meetingPrepNotes(for: event), "")
+        XCTAssertEqual(store.meetingPrepNotesByKey, [:])
+    }
+
     func testKbFolderURLWhenEmpty() {
         let store = makeStore()
         XCTAssertNil(store.kbFolderURL)


### PR DESCRIPTION
## Summary
- add prep notes to the upcoming meeting history card
- add Join and Start recording actions there
- seed the live scratchpad when recording starts from that view

## Stacking note
This draft is intentionally stacked on top of #381. While #381 is open, this PR includes both diffs against `main`. Once #381 lands, I will rebase/refresh this branch so the remaining diff is just the prep-notes and recording-actions layer.

## Testing
- swift test --filter ExternalCommandTests
- swift test --filter LiveSessionControllerTests
- swift test --filter SettingsStoreTests
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh



Refs #382