### PR TITLE
Add meeting-family note template defaults

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -114,6 +114,7 @@ final class NotesController {
     /// The session ID that triggered the currently in-progress generation, if any.
     /// Used to prevent bleeding status/content onto a different session when the user switches mid-generation.
     @ObservationIgnored private var generatingSessionID: String?
+    @ObservationIgnored private var cancelledGenerationSessionIDs: Set<String> = []
 
     /// Audio player for session recordings.
     @ObservationIgnored private var audioPlayer: AVPlayer?
@@ -227,14 +228,13 @@ final class NotesController {
             state.audioFileURL = data.audioURL
 
             let session = state.sessionHistory.first { $0.id == sessionID }
-            if let snapID = session?.templateSnapshot?.id {
-                state.selectedTemplate = coordinator.templateStore.template(for: snapID)
-            } else {
-                state.selectedTemplate = coordinator.templateStore.template(for: TemplateStore.genericID)
-            }
+            let familySelection = session.map { Self.meetingFamilySelection(for: $0, calendarEvent: data.calendarEvent) }
+            state.selectedTemplate = selectedTemplate(
+                forSessionTemplateID: session?.templateSnapshot?.id,
+                meetingFamilyKey: familySelection?.key
+            )
 
-            if let session {
-                let familySelection = Self.meetingFamilySelection(for: session, calendarEvent: data.calendarEvent)
+            if let familySelection {
                 state.selectedMeetingFamily = familySelection
                 presentMeetingHistory(for: familySelection)
             }
@@ -260,6 +260,10 @@ final class NotesController {
         state.selectedSessionDirectory = nil
         state.audioFileURL = nil
         state.showingOriginal = false
+        state.selectedTemplate = selectedTemplate(
+            forSessionTemplateID: nil,
+            meetingFamilyKey: selection.key
+        )
         coordinator.batchTextCleaner.cancel()
         syncCleanupStatus()
         presentMeetingHistory(for: selection)
@@ -352,6 +356,7 @@ final class NotesController {
         let capturedCalendarEvent = state.loadedCalendarEvent
 
         generatingSessionID = sessionID
+        cancelledGenerationSessionIDs.remove(sessionID)
         state.notesGenerationStatus = .generating
         state.streamingMarkdown = ""
 
@@ -384,6 +389,14 @@ final class NotesController {
 
     private func finishGeneration(sessionID: String, template: MeetingTemplate) async {
         defer { generatingSessionID = nil }
+
+        if cancelledGenerationSessionIDs.remove(sessionID) != nil {
+            if state.selectedSessionID == sessionID {
+                state.notesGenerationStatus = .idle
+                state.streamingMarkdown = ""
+            }
+            return
+        }
 
         // Always save notes to disk regardless of which session the user is now on
         if !coordinator.notesEngine.generatedMarkdown.isEmpty {
@@ -422,6 +435,9 @@ final class NotesController {
     }
 
     func cancelGeneration() {
+        if let sessionID = generatingSessionID {
+            cancelledGenerationSessionIDs.insert(sessionID)
+        }
         coordinator.notesEngine.cancel()
         generatingSessionID = nil
         state.notesGenerationStatus = .idle
@@ -686,6 +702,18 @@ final class NotesController {
         state.selectedTemplate = template
     }
 
+    func setSelectedTemplateSavedForMeetingFamily(_ enabled: Bool) {
+        guard let settings,
+              let selection = state.selectedMeetingFamily else { return }
+
+        if enabled {
+            guard let template = state.selectedTemplate else { return }
+            settings.setMeetingFamilyTemplatePreference(template.id, forHistoryKey: selection.key)
+        } else {
+            settings.setMeetingFamilyTemplatePreference(nil, forHistoryKey: selection.key)
+        }
+    }
+
     // MARK: - Accessors
 
     /// Templates available for generation.
@@ -716,6 +744,31 @@ final class NotesController {
     }
 
     // MARK: - Private
+
+    private func selectedTemplate(
+        forSessionTemplateID sessionTemplateID: UUID?,
+        meetingFamilyKey: String?
+    ) -> MeetingTemplate? {
+        if let sessionTemplateID,
+           sessionTemplateID != TemplateStore.genericID,
+           let template = coordinator.templateStore.template(for: sessionTemplateID) {
+            return template
+        }
+
+        if let meetingFamilyKey,
+           let preferredID = settings?.meetingFamilyPreferences(forHistoryKey: meetingFamilyKey)?.templateID,
+           let template = coordinator.templateStore.template(for: preferredID) {
+            return template
+        }
+
+        if let sessionTemplateID,
+           let template = coordinator.templateStore.template(for: sessionTemplateID) {
+            return template
+        }
+
+        return coordinator.templateStore.template(for: TemplateStore.genericID)
+            ?? TemplateStore.builtInTemplates.first
+    }
 
     func loadHistory() async {
         state.sessionHistory = await coordinator.sessionRepository.listSessions()

--- a/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
@@ -8,6 +8,7 @@ final class NotesEngine {
     enum Mode {
         case live
         case scripted(markdown: String)
+        case scriptedDelayed(markdown: String, delay: Duration)
     }
 
     @ObservationIgnored nonisolated(unsafe) private var _isGenerating = false
@@ -51,11 +52,28 @@ final class NotesEngine {
         generatedMarkdown = ""
         error = nil
 
-        if case .scripted(let markdown) = mode {
+        switch mode {
+        case .scripted(let markdown):
             generatedMarkdown = markdown
             isGenerating = false
             onFinished()
             return
+        case .scriptedDelayed(let markdown, let delay):
+            let task = Task { [weak self] in
+                do {
+                    try await Task.sleep(for: delay)
+                    guard !Task.isCancelled else { return }
+                    self?.generatedMarkdown = markdown
+                } catch {
+                    // Ignore cancellation for scripted test mode.
+                }
+                self?.isGenerating = false
+                onFinished()
+            }
+            currentTask = task
+            return
+        case .live:
+            break
         }
 
         let apiKey: String?

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -848,6 +848,20 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _meetingFamilyPreferencesByKey: [String: MeetingFamilyPreferences]
+    var meetingFamilyPreferencesByKey: [String: MeetingFamilyPreferences] {
+        get { access(keyPath: \.meetingFamilyPreferencesByKey); return _meetingFamilyPreferencesByKey }
+        set {
+            withMutation(keyPath: \.meetingFamilyPreferencesByKey) {
+                _meetingFamilyPreferencesByKey = Self.normalizeMeetingFamilyPreferences(newValue)
+                defaults.set(
+                    Self.encodeMeetingFamilyPreferences(_meetingFamilyPreferencesByKey),
+                    forKey: "meetingFamilyPreferencesByKey"
+                )
+            }
+        }
+    }
+
     func meetingPrepNotes(for event: CalendarEvent) -> String {
         let key = canonicalMeetingHistoryKey(for: event)
         return meetingPrepNotesByKey[key] ?? ""
@@ -873,6 +887,38 @@ final class SettingsStore {
             for: historyKey,
             aliases: meetingHistoryAliasesByKey
         )
+    }
+
+    func meetingFamilyPreferences(for event: CalendarEvent) -> MeetingFamilyPreferences? {
+        meetingFamilyPreferences(forHistoryKey: MeetingHistoryResolver.historyKey(for: event))
+    }
+
+    func meetingFamilyPreferences(forHistoryKey historyKey: String) -> MeetingFamilyPreferences? {
+        let key = canonicalMeetingHistoryKey(forHistoryKey: historyKey)
+        return meetingFamilyPreferencesByKey[key]
+    }
+
+    func setMeetingFamilyTemplatePreference(_ templateID: UUID?, for event: CalendarEvent) {
+        setMeetingFamilyTemplatePreference(
+            templateID,
+            forHistoryKey: MeetingHistoryResolver.historyKey(for: event)
+        )
+    }
+
+    func setMeetingFamilyTemplatePreference(_ templateID: UUID?, forHistoryKey historyKey: String) {
+        let key = canonicalMeetingHistoryKey(forHistoryKey: historyKey)
+        guard !key.isEmpty else { return }
+
+        var preferences = meetingFamilyPreferencesByKey
+        var value = preferences[key] ?? MeetingFamilyPreferences()
+        value.templateID = templateID
+
+        if value.isEmpty {
+            preferences.removeValue(forKey: key)
+        } else {
+            preferences[key] = value
+        }
+        meetingFamilyPreferencesByKey = preferences
     }
 
     func linkMeetingHistoryAlias(from aliasHistoryKey: String, to canonicalHistoryKey: String) {
@@ -1106,6 +1152,9 @@ final class SettingsStore {
         self._meetingHistoryAliasesByKey = Self.decodeMeetingHistoryAliases(
             defaults.data(forKey: "meetingHistoryAliasesByKey")
         ) ?? [:]
+        self._meetingFamilyPreferencesByKey = Self.decodeMeetingFamilyPreferences(
+            defaults.data(forKey: "meetingFamilyPreferencesByKey")
+        ) ?? [:]
         self._kbFolderPath = defaults.string(forKey: "kbFolderPath") ?? ""
         self._hasSeenLaunchAtLoginSuggestion = defaults.bool(forKey: "hasSeenLaunchAtLoginSuggestion")
 
@@ -1253,6 +1302,16 @@ final class SettingsStore {
         return try? JSONDecoder().decode([String: String].self, from: data)
     }
 
+    private static func encodeMeetingFamilyPreferences(_ preferences: [String: MeetingFamilyPreferences]) -> Data? {
+        let encoder = JSONEncoder()
+        return try? encoder.encode(preferences)
+    }
+
+    private static func decodeMeetingFamilyPreferences(_ data: Data?) -> [String: MeetingFamilyPreferences]? {
+        guard let data else { return nil }
+        return try? JSONDecoder().decode([String: MeetingFamilyPreferences].self, from: data)
+    }
+
     private static func normalizeMeetingPrepNotes(_ notes: [String: String]) -> [String: String] {
         var result: [String: String] = [:]
         for (rawKey, rawValue) in notes {
@@ -1273,6 +1332,19 @@ final class SettingsStore {
                 continue
             }
             result[normalizedKey] = normalizedValue
+        }
+        return result
+    }
+
+    private static func normalizeMeetingFamilyPreferences(
+        _ preferences: [String: MeetingFamilyPreferences]
+    ) -> [String: MeetingFamilyPreferences] {
+        var result: [String: MeetingFamilyPreferences] = [:]
+        for (rawKey, rawValue) in preferences {
+            let normalizedKey = rawKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !normalizedKey.isEmpty else { continue }
+            guard !rawValue.isEmpty else { continue }
+            result[normalizedKey] = rawValue
         }
         return result
     }

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -50,6 +50,14 @@ struct NotesFolderDefinition: Identifiable, Codable, Equatable, Sendable {
     }
 }
 
+struct MeetingFamilyPreferences: Codable, Equatable, Sendable {
+    var templateID: UUID?
+
+    var isEmpty: Bool {
+        templateID == nil
+    }
+}
+
 /// Controls how eagerly the suggestion engine surfaces talking points.
 enum SuggestionVerbosity: String, CaseIterable, Identifiable {
     /// Mostly silent — surfaces suggestions only when highly relevant (current default behavior).

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -833,7 +833,11 @@ struct NotesView: View {
                 } else {
                     ScrollView {
                         VStack(alignment: .leading, spacing: 18) {
-                            meetingFamilyOverviewSection(selection: selection, historyCount: state.meetingHistoryEntries.count)
+                            meetingFamilyOverviewSection(
+                                state: state,
+                                selection: selection,
+                                historyCount: state.meetingHistoryEntries.count
+                            )
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(20)
@@ -1004,7 +1008,11 @@ struct NotesView: View {
     }
 
     @ViewBuilder
-    private func meetingFamilyOverviewSection(selection: MeetingFamilySelection, historyCount: Int) -> some View {
+    private func meetingFamilyOverviewSection(
+        state: NotesState,
+        selection: MeetingFamilySelection,
+        historyCount: Int
+    ) -> some View {
         if let event = selection.upcomingEvent {
             let prepNotes = Binding(
                 get: { settings.meetingPrepNotes(for: event) },
@@ -1043,7 +1051,7 @@ struct NotesView: View {
                         }
 
                         Button {
-                            startRecording(for: event)
+                            startRecording(for: event, selectedTemplate: state.selectedTemplate)
                         } label: {
                             Label("Start recording", systemImage: "mic.fill")
                                 .font(.system(size: 12, weight: .semibold))
@@ -1285,7 +1293,8 @@ struct NotesView: View {
         detailViewMode = session.hasNotes ? .notes : .transcript
     }
 
-    private func startRecording(for event: CalendarEvent) {
+    private func startRecording(for event: CalendarEvent, selectedTemplate: MeetingTemplate?) {
+        coordinator.selectedTemplate = selectedTemplate
         let prepNotes = settings.meetingPrepNotes(for: event)
         coordinator.queueExternalCommand(
             .startSession(
@@ -1672,9 +1681,37 @@ struct NotesView: View {
         case .idle, .completed, .error:
             if let notes = state.loadedNotes {
                 notesContentView(notes, sessionDirectory: state.selectedSessionDirectory)
+            } else if state.loadedTranscript.isEmpty {
+                notesNoTranscriptState(state: state)
             } else {
                 notesEmptyState(controller: controller, state: state, sessionID: sessionID)
             }
+        }
+    }
+
+    @ViewBuilder
+    private func notesNoTranscriptState(state: NotesState) -> some View {
+        let isEmbeddedMeetingFamilyDetail = state.selectedMeetingFamily != nil
+
+        if isEmbeddedMeetingFamilyDetail {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("No transcript")
+                        .font(.system(size: 18, weight: .semibold))
+                    Text("There are no recorded utterances to turn into notes for this session.")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 24)
+            }
+        } else {
+            ContentUnavailableView(
+                "No Transcript",
+                systemImage: "waveform",
+                description: Text("There are no recorded utterances to turn into notes for this session.")
+            )
         }
     }
 
@@ -1869,6 +1906,23 @@ struct NotesView: View {
                             RoundedRectangle(cornerRadius: 12)
                                 .strokeBorder(.quaternary, lineWidth: 1)
                         )
+
+                        if let selection = state.selectedMeetingFamily {
+                            Toggle(isOn: Binding(
+                                get: {
+                                    guard let selectedTemplate = state.selectedTemplate else { return false }
+                                    return settings.meetingFamilyPreferences(forHistoryKey: selection.key)?.templateID == selectedTemplate.id
+                                },
+                                set: { controller.setSelectedTemplateSavedForMeetingFamily($0) }
+                            )) {
+                                Text("Use as default for meetings like this")
+                                    .font(.system(size: 11, weight: .medium))
+                                    .foregroundStyle(.secondary)
+                            }
+                            .toggleStyle(.checkbox)
+                            .font(.system(size: 11))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                     }
 
                     Button {

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -94,6 +94,21 @@ final class NotesControllerTests: XCTestCase {
         return (controller, coordinator)
     }
 
+    private func makeController(
+        root: URL,
+        settings: AppSettings? = nil,
+        notesEngine: NotesEngine
+    ) -> (NotesController, AppCoordinator) {
+        let coordinator = AppCoordinator(
+            sessionRepository: SessionRepository(rootDirectory: root),
+            templateStore: TemplateStore(rootDirectory: root),
+            notesEngine: notesEngine,
+            transcriptStore: TranscriptStore()
+        )
+        let controller = NotesController(coordinator: coordinator, settings: settings)
+        return (controller, coordinator)
+    }
+
     // MARK: - Tests
 
     func testSelectSessionLoadsTranscriptAndNotes() async {
@@ -628,6 +643,37 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertTrue(controller.state.loadedTranscript.isEmpty)
     }
 
+    func testSelectSessionUsesMeetingFamilyTemplatePreferenceInsteadOfGenericTemplate() async {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+
+        let event = CalendarEvent(
+            id: "evt-weekly",
+            title: "Weekly Sync",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+        settings.setMeetingFamilyTemplatePreference(TemplateStore.standUpID, for: event)
+
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "weekly",
+            title: "Weekly Sync",
+            calendarEvent: event
+        )
+        await controller.loadHistory()
+
+        controller.selectSession("weekly")
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertEqual(controller.state.selectedTemplate?.id, TemplateStore.standUpID)
+    }
+
     func testNormalizedNotesMarkdownPrependsFallbackHeadingWhenMissing() {
         let markdown = NotesController.normalizedNotesMarkdown(
             "## Summary\nHello",
@@ -729,6 +775,36 @@ final class NotesControllerTests: XCTestCase {
 
         XCTAssertFalse(controller.state.freshlyGeneratedSessionIDs.contains(sessionID), "Should clear the fresh badge when selected")
         XCTAssertNotNil(controller.state.loadedNotes, "Should load the generated notes")
+    }
+
+    func testCancelGenerationDoesNotPersistPartialNotes() async {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let notesEngine = NotesEngine(
+            mode: .scriptedDelayed(
+                markdown: "# Partial Notes\n\n## Summary\nThis should not persist.",
+                delay: .milliseconds(300)
+            )
+        )
+        let (controller, coordinator) = makeController(root: root, settings: settings, notesEngine: notesEngine)
+        let sessionID = "session_test_cancel_generation"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID)
+        await controller.loadHistory()
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        controller.generateNotes(sessionID: sessionID, settings: settings)
+        try? await Task.sleep(for: .milliseconds(50))
+        controller.cancelGeneration()
+        try? await Task.sleep(for: .milliseconds(400))
+
+        XCTAssertEqual(controller.state.notesGenerationStatus, .idle)
+        XCTAssertTrue(controller.state.streamingMarkdown.isEmpty)
+        XCTAssertNil(controller.state.loadedNotes)
+
+        let data = await coordinator.sessionRepository.loadSessionData(sessionID: sessionID)
+        XCTAssertNil(data.notes)
     }
 
     func testAllTagsHidesGranolaImportMetadataTags() async {

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -414,6 +414,49 @@ final class SettingsStoreTests: XCTestCase {
         )
     }
 
+    func testMeetingFamilyTemplatePreferenceCanonicalizesThroughAliases() {
+        let store = makeStore()
+        store.meetingHistoryAliasesByKey = [
+            "payment ops": "payment ops merchant standup",
+        ]
+
+        let renamedEvent = CalendarEvent(
+            id: "evt-renamed",
+            title: "Payment Ops / Merchant standup",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+        let legacyEvent = CalendarEvent(
+            id: "evt-legacy",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        store.setMeetingFamilyTemplatePreference(TemplateStore.standUpID, for: renamedEvent)
+
+        XCTAssertEqual(
+            store.meetingFamilyPreferences(for: legacyEvent)?.templateID,
+            TemplateStore.standUpID
+        )
+        XCTAssertEqual(
+            store.meetingFamilyPreferencesByKey[MeetingHistoryResolver.historyKey(for: renamedEvent)]?.templateID,
+            TemplateStore.standUpID
+        )
+
+        store.setMeetingFamilyTemplatePreference(nil, for: legacyEvent)
+        XCTAssertNil(store.meetingFamilyPreferences(for: renamedEvent))
+        XCTAssertTrue(store.meetingFamilyPreferencesByKey.isEmpty)
+    }
+
     func testKbFolderURLWhenEmpty() {
         let store = makeStore()
         XCTAssertNil(store.kbFolderURL)


### PR DESCRIPTION
Fixes #407

## Summary
- save note template defaults against the canonical meeting-family key
- use meeting-family defaults for first note generation and when starting recording from the meeting-family view
- ignore late note-generation completions after cancel so partial notes are not persisted
- show a no-transcript state instead of note-generation controls when a session has no utterances

## Validation
- swift test --filter NotesControllerTests
- swift test --filter SettingsStoreTests
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh