### PR TITLE
Link renamed meetings into history families

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -10,6 +10,8 @@ struct NotesState {
     var selectedSessionID: String?
     var selectedMeetingHistory: MeetingHistorySelection?
     var meetingHistoryEntries: [MeetingHistoryEntry] = []
+    var relatedMeetingSuggestions: [MeetingHistorySuggestion] = []
+    var linkingMeetingSuggestionKey: String?
     var loadedTranscript: [SessionRecord] = []
     var loadedNotes: GeneratedNotes?
     var loadedCalendarEvent: CalendarEvent?
@@ -71,6 +73,16 @@ struct MeetingHistoryEntry: Identifiable {
     var id: String { session.id }
 }
 
+struct MeetingHistorySuggestion: Identifiable, Equatable {
+    let key: String
+    let title: String
+    let sessionCount: Int
+    let notesCount: Int
+    let latestStartedAt: Date
+
+    var id: String { key }
+}
+
 // MARK: - Controller
 
 /// Owns all notes/history business logic previously embedded in NotesView.
@@ -81,6 +93,7 @@ final class NotesController {
     private(set) var state = NotesState()
 
     private let coordinator: AppCoordinator
+    private let settings: AppSettings?
 
     /// Observation polling task for engine state mapping.
     @ObservationIgnored nonisolated(unsafe) private var engineObservationTask: Task<Void, Never>?
@@ -93,8 +106,9 @@ final class NotesController {
     @ObservationIgnored private var audioPlayer: AVPlayer?
     @ObservationIgnored private var playerObservation: Any?
 
-    init(coordinator: AppCoordinator) {
+    init(coordinator: AppCoordinator, settings: AppSettings? = nil) {
         self.coordinator = coordinator
+        self.settings = settings
         startEngineObservation()
     }
 
@@ -159,6 +173,8 @@ final class NotesController {
         state.selectedSessionID = sessionID
         state.selectedMeetingHistory = nil
         state.meetingHistoryEntries = []
+        state.relatedMeetingSuggestions = []
+        state.linkingMeetingSuggestionKey = nil
         stopAudio()
 
         guard let sessionID else {
@@ -211,6 +227,8 @@ final class NotesController {
         state.selectedSessionID = nil
         state.selectedMeetingHistory = MeetingHistorySelection(event: event)
         state.meetingHistoryEntries = []
+        state.relatedMeetingSuggestions = []
+        state.linkingMeetingSuggestionKey = nil
         stopAudio()
 
         state.loadedNotes = nil
@@ -224,8 +242,28 @@ final class NotesController {
 
         Task {
             let entries = await loadMeetingHistoryEntries(for: event)
+            let suggestions = loadMeetingHistorySuggestions(
+                for: MeetingHistorySelection(event: event),
+                hasExactHistory: !entries.isEmpty
+            )
             guard state.selectedMeetingHistory?.event.id == event.id else { return }
             state.meetingHistoryEntries = entries
+            state.relatedMeetingSuggestions = suggestions
+        }
+    }
+
+    func linkMeetingHistorySuggestion(_ suggestion: MeetingHistorySuggestion) {
+        guard let settings, let selection = state.selectedMeetingHistory else { return }
+        state.linkingMeetingSuggestionKey = suggestion.key
+        settings.linkMeetingHistoryAlias(from: suggestion.key, to: selection.key)
+
+        Task {
+            let entries = await loadMeetingHistoryEntries(for: selection.event)
+            let suggestions = loadMeetingHistorySuggestions(for: selection, hasExactHistory: !entries.isEmpty)
+            guard state.selectedMeetingHistory?.event.id == selection.event.id else { return }
+            state.meetingHistoryEntries = entries
+            state.relatedMeetingSuggestions = suggestions
+            state.linkingMeetingSuggestionKey = nil
         }
     }
 
@@ -649,7 +687,12 @@ final class NotesController {
     func loadHistory() async {
         state.sessionHistory = await coordinator.sessionRepository.listSessions()
         if let selection = state.selectedMeetingHistory {
-            state.meetingHistoryEntries = await loadMeetingHistoryEntries(for: selection.event)
+            let entries = await loadMeetingHistoryEntries(for: selection.event)
+            state.meetingHistoryEntries = entries
+            state.relatedMeetingSuggestions = loadMeetingHistorySuggestions(
+                for: selection,
+                hasExactHistory: !entries.isEmpty
+            )
         }
     }
 
@@ -685,7 +728,11 @@ final class NotesController {
     }
 
     private func loadMeetingHistoryEntries(for event: CalendarEvent) async -> [MeetingHistoryEntry] {
-        let sessions = MeetingHistoryResolver.matchingSessions(for: event, sessionHistory: state.sessionHistory)
+        let sessions = MeetingHistoryResolver.matchingSessions(
+            forHistoryKey: MeetingHistoryResolver.historyKey(for: event),
+            sessionHistory: state.sessionHistory,
+            aliases: settings?.meetingHistoryAliasesByKey ?? [:]
+        )
         var entries: [MeetingHistoryEntry] = []
         entries.reserveCapacity(sessions.count)
 
@@ -700,6 +747,74 @@ final class NotesController {
         }
 
         return entries
+    }
+
+    private func loadMeetingHistorySuggestions(
+        for selection: MeetingHistorySelection,
+        hasExactHistory _: Bool
+    ) -> [MeetingHistorySuggestion] {
+        let aliases = settings?.meetingHistoryAliasesByKey ?? [:]
+        let canonicalSelectionKey = MeetingHistoryResolver.canonicalHistoryKey(
+            for: selection.key,
+            aliases: aliases
+        )
+
+        var groupedSessions: [String: [SessionIndex]] = [:]
+        for session in state.sessionHistory {
+            let title = session.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            let historyKey = MeetingHistoryResolver.historyKey(for: title)
+            guard !historyKey.isEmpty else { continue }
+
+            let canonicalSessionKey = MeetingHistoryResolver.canonicalHistoryKey(
+                for: historyKey,
+                aliases: aliases
+            )
+            guard canonicalSessionKey != canonicalSelectionKey else { continue }
+            guard MeetingHistoryResolver.relationScore(
+                from: canonicalSelectionKey,
+                to: canonicalSessionKey
+            ) != nil else { continue }
+
+            groupedSessions[canonicalSessionKey, default: []].append(session)
+        }
+
+        let suggestions: [MeetingHistorySuggestion] = groupedSessions.compactMap { entry in
+            let (key, sessions) = entry
+            let sortedSessions = sessions.sorted { $0.startedAt > $1.startedAt }
+            guard let latestSession = sortedSessions.first else { return nil }
+            let title = latestSession.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let displayTitle = (title?.isEmpty == false ? title : nil) ?? "Untitled"
+            return MeetingHistorySuggestion(
+                key: key,
+                title: displayTitle,
+                sessionCount: sortedSessions.count,
+                notesCount: sortedSessions.filter(\.hasNotes).count,
+                latestStartedAt: latestSession.startedAt
+            )
+        }
+        .sorted { lhs, rhs in
+            let lhsScore = MeetingHistoryResolver.relationScore(from: canonicalSelectionKey, to: lhs.key) ?? 0
+            let rhsScore = MeetingHistoryResolver.relationScore(from: canonicalSelectionKey, to: rhs.key) ?? 0
+            if lhsScore != rhsScore { return lhsScore > rhsScore }
+            if lhs.sessionCount != rhs.sessionCount { return lhs.sessionCount > rhs.sessionCount }
+            return lhs.latestStartedAt > rhs.latestStartedAt
+        }
+
+        let selectionTokenCount = canonicalSelectionKey.split(separator: " ").count
+        if selectionTokenCount == 1 {
+            let recurringSuggestions = suggestions.filter { $0.sessionCount >= 2 }
+            if !recurringSuggestions.isEmpty {
+                if let primary = recurringSuggestions.first {
+                    let nextCount = recurringSuggestions.dropFirst().first?.sessionCount ?? 0
+                    if primary.sessionCount >= max(6, nextCount * 3) {
+                        return [primary]
+                    }
+                }
+                return recurringSuggestions
+            }
+        }
+
+        return suggestions
     }
 
     static func notesPreview(from markdown: String) -> String? {

--- a/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
+++ b/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
@@ -138,10 +138,61 @@ enum MeetingHistoryResolver {
     }
 
     static func matchingSessions(forHistoryKey historyKey: String, sessionHistory: [SessionIndex]) -> [SessionIndex] {
+        matchingSessions(forHistoryKey: historyKey, sessionHistory: sessionHistory, aliases: [:])
+    }
+
+    static func matchingSessions(
+        forHistoryKey historyKey: String,
+        sessionHistory: [SessionIndex],
+        aliases: [String: String]
+    ) -> [SessionIndex] {
         guard !historyKey.isEmpty else { return [] }
+        let canonicalKey = canonicalHistoryKey(for: historyKey, aliases: aliases)
         return sessionHistory
-            .filter { normalizedTitle($0.title ?? "") == historyKey }
+            .filter {
+                canonicalHistoryKey(for: normalizedTitle($0.title ?? ""), aliases: aliases) == canonicalKey
+            }
             .sorted { $0.startedAt > $1.startedAt }
+    }
+
+    static func canonicalHistoryKey(for historyKey: String, aliases: [String: String]) -> String {
+        let normalizedKey = historyKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalizedKey.isEmpty else { return "" }
+
+        var current = normalizedKey
+        var seen: Set<String> = [normalizedKey]
+        while let next = aliases[current], !next.isEmpty, !seen.contains(next) {
+            current = next
+            seen.insert(next)
+        }
+        return current
+    }
+
+    static func relationScore(from sourceHistoryKey: String, to candidateHistoryKey: String) -> Double? {
+        let sourceTokens = tokenSet(forHistoryKey: sourceHistoryKey)
+        let candidateTokens = tokenSet(forHistoryKey: candidateHistoryKey)
+        if let singleTokenScore = singleTokenRelationScore(
+            sourceTokens: sourceTokens,
+            candidateTokens: candidateTokens
+        ) {
+            return singleTokenScore
+        }
+
+        guard sourceTokens.count >= 2, candidateTokens.count >= 2 else { return nil }
+
+        let overlap = sourceTokens.intersection(candidateTokens)
+        guard overlap.count >= 2 else { return nil }
+
+        let minimumCount = min(sourceTokens.count, candidateTokens.count)
+        guard minimumCount > 0 else { return nil }
+
+        let overlapRatio = Double(overlap.count) / Double(minimumCount)
+        if sourceTokens.isSubset(of: candidateTokens) || candidateTokens.isSubset(of: sourceTokens) {
+            return 1.0 + overlapRatio
+        }
+
+        guard overlapRatio >= 0.75 else { return nil }
+        return overlapRatio
     }
 
     static func normalizedTitle(_ title: String) -> String {
@@ -153,6 +204,24 @@ enum MeetingHistoryResolver {
             .split(whereSeparator: \.isWhitespace)
             .joined(separator: " ")
             .lowercased()
+    }
+
+    private static func tokenSet(forHistoryKey historyKey: String) -> Set<String> {
+        Set(historyKey.split(separator: " ").map(String.init))
+    }
+
+    private static func singleTokenRelationScore(
+        sourceTokens: Set<String>,
+        candidateTokens: Set<String>
+    ) -> Double? {
+        let overlap = sourceTokens.intersection(candidateTokens)
+        guard overlap.count == 1 else { return nil }
+
+        let minimumCount = min(sourceTokens.count, candidateTokens.count)
+        guard minimumCount == 1 else { return nil }
+        guard let token = overlap.first, token.count >= 4 else { return nil }
+
+        return 0.9
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -834,12 +834,27 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _meetingHistoryAliasesByKey: [String: String]
+    var meetingHistoryAliasesByKey: [String: String] {
+        get { access(keyPath: \.meetingHistoryAliasesByKey); return _meetingHistoryAliasesByKey }
+        set {
+            withMutation(keyPath: \.meetingHistoryAliasesByKey) {
+                _meetingHistoryAliasesByKey = Self.normalizeMeetingHistoryAliases(newValue)
+                defaults.set(
+                    Self.encodeMeetingHistoryAliases(_meetingHistoryAliasesByKey),
+                    forKey: "meetingHistoryAliasesByKey"
+                )
+            }
+        }
+    }
+
     func meetingPrepNotes(for event: CalendarEvent) -> String {
-        meetingPrepNotesByKey[MeetingHistoryResolver.historyKey(for: event)] ?? ""
+        let key = canonicalMeetingHistoryKey(for: event)
+        return meetingPrepNotesByKey[key] ?? ""
     }
 
     func setMeetingPrepNotes(_ text: String, for event: CalendarEvent) {
-        let key = MeetingHistoryResolver.historyKey(for: event)
+        let key = canonicalMeetingHistoryKey(for: event)
         var notes = meetingPrepNotesByKey
         if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             notes.removeValue(forKey: key)
@@ -847,6 +862,27 @@ final class SettingsStore {
             notes[key] = text
         }
         meetingPrepNotesByKey = notes
+    }
+
+    func canonicalMeetingHistoryKey(for event: CalendarEvent) -> String {
+        canonicalMeetingHistoryKey(forHistoryKey: MeetingHistoryResolver.historyKey(for: event))
+    }
+
+    func canonicalMeetingHistoryKey(forHistoryKey historyKey: String) -> String {
+        MeetingHistoryResolver.canonicalHistoryKey(
+            for: historyKey,
+            aliases: meetingHistoryAliasesByKey
+        )
+    }
+
+    func linkMeetingHistoryAlias(from aliasHistoryKey: String, to canonicalHistoryKey: String) {
+        let aliasKey = MeetingHistoryResolver.historyKey(for: aliasHistoryKey)
+        let targetKey = canonicalMeetingHistoryKey(forHistoryKey: canonicalHistoryKey)
+        guard !aliasKey.isEmpty, !targetKey.isEmpty, aliasKey != targetKey else { return }
+
+        var aliases = meetingHistoryAliasesByKey
+        aliases[aliasKey] = targetKey
+        meetingHistoryAliasesByKey = aliases
     }
 
     /// Save a security-scoped bookmark for the user-selected notes folder.
@@ -1067,6 +1103,9 @@ final class SettingsStore {
         self._notesFolderPath = defaults.string(forKey: "notesFolderPath") ?? defaultNotesPath
         self._notesFolders = Self.decodeNotesFolders(defaults.data(forKey: "notesFolders")) ?? []
         self._meetingPrepNotesByKey = Self.decodeMeetingPrepNotes(defaults.data(forKey: "meetingPrepNotesByKey")) ?? [:]
+        self._meetingHistoryAliasesByKey = Self.decodeMeetingHistoryAliases(
+            defaults.data(forKey: "meetingHistoryAliasesByKey")
+        ) ?? [:]
         self._kbFolderPath = defaults.string(forKey: "kbFolderPath") ?? ""
         self._hasSeenLaunchAtLoginSuggestion = defaults.bool(forKey: "hasSeenLaunchAtLoginSuggestion")
 
@@ -1204,6 +1243,16 @@ final class SettingsStore {
         return try? JSONDecoder().decode([String: String].self, from: data)
     }
 
+    private static func encodeMeetingHistoryAliases(_ aliases: [String: String]) -> Data? {
+        let encoder = JSONEncoder()
+        return try? encoder.encode(aliases)
+    }
+
+    private static func decodeMeetingHistoryAliases(_ data: Data?) -> [String: String]? {
+        guard let data else { return nil }
+        return try? JSONDecoder().decode([String: String].self, from: data)
+    }
+
     private static func normalizeMeetingPrepNotes(_ notes: [String: String]) -> [String: String] {
         var result: [String: String] = [:]
         for (rawKey, rawValue) in notes {
@@ -1211,6 +1260,19 @@ final class SettingsStore {
             guard !normalizedKey.isEmpty else { continue }
             guard !rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { continue }
             result[normalizedKey] = rawValue
+        }
+        return result
+    }
+
+    private static func normalizeMeetingHistoryAliases(_ aliases: [String: String]) -> [String: String] {
+        var result: [String: String] = [:]
+        for (rawKey, rawValue) in aliases {
+            let normalizedKey = rawKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let normalizedValue = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalizedKey.isEmpty, !normalizedValue.isEmpty, normalizedKey != normalizedValue else {
+                continue
+            }
+            result[normalizedKey] = normalizedValue
         }
         return result
     }

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -40,7 +40,7 @@ struct NotesView: View {
             }
         }
         .task {
-            let controller = NotesController(coordinator: coordinator)
+            let controller = NotesController(coordinator: coordinator, settings: settings)
             notesController = controller
             await controller.loadHistory()
 
@@ -821,15 +821,30 @@ struct NotesView: View {
             VStack(alignment: .leading, spacing: 18) {
                 meetingHistoryOverviewCard(selection: selection)
 
-                if state.meetingHistoryEntries.isEmpty {
+                if state.meetingHistoryEntries.isEmpty && state.relatedMeetingSuggestions.isEmpty {
                     ContentUnavailableView(
                         "No history yet",
                         systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90",
                         description: Text("OpenOats hasn’t saved any past meetings for this title yet.")
                     )
                     .frame(maxWidth: .infinity, minHeight: 220)
-                } else {
+                } else if !state.meetingHistoryEntries.isEmpty {
                     meetingHistorySection(controller: controller, historyEntries: state.meetingHistoryEntries)
+                    if !state.relatedMeetingSuggestions.isEmpty {
+                        relatedMeetingSuggestionsSection(
+                            controller: controller,
+                            suggestions: state.relatedMeetingSuggestions,
+                            showsExistingHistory: true,
+                            linkingSuggestionKey: state.linkingMeetingSuggestionKey
+                        )
+                    }
+                } else {
+                    relatedMeetingSuggestionsSection(
+                        controller: controller,
+                        suggestions: state.relatedMeetingSuggestions,
+                        showsExistingHistory: false,
+                        linkingSuggestionKey: state.linkingMeetingSuggestionKey
+                    )
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -996,6 +1011,76 @@ struct NotesView: View {
                     }
                     .buttonStyle(.plain)
                     .help("Open this meeting")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func relatedMeetingSuggestionsSection(
+        controller: NotesController,
+        suggestions: [MeetingHistorySuggestion],
+        showsExistingHistory: Bool,
+        linkingSuggestionKey: String?
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(showsExistingHistory ? "Link more meetings" : "Possible related meetings")
+                    .font(.system(size: 15, weight: .semibold))
+                Text(
+                    showsExistingHistory
+                        ? "Bring other renamed titles into this meeting series."
+                        : "Link an older title into this meeting series."
+                )
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+
+            VStack(spacing: 10) {
+                ForEach(suggestions) { suggestion in
+                    let isLinking = linkingSuggestionKey == suggestion.key
+                    HStack(alignment: .center, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(suggestion.title)
+                                .font(.system(size: 15, weight: .semibold))
+                                .foregroundStyle(.primary)
+
+                            HStack(spacing: 8) {
+                                Text("\(suggestion.sessionCount) past meeting\(suggestion.sessionCount == 1 ? "" : "s")")
+                                if suggestion.notesCount > 0 {
+                                    Text("•")
+                                    Text("\(suggestion.notesCount) with notes")
+                                }
+                            }
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                        }
+
+                        Spacer(minLength: 0)
+
+                        Button {
+                            controller.linkMeetingHistorySuggestion(suggestion)
+                        } label: {
+                            HStack(spacing: 6) {
+                                if isLinking {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                }
+                                Text(isLinking ? "Linking…" : "Link")
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(isLinking)
+                    }
+                    .padding(14)
+                    .background(
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(Color(nsColor: .controlBackgroundColor))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .strokeBorder(.quaternary, lineWidth: 1)
+                    )
                 }
             }
         }

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -83,14 +83,14 @@ final class NotesControllerTests: XCTestCase {
         await coordinator.loadHistory()
     }
 
-    private func makeController(root: URL) -> (NotesController, AppCoordinator) {
+    private func makeController(root: URL, settings: AppSettings? = nil) -> (NotesController, AppCoordinator) {
         let coordinator = AppCoordinator(
             sessionRepository: SessionRepository(rootDirectory: root),
             templateStore: TemplateStore(rootDirectory: root),
             notesEngine: NotesEngine(mode: .scripted(markdown: "# Test Notes\n\n## Summary\nTest summary.")),
             transcriptStore: TranscriptStore()
         )
-        let controller = NotesController(coordinator: coordinator)
+        let controller = NotesController(coordinator: coordinator, settings: settings)
         return (controller, coordinator)
     }
 
@@ -390,6 +390,165 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertNil(controller.state.selectedSessionID)
         XCTAssertEqual(controller.state.meetingHistoryEntries.map(\.session.id), ["newer", "older"])
         XCTAssertEqual(controller.state.meetingHistoryEntries.first?.notesPreview, "Reviewed payout issues and next steps.")
+    }
+
+    func testShowMeetingHistorySuggestsRenamedMeetingSeriesWhenExactHistoryIsEmpty() async {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+
+        await seedSession(coordinator: coordinator, sessionID: "legacy1", title: "Payment Ops")
+        await seedSession(coordinator: coordinator, sessionID: "legacy2", title: "Payment Ops")
+        await controller.loadHistory()
+
+        let event = CalendarEvent(
+            id: "evt_renamed",
+            title: "Payment Ops / Merchant standup",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        controller.showMeetingHistory(for: event)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertTrue(controller.state.meetingHistoryEntries.isEmpty)
+        XCTAssertEqual(controller.state.relatedMeetingSuggestions.map(\.title), ["Payment Ops"])
+        XCTAssertEqual(controller.state.relatedMeetingSuggestions.first?.sessionCount, 2)
+    }
+
+    func testShowMeetingHistorySuggestsSingleTokenRenameWhenTokenIsSpecific() async {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+
+        await seedSession(coordinator: coordinator, sessionID: "legacy1", title: "Payment Ops")
+        await seedSession(coordinator: coordinator, sessionID: "legacy2", title: "Payment Ops")
+        await controller.loadHistory()
+
+        let event = CalendarEvent(
+            id: "evt_single_token",
+            title: "Payment",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        controller.showMeetingHistory(for: event)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertTrue(controller.state.meetingHistoryEntries.isEmpty)
+        XCTAssertEqual(controller.state.relatedMeetingSuggestions.map(\.title), ["Payment Ops"])
+    }
+
+    func testShowMeetingHistoryPrefersRecurringFamiliesForSingleTokenSuggestions() async {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+
+        await seedSession(coordinator: coordinator, sessionID: "recurring1", title: "Payment Ops")
+        await seedSession(coordinator: coordinator, sessionID: "recurring2", title: "Payment Ops")
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "oneoff1",
+            title: "Payment methods investigation for Adyen store setup"
+        )
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "oneoff2",
+            title: "Payment Ops - payment redirection fraud"
+        )
+        await controller.loadHistory()
+
+        let event = CalendarEvent(
+            id: "evt_single_token_recurring_only",
+            title: "Payment",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        controller.showMeetingHistory(for: event)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertEqual(controller.state.relatedMeetingSuggestions.map(\.title), ["Payment Ops"])
+    }
+
+    func testShowMeetingHistoryKeepsOnlyDominantRecurringFamilyForSingleTokenSuggestions() async {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+
+        for index in 0..<6 {
+            await seedSession(coordinator: coordinator, sessionID: "ops_\(index)", title: "Payment Ops")
+        }
+        for index in 0..<2 {
+            await seedSession(coordinator: coordinator, sessionID: "links_\(index)", title: "Payment Links")
+        }
+        await controller.loadHistory()
+
+        let event = CalendarEvent(
+            id: "evt_single_token_dominant",
+            title: "Payment",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        controller.showMeetingHistory(for: event)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertEqual(controller.state.relatedMeetingSuggestions.map(\.title), ["Payment Ops"])
+    }
+
+    func testLinkMeetingHistorySuggestionReloadsHistoryUsingAlias() async {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+
+        await seedSession(coordinator: coordinator, sessionID: "legacy", title: "Payment Ops")
+        await seedSession(coordinator: coordinator, sessionID: "other-variant", title: "Payment Ops Merchant")
+        await controller.loadHistory()
+
+        let event = CalendarEvent(
+            id: "evt_renamed",
+            title: "Payment Ops / Merchant standup",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        controller.showMeetingHistory(for: event)
+        try? await Task.sleep(for: .milliseconds(250))
+        XCTAssertEqual(Set(controller.state.relatedMeetingSuggestions.map(\.title)), ["Payment Ops", "Payment Ops Merchant"])
+
+        guard let suggestion = controller.state.relatedMeetingSuggestions.first(where: { $0.title == "Payment Ops" }) else {
+            XCTFail("Expected related meeting suggestion")
+            return
+        }
+
+        controller.linkMeetingHistorySuggestion(suggestion)
+        XCTAssertEqual(controller.state.linkingMeetingSuggestionKey, suggestion.key)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertEqual(controller.state.meetingHistoryEntries.map(\.session.id), ["legacy"])
+        XCTAssertNil(controller.state.linkingMeetingSuggestionKey)
+        XCTAssertEqual(controller.state.relatedMeetingSuggestions.map(\.title), ["Payment Ops Merchant"])
     }
 
     func testMeetingHistoryPreviewStripsBulletsAndMarkdownMarkers() {

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -371,6 +371,49 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.meetingPrepNotesByKey, [:])
     }
 
+    func testMeetingHistoryAliasesNormalizeAndCanonicalizePrepNotes() {
+        let store = makeStore()
+        store.meetingHistoryAliasesByKey = [
+            " Payment Ops ": "payment ops merchant standup",
+            "payment ops merchant standup": "payment ops merchant standup",
+            "": "ignored",
+        ]
+
+        XCTAssertEqual(
+            store.meetingHistoryAliasesByKey,
+            ["payment ops": "payment ops merchant standup"]
+        )
+
+        let renamedEvent = CalendarEvent(
+            id: "evt-renamed",
+            title: "Payment Ops / Merchant standup",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+        let legacyEvent = CalendarEvent(
+            id: "evt-legacy",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        store.setMeetingPrepNotes("Carry this forward", for: renamedEvent)
+
+        XCTAssertEqual(store.meetingPrepNotes(for: legacyEvent), "Carry this forward")
+        XCTAssertEqual(
+            store.canonicalMeetingHistoryKey(for: legacyEvent),
+            MeetingHistoryResolver.historyKey(for: renamedEvent)
+        )
+    }
+
     func testKbFolderURLWhenEmpty() {
         let store = makeStore()
         XCTAssertNil(store.kbFolderURL)

--- a/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
@@ -115,6 +115,37 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
         XCTAssertTrue(MeetingHistoryResolver.matchingSessions(for: event, sessionHistory: sessions).isEmpty)
     }
 
+    func testMeetingHistoryResolverMatchesAliasedTitles() {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessions = [
+            SessionIndex(
+                id: "legacy",
+                startedAt: startedAt.addingTimeInterval(-500),
+                endedAt: nil,
+                templateSnapshot: nil,
+                title: "Payment Ops",
+                utteranceCount: 10,
+                hasNotes: true,
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                tags: nil,
+                source: nil
+            ),
+        ]
+
+        let matched = MeetingHistoryResolver.matchingSessions(
+            forHistoryKey: MeetingHistoryResolver.historyKey(for: "Payment Ops / Merchant standup"),
+            sessionHistory: sessions,
+            aliases: [
+                MeetingHistoryResolver.historyKey(for: "Payment Ops"):
+                    MeetingHistoryResolver.historyKey(for: "Payment Ops / Merchant standup")
+            ]
+        )
+
+        XCTAssertEqual(matched.map(\.id), ["legacy"])
+    }
+
     func testSelectionPrefersCalendarCoverageBeforeFillingRemainingSlots() {
         let base = Date(timeIntervalSince1970: 1_700_000_000)
         let events = [


### PR DESCRIPTION
Fixes #390

## Summary
- add settings-backed meeting history aliases so renamed recurring meetings can resolve into the same family
- suggest likely older meeting families when an upcoming meeting has no exact history and let the user link them explicitly
- canonicalize meeting prep notes through the alias map so prep state follows the linked family

## Validation
- `swift test --filter SettingsStoreTests --filter UpcomingCalendarGroupingTests --filter NotesControllerTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`

## Screenshot
![Meeting history alias linking](https://raw.githubusercontent.com/kkarimi/OpenOats/pr-assets-meeting-history-alias-linking/docs/pr-assets/meeting-history-alias-linking.png)