### PR TITLE
fix: open Settings from menubar popover

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.52.0"
-  sha256 "fe8151443bc645ec7915e251a8866949990410bf11eb14476b218cf98991d9b6"
+  version "1.53.0"
+  sha256 "8dba8793dc12f9011056a45fd1200cf05d6adeeca32cccc999ba2d2648218405"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/App/MenuBarController.swift
+++ b/OpenOats/Sources/OpenOats/App/MenuBarController.swift
@@ -38,6 +38,11 @@ final class MenuBarController {
                 self?.popover.performClose(nil)
                 onCheckForUpdates()
             },
+            onShowSettings: { [weak self] in
+                self?.popover.performClose(nil)
+                NSApp.activate(ignoringOtherApps: true)
+                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+            },
             onQuit: { [weak self] in
                 self?.popover.performClose(nil)
                 self?.onQuitApp?()

--- a/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
+++ b/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
@@ -5,6 +5,7 @@ struct MenuBarPopoverView: View {
     let settings: AppSettings
     let onShowMainWindow: () -> Void
     let onCheckForUpdates: () -> Void
+    let onShowSettings: () -> Void
     let onQuit: () -> Void
 
     @State private var elapsedSeconds: Int = 0
@@ -52,9 +53,7 @@ struct MenuBarPopoverView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
 
-            Button(action: {
-                NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
-            }) {
+            Button(action: onShowSettings) {
                 HStack {
                     Text("Settings…")
                     Spacer()


### PR DESCRIPTION
Closes #387

## Summary

- The Settings button in the menubar popover was non-functional because it called `NSApp.sendAction(Selector(("showSettingsWindow:")))` directly — but the popover lives in a detached `NSHostingController` outside the SwiftUI scene responder chain, so the action never reached a handler.
- Replaced with a closure callback (`onShowSettings`) that closes the popover, activates the app, then sends the action — matching the pattern used by Show OpenOats, Check for Updates, and Quit.
- Also bumps Homebrew cask to v1.53.0 (from `automation/homebrew-cask-1.53.0`).

## Test plan

- [ ] Click the OpenOats menubar icon
- [ ] Click "Settings…" — the Settings window should open
- [ ] Verify the popover dismisses before the Settings window appears
- [ ] Verify "Show OpenOats", "Check for Updates", and "Quit" still work