### PR TITLE
Show past sessions in the meeting family view

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -8,7 +8,7 @@ import Observation
 struct NotesState {
     var sessionHistory: [SessionIndex] = []
     var selectedSessionID: String?
-    var selectedMeetingHistory: MeetingHistorySelection?
+    var selectedMeetingFamily: MeetingFamilySelection?
     var meetingHistoryEntries: [MeetingHistoryEntry] = []
     var relatedMeetingSuggestions: [MeetingHistorySuggestion] = []
     var linkingMeetingSuggestionKey: String?
@@ -32,6 +32,11 @@ struct NotesState {
     /// Sessions whose notes were freshly generated while the user was on a different session.
     /// Cleared when the user opens that session. Used to show the blue "unread" indicator.
     var freshlyGeneratedSessionIDs: Set<String> = []
+
+    var selectedMeetingHistory: MeetingHistorySelection? {
+        guard let event = selectedMeetingFamily?.upcomingEvent else { return nil }
+        return MeetingHistorySelection(event: event)
+    }
 }
 
 enum CleanupStatus: Equatable {
@@ -58,6 +63,13 @@ struct SessionFolderGroup: Identifiable {
     let id: String
     let title: String
     let sessions: [SessionIndex]
+}
+
+struct MeetingFamilySelection: Equatable {
+    let key: String
+    let title: String
+    let calendarTitle: String?
+    let upcomingEvent: CalendarEvent?
 }
 
 struct MeetingHistorySelection: Equatable {
@@ -130,7 +142,7 @@ final class NotesController {
                 selectSession(sessionID)
                 return true
             case .meetingHistory(let event):
-                showMeetingHistory(for: event)
+                showMeetingFamily(for: event)
                 return true
             case .clearSelection:
                 selectSession(nil)
@@ -158,7 +170,7 @@ final class NotesController {
             case .session(let sessionID):
                 selectSession(sessionID)
             case .meetingHistory(let event):
-                showMeetingHistory(for: event)
+                showMeetingFamily(for: event)
             case .clearSelection:
                 selectSession(nil)
             }
@@ -171,7 +183,7 @@ final class NotesController {
 
     func selectSession(_ sessionID: String?) {
         state.selectedSessionID = sessionID
-        state.selectedMeetingHistory = nil
+        state.selectedMeetingFamily = nil
         state.meetingHistoryEntries = []
         state.relatedMeetingSuggestions = []
         state.linkingMeetingSuggestionKey = nil
@@ -218,14 +230,26 @@ final class NotesController {
                 state.selectedTemplate = coordinator.templateStore.template(for: TemplateStore.genericID)
             }
 
+            if let session {
+                let familySelection = Self.meetingFamilySelection(for: session, calendarEvent: data.calendarEvent)
+                state.selectedMeetingFamily = familySelection
+                let entries = await loadMeetingHistoryEntries(for: familySelection)
+                state.meetingHistoryEntries = entries
+                state.relatedMeetingSuggestions = loadMeetingHistorySuggestions(
+                    for: familySelection,
+                    hasExactHistory: !entries.isEmpty
+                )
+            }
+
             let hasAny = data.transcript.contains { $0.cleanedText != nil }
             state.cleanupStatus = hasAny ? .completed : .idle
         }
     }
 
-    func showMeetingHistory(for event: CalendarEvent) {
+    func showMeetingFamily(for event: CalendarEvent) {
         state.selectedSessionID = nil
-        state.selectedMeetingHistory = MeetingHistorySelection(event: event)
+        let selection = Self.meetingFamilySelection(for: event)
+        state.selectedMeetingFamily = selection
         state.meetingHistoryEntries = []
         state.relatedMeetingSuggestions = []
         state.linkingMeetingSuggestionKey = nil
@@ -241,30 +265,45 @@ final class NotesController {
         syncCleanupStatus()
 
         Task {
-            let entries = await loadMeetingHistoryEntries(for: event)
-            let suggestions = loadMeetingHistorySuggestions(
-                for: MeetingHistorySelection(event: event),
-                hasExactHistory: !entries.isEmpty
-            )
-            guard state.selectedMeetingHistory?.event.id == event.id else { return }
+            let entries = await loadMeetingHistoryEntries(for: selection)
+            let suggestions = loadMeetingHistorySuggestions(for: selection, hasExactHistory: !entries.isEmpty)
+            guard state.selectedMeetingFamily?.key == selection.key else { return }
             state.meetingHistoryEntries = entries
             state.relatedMeetingSuggestions = suggestions
         }
     }
 
+    func showMeetingHistory(for event: CalendarEvent) {
+        showMeetingFamily(for: event)
+    }
+
     func linkMeetingHistorySuggestion(_ suggestion: MeetingHistorySuggestion) {
-        guard let settings, let selection = state.selectedMeetingHistory else { return }
+        guard let settings, let selection = state.selectedMeetingFamily else { return }
         state.linkingMeetingSuggestionKey = suggestion.key
         settings.linkMeetingHistoryAlias(from: suggestion.key, to: selection.key)
 
         Task {
-            let entries = await loadMeetingHistoryEntries(for: selection.event)
+            let entries = await loadMeetingHistoryEntries(for: selection)
             let suggestions = loadMeetingHistorySuggestions(for: selection, hasExactHistory: !entries.isEmpty)
-            guard state.selectedMeetingHistory?.event.id == selection.event.id else { return }
+            guard state.selectedMeetingFamily?.key == selection.key else { return }
             state.meetingHistoryEntries = entries
             state.relatedMeetingSuggestions = suggestions
             state.linkingMeetingSuggestionKey = nil
         }
+    }
+
+    func showCurrentMeetingFamilyOverview() {
+        guard state.selectedMeetingFamily != nil else { return }
+        state.selectedSessionID = nil
+        stopAudio()
+        state.loadedNotes = nil
+        state.loadedTranscript = []
+        state.loadedCalendarEvent = nil
+        state.audioFileURL = nil
+        state.selectedSessionDirectory = nil
+        state.showingOriginal = false
+        coordinator.batchTextCleaner.cancel()
+        syncCleanupStatus()
     }
 
     // MARK: - Audio Playback
@@ -686,8 +725,8 @@ final class NotesController {
 
     func loadHistory() async {
         state.sessionHistory = await coordinator.sessionRepository.listSessions()
-        if let selection = state.selectedMeetingHistory {
-            let entries = await loadMeetingHistoryEntries(for: selection.event)
+        if let selection = state.selectedMeetingFamily {
+            let entries = await loadMeetingHistoryEntries(for: selection)
             state.meetingHistoryEntries = entries
             state.relatedMeetingSuggestions = loadMeetingHistorySuggestions(
                 for: selection,
@@ -727,9 +766,9 @@ final class NotesController {
         return "# Meeting Notes: \(displayTitle)\n\n"
     }
 
-    private func loadMeetingHistoryEntries(for event: CalendarEvent) async -> [MeetingHistoryEntry] {
+    private func loadMeetingHistoryEntries(for selection: MeetingFamilySelection) async -> [MeetingHistoryEntry] {
         let sessions = MeetingHistoryResolver.matchingSessions(
-            forHistoryKey: MeetingHistoryResolver.historyKey(for: event),
+            forHistoryKey: selection.key,
             sessionHistory: state.sessionHistory,
             aliases: settings?.meetingHistoryAliasesByKey ?? [:]
         )
@@ -750,7 +789,7 @@ final class NotesController {
     }
 
     private func loadMeetingHistorySuggestions(
-        for selection: MeetingHistorySelection,
+        for selection: MeetingFamilySelection,
         hasExactHistory _: Bool
     ) -> [MeetingHistorySuggestion] {
         let aliases = settings?.meetingHistoryAliasesByKey ?? [:]
@@ -815,6 +854,30 @@ final class NotesController {
         }
 
         return suggestions
+    }
+
+    private static func meetingFamilySelection(
+        for session: SessionIndex,
+        calendarEvent: CalendarEvent?
+    ) -> MeetingFamilySelection {
+        let trimmedTitle = session.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let title = trimmedTitle.isEmpty ? "Untitled" : trimmedTitle
+        let key = MeetingHistoryResolver.historyKey(for: title)
+        return MeetingFamilySelection(
+            key: key,
+            title: title,
+            calendarTitle: calendarEvent?.calendarTitle,
+            upcomingEvent: nil
+        )
+    }
+
+    private static func meetingFamilySelection(for event: CalendarEvent) -> MeetingFamilySelection {
+        MeetingFamilySelection(
+            key: MeetingHistoryResolver.historyKey(for: event),
+            title: event.title,
+            calendarTitle: event.calendarTitle,
+            upcomingEvent: event
+        )
     }
 
     static func notesPreview(from markdown: String) -> String? {

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -55,7 +55,7 @@ struct NotesView: View {
                     let isImported = controller.state.sessionHistory.first(where: { $0.id == sessionID })?.source == "imported"
                     detailViewMode = isImported ? .transcript : .notes
                 case .meetingHistory(let event):
-                    controller.showMeetingHistory(for: event)
+                    controller.showMeetingFamily(for: event)
                     detailViewMode = .notes
                 case .clearSelection:
                     controller.selectSession(nil)
@@ -783,160 +783,264 @@ struct NotesView: View {
 
     @ViewBuilder
     private func detailContent(controller: NotesController, state: NotesState) -> some View {
-        if let selection = state.selectedMeetingHistory {
-            meetingHistoryDetail(controller: controller, state: state, selection: selection)
-        } else if let sessionID = state.selectedSessionID {
-            VStack(spacing: 0) {
-                detailToolbar(controller: controller, state: state)
-                Divider()
-                if let calendarEvent = state.loadedCalendarEvent {
-                    notesCalendarContextStrip(calendarEvent)
-                    Divider()
-                }
-                detailBody(controller: controller, state: state, sessionID: sessionID)
-            }
-            .background {
-                Group {
-                    Button("") { detailViewMode = .transcript }
-                        .keyboardShortcut("1", modifiers: .command)
-                    Button("") { detailViewMode = .notes }
-                        .keyboardShortcut("2", modifiers: .command)
-                }
-                .frame(width: 0, height: 0)
-                .opacity(0)
-                .accessibilityHidden(true)
-            }
+        if let selection = state.selectedMeetingFamily {
+            meetingFamilyDetail(controller: controller, state: state, selection: selection)
         } else {
             ContentUnavailableView("Select a Session", systemImage: "doc.text", description: Text("Choose a session from the sidebar to view or generate notes."))
         }
     }
 
     @ViewBuilder
-    private func meetingHistoryDetail(
+    private func meetingFamilyDetail(
         controller: NotesController,
         state: NotesState,
-        selection: MeetingHistorySelection
+        selection: MeetingFamilySelection
     ) -> some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                meetingHistoryOverviewCard(selection: selection)
+        let focusedSessionID = state.selectedSessionID
+        let historyEntries = state.meetingHistoryEntries.filter { $0.session.id != focusedSessionID }
+        let notesCount = historyEntries.filter { $0.session.hasNotes }.count
 
-                if state.meetingHistoryEntries.isEmpty && state.relatedMeetingSuggestions.isEmpty {
-                    ContentUnavailableView(
-                        "No history yet",
-                        systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90",
-                        description: Text("OpenOats hasn’t saved any past meetings for this title yet.")
-                    )
-                    .frame(maxWidth: .infinity, minHeight: 220)
-                } else if !state.meetingHistoryEntries.isEmpty {
-                    meetingHistorySection(controller: controller, historyEntries: state.meetingHistoryEntries)
-                    if !state.relatedMeetingSuggestions.isEmpty {
-                        relatedMeetingSuggestionsSection(
-                            controller: controller,
-                            suggestions: state.relatedMeetingSuggestions,
-                            showsExistingHistory: true,
-                            linkingSuggestionKey: state.linkingMeetingSuggestionKey
-                        )
+        VStack(spacing: 0) {
+            if focusedSessionID != nil {
+                focusedSessionDetail(controller: controller, state: state, selection: selection)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 18) {
+                        meetingFamilyOverviewSection(selection: selection, historyCount: state.meetingHistoryEntries.count)
+
+                        if historyEntries.isEmpty && state.relatedMeetingSuggestions.isEmpty {
+                            ContentUnavailableView(
+                                "No history yet",
+                                systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90",
+                                description: Text("OpenOats hasn’t saved any other meetings for this title yet.")
+                            )
+                            .frame(maxWidth: .infinity, minHeight: 220)
+                        } else if !state.relatedMeetingSuggestions.isEmpty {
+                            relatedMeetingSuggestionsSection(
+                                controller: controller,
+                                suggestions: state.relatedMeetingSuggestions,
+                                showsExistingHistory: !historyEntries.isEmpty,
+                                linkingSuggestionKey: state.linkingMeetingSuggestionKey
+                            )
+                        }
                     }
-                } else {
-                    relatedMeetingSuggestionsSection(
-                        controller: controller,
-                        suggestions: state.relatedMeetingSuggestions,
-                        showsExistingHistory: false,
-                        linkingSuggestionKey: state.linkingMeetingSuggestionKey
-                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(20)
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(20)
+
+            if !historyEntries.isEmpty {
+                Divider()
+
+                meetingHistorySection(
+                    controller: controller,
+                    historyEntries: historyEntries,
+                    notesCount: notesCount
+                )
+                .frame(maxWidth: .infinity, minHeight: 220, maxHeight: focusedSessionID == nil ? .infinity : 300)
+            }
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func meetingHistoryOverviewCard(selection: MeetingHistorySelection) -> some View {
-        let event = selection.event
-        let prepNotes = Binding(
-            get: { settings.meetingPrepNotes(for: event) },
-            set: { settings.setMeetingPrepNotes($0, for: event) }
-        )
+    @ViewBuilder
+    private func meetingFamilyOverviewSection(selection: MeetingFamilySelection, historyCount: Int) -> some View {
+        if let event = selection.upcomingEvent {
+            let prepNotes = Binding(
+                get: { settings.meetingPrepNotes(for: event) },
+                set: { settings.setMeetingPrepNotes($0, for: event) }
+            )
 
-        return VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(event.title)
+                            .font(.system(size: 26, weight: .semibold))
+                            .foregroundStyle(.primary)
+
+                        HStack(spacing: 12) {
+                            Text(CalendarEventDisplay.timeRange(for: event))
+                            if let calendarTitle = event.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+                               !calendarTitle.isEmpty {
+                                Text("Calendar: \(calendarTitle)")
+                            }
+                        }
+                        .font(.system(size: 13))
+                        .foregroundStyle(.secondary)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    HStack(spacing: 8) {
+                        if event.meetingURL != nil {
+                            Button {
+                                joinMeeting(for: event)
+                            } label: {
+                                Label("Join", systemImage: "video.fill")
+                                    .font(.system(size: 12, weight: .medium))
+                            }
+                            .buttonStyle(.bordered)
+                        }
+
+                        Button {
+                            startRecording(for: event)
+                        } label: {
+                            Label("Start recording", systemImage: "mic.fill")
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(coordinator.isRecording)
+                    }
+                }
+
                 VStack(alignment: .leading, spacing: 8) {
-                    Text(event.title)
-                        .font(.system(size: 26, weight: .semibold))
-                        .foregroundStyle(.primary)
+                    HStack(spacing: 6) {
+                        Text("Prep notes")
+                            .font(.system(size: 12, weight: .medium))
+                        if !prepNotes.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            Circle()
+                                .fill(Color.accentColor)
+                                .frame(width: 5, height: 5)
+                        }
+                    }
 
-                    HStack(spacing: 12) {
-                        Text(CalendarEventDisplay.timeRange(for: event))
-                        if let calendarTitle = event.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+                    TextEditor(text: prepNotes)
+                        .font(.system(size: 12))
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 96)
+                        .padding(6)
+                        .background(Color(nsColor: .textBackgroundColor).opacity(0.65))
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+            }
+            .padding(18)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(.quaternary, lineWidth: 1)
+            )
+        } else {
+            VStack(alignment: .leading, spacing: 10) {
+                Text(selection.title)
+                    .font(.system(size: 26, weight: .semibold))
+                    .foregroundStyle(.primary)
+
+                HStack(spacing: 12) {
+                    Text("Meeting history")
+                    Text("\(historyCount) saved meeting\(historyCount == 1 ? "" : "s")")
+                    if let calendarTitle = selection.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+                       !calendarTitle.isEmpty {
+                        Text("Calendar: \(calendarTitle)")
+                    }
+                }
+                .font(.system(size: 13))
+                .foregroundStyle(.secondary)
+            }
+            .padding(18)
+            .background(
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 16)
+                    .strokeBorder(.quaternary, lineWidth: 1)
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func focusedSessionDetail(controller: NotesController, state: NotesState, selection: MeetingFamilySelection) -> some View {
+        VStack(spacing: 0) {
+            detailToolbar(controller: controller, state: state)
+            Divider()
+            meetingFamilyHeaderStrip(state: state, selection: selection, controller: controller)
+            Divider()
+            if let calendarEvent = state.loadedCalendarEvent {
+                notesCalendarContextStrip(calendarEvent)
+                Divider()
+            }
+            if let sessionID = state.selectedSessionID {
+                detailBody(controller: controller, state: state, sessionID: sessionID)
+            }
+        }
+        .background {
+            Group {
+                Button("") { detailViewMode = .transcript }
+                    .keyboardShortcut("1", modifiers: .command)
+                Button("") { detailViewMode = .notes }
+                    .keyboardShortcut("2", modifiers: .command)
+            }
+            .frame(width: 0, height: 0)
+            .opacity(0)
+            .accessibilityHidden(true)
+        }
+    }
+
+    @ViewBuilder
+    private func meetingFamilyHeaderStrip(
+        state: NotesState,
+        selection: MeetingFamilySelection,
+        controller: NotesController
+    ) -> some View {
+        let hasCalendarContext = state.loadedCalendarEvent != nil
+
+        HStack(alignment: .center, spacing: 10) {
+            Button {
+                controller.showCurrentMeetingFamilyOverview()
+                detailViewMode = .notes
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 28, height: 28)
+                    .contentShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .buttonStyle(.borderless)
+            .help("Back")
+
+            if hasCalendarContext {
+                Text("Meeting history")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+            } else {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(selection.title)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+
+                    HStack(spacing: 8) {
+                        if let sessionID = state.selectedSessionID,
+                           let session = state.sessionHistory.first(where: { $0.id == sessionID }) {
+                            Text(session.startedAt, format: .dateTime.day().month(.abbreviated).year().hour().minute())
+                        }
+
+                        if let calendarTitle = selection.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
                            !calendarTitle.isEmpty {
                             Text("Calendar: \(calendarTitle)")
                         }
                     }
-                    .font(.system(size: 13))
+                    .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                 }
-
-                Spacer(minLength: 0)
-
-                HStack(spacing: 8) {
-                    if event.meetingURL != nil {
-                        Button {
-                            joinMeeting(for: event)
-                        } label: {
-                            Label("Join", systemImage: "video.fill")
-                                .font(.system(size: 12, weight: .medium))
-                        }
-                        .buttonStyle(.bordered)
-                    }
-
-                    Button {
-                        startRecording(for: event)
-                    } label: {
-                        Label("Start recording", systemImage: "mic.fill")
-                            .font(.system(size: 12, weight: .semibold))
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(coordinator.isRecording)
-                }
             }
 
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 6) {
-                    Text("Prep notes")
-                        .font(.system(size: 12, weight: .medium))
-                    if !prepNotes.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        Circle()
-                            .fill(Color.accentColor)
-                            .frame(width: 5, height: 5)
-                    }
-                }
-
-                TextEditor(text: prepNotes)
-                    .font(.system(size: 12))
-                    .scrollContentBackground(.hidden)
-                    .frame(minHeight: 96)
-                    .padding(6)
-                    .background(Color(nsColor: .textBackgroundColor).opacity(0.65))
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
-            }
+            Spacer(minLength: 0)
         }
-        .padding(18)
-        .background(
-            RoundedRectangle(cornerRadius: 16)
-                .fill(Color(nsColor: .controlBackgroundColor))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .strokeBorder(.quaternary, lineWidth: 1)
-        )
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(.ultraThinMaterial)
     }
 
     @ViewBuilder
-    private func meetingHistorySection(controller: NotesController, historyEntries: [MeetingHistoryEntry]) -> some View {
-        let notesCount = historyEntries.filter { $0.session.hasNotes }.count
-
+    private func meetingHistorySection(
+        controller: NotesController,
+        historyEntries: [MeetingHistoryEntry],
+        notesCount: Int
+    ) -> some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .firstTextBaseline, spacing: 12) {
                 Text("Previous meetings")
@@ -947,143 +1051,77 @@ struct NotesView: View {
             .font(.system(size: 13))
             .foregroundStyle(.secondary)
 
-            VStack(spacing: 10) {
-                ForEach(historyEntries) { entry in
-                    Button {
-                        openSessionFromMeetingHistory(entry.session, controller: controller)
-                    } label: {
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack(alignment: .firstTextBaseline, spacing: 10) {
-                                Text(entry.session.startedAt, format: .dateTime.day().month(.abbreviated).year().hour().minute())
-                                    .font(.system(size: 15, weight: .semibold))
-                                    .foregroundStyle(.primary)
-
-                                Spacer(minLength: 0)
-
-                                if entry.session.hasNotes {
-                                    Image(systemName: "doc.text.fill")
-                                        .font(.system(size: 11, weight: .medium))
-                                        .foregroundStyle(.secondary)
-                                }
-
-                                if entry.session.folderPath != nil {
-                                    Image(systemName: "folder.fill")
-                                        .font(.system(size: 11, weight: .medium))
-                                        .foregroundStyle(folderColor(for: entry.session.folderPath))
-                                }
-                            }
-
-                            HStack(spacing: 8) {
-                                if entry.session.utteranceCount > 0 {
-                                    Text("\(entry.session.utteranceCount) utterances")
-                                } else {
-                                    Text("No transcript")
-                                }
-
-                                if let source = entry.session.source?.trimmingCharacters(in: .whitespacesAndNewlines),
-                                   !source.isEmpty {
-                                    Text("•")
-                                    Text(source.capitalized)
-                                }
-                            }
-                            .font(.system(size: 12))
-                            .foregroundStyle(.secondary)
-
-                            if let preview = entry.notesPreview {
-                                Text(preview)
-                                    .font(.system(size: 13))
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(2)
-                                    .multilineTextAlignment(.leading)
-                            }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(14)
-                        .background(
-                            RoundedRectangle(cornerRadius: 12)
-                                .fill(Color(nsColor: .controlBackgroundColor))
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .strokeBorder(.quaternary, lineWidth: 1)
-                        )
-                        .contentShape(RoundedRectangle(cornerRadius: 12))
-                    }
-                    .buttonStyle(.plain)
-                    .help("Open this meeting")
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func relatedMeetingSuggestionsSection(
-        controller: NotesController,
-        suggestions: [MeetingHistorySuggestion],
-        showsExistingHistory: Bool,
-        linkingSuggestionKey: String?
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(showsExistingHistory ? "Link more meetings" : "Possible related meetings")
-                    .font(.system(size: 15, weight: .semibold))
-                Text(
-                    showsExistingHistory
-                        ? "Bring other renamed titles into this meeting series."
-                        : "Link an older title into this meeting series."
-                )
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-            }
-
-            VStack(spacing: 10) {
-                ForEach(suggestions) { suggestion in
-                    let isLinking = linkingSuggestionKey == suggestion.key
-                    HStack(alignment: .center, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 6) {
-                            Text(suggestion.title)
-                                .font(.system(size: 15, weight: .semibold))
-                                .foregroundStyle(.primary)
-
-                            HStack(spacing: 8) {
-                                Text("\(suggestion.sessionCount) past meeting\(suggestion.sessionCount == 1 ? "" : "s")")
-                                if suggestion.notesCount > 0 {
-                                    Text("•")
-                                    Text("\(suggestion.notesCount) with notes")
-                                }
-                            }
-                            .font(.system(size: 12))
-                            .foregroundStyle(.secondary)
-                        }
-
-                        Spacer(minLength: 0)
-
+            ScrollView {
+                VStack(spacing: 10) {
+                    ForEach(historyEntries) { entry in
                         Button {
-                            controller.linkMeetingHistorySuggestion(suggestion)
+                            openSessionFromMeetingHistory(entry.session, controller: controller)
                         } label: {
-                            HStack(spacing: 6) {
-                                if isLinking {
-                                    ProgressView()
-                                        .controlSize(.small)
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack(alignment: .firstTextBaseline, spacing: 10) {
+                                    Text(entry.session.startedAt, format: .dateTime.day().month(.abbreviated).year().hour().minute())
+                                        .font(.system(size: 15, weight: .semibold))
+                                        .foregroundStyle(.primary)
+
+                                    Spacer(minLength: 0)
+
+                                    if entry.session.hasNotes {
+                                        Image(systemName: "doc.text.fill")
+                                            .font(.system(size: 11, weight: .medium))
+                                            .foregroundStyle(.secondary)
+                                    }
+
+                                    if entry.session.folderPath != nil {
+                                        Image(systemName: "folder.fill")
+                                            .font(.system(size: 11, weight: .medium))
+                                            .foregroundStyle(folderColor(for: entry.session.folderPath))
+                                    }
                                 }
-                                Text(isLinking ? "Linking…" : "Link")
+
+                                HStack(spacing: 8) {
+                                    if entry.session.utteranceCount > 0 {
+                                        Text("\(entry.session.utteranceCount) utterances")
+                                    } else {
+                                        Text("No transcript")
+                                    }
+
+                                    if let source = entry.session.source?.trimmingCharacters(in: .whitespacesAndNewlines),
+                                       !source.isEmpty {
+                                        Text("•")
+                                        Text(source.capitalized)
+                                    }
+                                }
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+
+                                if let preview = entry.notesPreview {
+                                    Text(preview)
+                                        .font(.system(size: 13))
+                                        .foregroundStyle(.secondary)
+                                        .lineLimit(2)
+                                        .multilineTextAlignment(.leading)
+                                }
                             }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(14)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .fill(Color(nsColor: .controlBackgroundColor))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12)
+                                    .strokeBorder(.quaternary, lineWidth: 1)
+                            )
+                            .contentShape(RoundedRectangle(cornerRadius: 12))
                         }
-                        .buttonStyle(.bordered)
-                        .disabled(isLinking)
+                        .buttonStyle(.plain)
+                        .help("Open this meeting")
                     }
-                    .padding(14)
-                    .background(
-                        RoundedRectangle(cornerRadius: 12)
-                            .fill(Color(nsColor: .controlBackgroundColor))
-                    )
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .strokeBorder(.quaternary, lineWidth: 1)
-                    )
                 }
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(20)
     }
 
     private func openSessionFromMeetingHistory(_ session: SessionIndex, controller: NotesController) {
@@ -1480,6 +1518,76 @@ struct NotesView: View {
                 notesContentView(notes, sessionDirectory: state.selectedSessionDirectory)
             } else {
                 notesEmptyState(controller: controller, state: state, sessionID: sessionID)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func relatedMeetingSuggestionsSection(
+        controller: NotesController,
+        suggestions: [MeetingHistorySuggestion],
+        showsExistingHistory: Bool,
+        linkingSuggestionKey: String?
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(showsExistingHistory ? "Link more meetings" : "Possible related meetings")
+                    .font(.system(size: 15, weight: .semibold))
+                Text(
+                    showsExistingHistory
+                        ? "Bring other renamed titles into this meeting series."
+                        : "Link an older title into this meeting series."
+                )
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+            }
+
+            VStack(spacing: 10) {
+                ForEach(suggestions) { suggestion in
+                    let isLinking = linkingSuggestionKey == suggestion.key
+                    HStack(alignment: .center, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(suggestion.title)
+                                .font(.system(size: 15, weight: .semibold))
+                                .foregroundStyle(.primary)
+
+                            HStack(spacing: 8) {
+                                Text("\(suggestion.sessionCount) past meeting\(suggestion.sessionCount == 1 ? "" : "s")")
+                                if suggestion.notesCount > 0 {
+                                    Text("•")
+                                    Text("\(suggestion.notesCount) with notes")
+                                }
+                            }
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                        }
+
+                        Spacer(minLength: 0)
+
+                        Button {
+                            controller.linkMeetingHistorySuggestion(suggestion)
+                        } label: {
+                            HStack(spacing: 6) {
+                                if isLinking {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Text(isLinking ? "Linking…" : "Link")
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(isLinking)
+                    }
+                    .padding(14)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color(nsColor: .controlBackgroundColor))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(.quaternary, lineWidth: 1)
+                    )
+                }
             }
         }
     }

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -556,6 +556,40 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(preview, "Booking invoices page - New interface for PMs")
     }
 
+    func testSelectSessionAlsoLoadsMeetingFamilyHistory() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+
+        await seedSession(coordinator: coordinator, sessionID: "current", title: "Weekly Sync")
+        await seedSession(coordinator: coordinator, sessionID: "older", title: "Weekly Sync")
+        await seedSession(coordinator: coordinator, sessionID: "other", title: "Design Review")
+        await controller.loadHistory()
+
+        controller.selectSession("current")
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertEqual(controller.state.selectedMeetingFamily?.title, "Weekly Sync")
+        XCTAssertEqual(controller.state.meetingHistoryEntries.map(\.session.id), ["current", "older"])
+    }
+
+    func testShowCurrentMeetingFamilyOverviewClearsFocusedSessionButKeepsFamily() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+
+        await seedSession(coordinator: coordinator, sessionID: "current", title: "Weekly Sync")
+        await seedSession(coordinator: coordinator, sessionID: "older", title: "Weekly Sync")
+        await controller.loadHistory()
+
+        controller.selectSession("current")
+        try? await Task.sleep(for: .milliseconds(250))
+        controller.showCurrentMeetingFamilyOverview()
+
+        XCTAssertNil(controller.state.selectedSessionID)
+        XCTAssertEqual(controller.state.selectedMeetingFamily?.title, "Weekly Sync")
+        XCTAssertEqual(controller.state.meetingHistoryEntries.map(\.session.id), ["current", "older"])
+        XCTAssertTrue(controller.state.loadedTranscript.isEmpty)
+    }
+
     func testNormalizedNotesMarkdownPrependsFallbackHeadingWhenMissing() {
         let markdown = NotesController.normalizedNotesMarkdown(
             "## Summary\nHello",


### PR DESCRIPTION
## Summary
- route historic Notes sidebar selection through the meeting-family container
- add a back affordance from the focused past occurrence to the family overview
- show a generic family header when there is no upcoming calendar event
- hide the previous-meetings section entirely when there are no related meetings

## Stacking note
This draft is intentionally stacked on top of #381 and #383. While those are open, this PR includes the combined diff against `main`. Once they land, I will rebase/refresh this branch so the remaining diff is just the historic-selection container layer.

## Testing
- swift test --filter NotesControllerTests
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh

Refs #384