### PR TITLE
feat: show template picker in empty notes state

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -682,6 +682,10 @@ final class NotesController {
         }
     }
 
+    func selectTemplate(_ template: MeetingTemplate) {
+        state.selectedTemplate = template
+    }
+
     // MARK: - Accessors
 
     /// Templates available for generation.

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -1637,6 +1637,25 @@ struct NotesView: View {
             }
 
             VStack(spacing: 8) {
+                if let selected = state.selectedTemplate {
+                    Menu {
+                        ForEach(controller.availableTemplates) { template in
+                            Button {
+                                controller.selectTemplate(template)
+                            } label: {
+                                Label(template.name, systemImage: template.icon)
+                            }
+                            .disabled(selected.id == template.id)
+                        }
+                    } label: {
+                        Label(selected.name, systemImage: selected.icon)
+                            .font(.system(size: 12))
+                    }
+                    .menuStyle(.button)
+                    .buttonStyle(.bordered)
+                    .fixedSize()
+                }
+
                 Button {
                     controller.generateNotes(sessionID: sessionID, settings: settings)
                 } label: {


### PR DESCRIPTION
Fixes #395

## Summary
- Show the active note template in the empty Notes state before first generation
- Allow changing it via a dropdown picker, matching the existing toolbar template menu style
- Users are no longer silently locked into the default template

## Changes
- `NotesController.swift`: Add `selectTemplate(_:)` method for pre-generation template selection
- `NotesView.swift`: Add template picker Menu to `notesEmptyState` above the "Generate Notes" button

## Validation
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh` — builds cleanly
- `swift test --filter NotesControllerTests` — all 31 tests pass