### PR TITLE
chore: update Homebrew cask to v1.53.1

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.53.0"
-  sha256 "8dba8793dc12f9011056a45fd1200cf05d6adeeca32cccc999ba2d2648218405"
+  version "1.53.1"
+  sha256 "2326675680664ce2e1381004622a6ad156433c959271915025761432512cf173"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Update Homebrew cask formula to match v1.53.1 release.

- version: 1.53.0 → 1.53.1
- sha256: updated to match new DMG

Automated update from release workflow.