### PR TITLE
Collapse ghost duplicate meeting sessions

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -490,14 +490,23 @@ final class LiveSessionController {
             }
         }
 
-        // 7. Update UI state + refresh history
-        coordinator.lastEndedSession = index
+        // 7. Collapse obviously empty duplicate sessions back into the real meeting session.
+        var effectiveIndex = index
+        var shouldRunBatchRetranscription = settings?.enableBatchRetranscription == true
+        if utteranceCount == 0,
+           let mergedSessionID = await coordinator.sessionRepository.reconcileGhostSession(sessionID: sessionID) {
+            effectiveIndex = await coordinator.sessionRepository.loadSession(id: mergedSessionID).index
+            shouldRunBatchRetranscription = false
+        }
+
+        // 8. Update UI state + refresh history
+        coordinator.lastEndedSession = effectiveIndex
         coordinator.sessionTemplateSnapshot = nil
         _currentSessionID = nil
         await coordinator.loadHistory()
 
-        // 8. Kick off batch transcription if enabled
-        if let settings, settings.enableBatchRetranscription, let batchAudioTranscriber = coordinator.batchAudioTranscriber {
+        // 9. Kick off batch transcription if enabled
+        if let settings, shouldRunBatchRetranscription, let batchAudioTranscriber = coordinator.batchAudioTranscriber {
             let batchSessionID = sessionID
             let batchModel = settings.batchTranscriptionModel
             let batchLocale = settings.locale

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -803,6 +803,78 @@ actor SessionRepository {
         writeSessionMetadata(meta, sessionID: sessionID)
     }
 
+    func updateSessionCalendarEvent(sessionID: String, calendarEvent: CalendarEvent?) {
+        if var meta = loadSessionMetadataFile(sessionID: sessionID) {
+            meta.calendarEvent = calendarEvent
+            writeSessionMetadata(meta, sessionID: sessionID)
+            scheduleMirror(sessionID: sessionID)
+            return
+        }
+
+        let index = LegacySessionReader.loadIndex(sessionID: sessionID, sessionsDirectory: sessionsDirectory)
+        let meta = SessionMetadata(
+            id: index.id,
+            startedAt: index.startedAt,
+            endedAt: index.endedAt,
+            templateSnapshot: index.templateSnapshot,
+            title: index.title,
+            utteranceCount: index.utteranceCount,
+            hasNotes: index.hasNotes,
+            language: index.language,
+            meetingApp: index.meetingApp,
+            engine: index.engine,
+            tags: index.tags,
+            folderPath: index.folderPath,
+            source: index.source,
+            calendarEvent: calendarEvent
+        )
+        let dir = sessionDirectory(for: sessionID)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        writeSessionMetadata(meta, sessionID: sessionID)
+        scheduleMirror(sessionID: sessionID)
+    }
+
+    func reconcileGhostSession(
+        sessionID: String,
+        maximumGap: TimeInterval = 5 * 60
+    ) -> String? {
+        guard let ghostMeta = loadSessionMetadataFile(sessionID: sessionID),
+              ghostMeta.utteranceCount == 0,
+              ghostMeta.hasNotes == false,
+              let calendarEvent = ghostMeta.calendarEvent,
+              !sessionHasMeaningfulArtifacts(sessionID: sessionID) else { return nil }
+
+        let historyKey = MeetingHistoryResolver.historyKey(for: ghostMeta.title ?? calendarEvent.title)
+        guard !historyKey.isEmpty else { return nil }
+
+        let candidates = listSessions()
+            .filter { candidate in
+                guard candidate.id != sessionID else { return false }
+                guard candidate.utteranceCount > 0 else { return false }
+                guard MeetingHistoryResolver.historyKey(for: candidate.title ?? "") == historyKey else {
+                    return false
+                }
+                let referenceDate = candidate.endedAt ?? candidate.startedAt
+                let gap = ghostMeta.startedAt.timeIntervalSince(referenceDate)
+                return gap >= 0 && gap <= maximumGap
+            }
+            .sorted {
+                let lhsGap = ghostMeta.startedAt.timeIntervalSince($0.endedAt ?? $0.startedAt)
+                let rhsGap = ghostMeta.startedAt.timeIntervalSince($1.endedAt ?? $1.startedAt)
+                return lhsGap < rhsGap
+            }
+
+        guard let target = candidates.first else { return nil }
+
+        if let targetMeta = loadSessionMetadataFile(sessionID: target.id),
+           targetMeta.calendarEvent == nil {
+            updateSessionCalendarEvent(sessionID: target.id, calendarEvent: calendarEvent)
+        }
+
+        deleteSession(sessionID: sessionID)
+        return target.id
+    }
+
     /// Update source and tags for an imported session.
     func updateSessionSource(sessionID: String, source: String, tags: [String]) {
         guard var meta = loadSessionMetadataFile(sessionID: sessionID) else { return }
@@ -873,6 +945,20 @@ actor SessionRepository {
 
     private static func normalizeSessionFolderPath(_ folderPath: String?) -> String? {
         NotesFolderDefinition.normalizePath(folderPath ?? "")
+    }
+
+    private func sessionHasMeaningfulArtifacts(sessionID: String) -> Bool {
+        if !loadTranscript(sessionID: sessionID).isEmpty { return true }
+        if !loadLiveTranscript(sessionID: sessionID).isEmpty { return true }
+
+        let audioDir = sessionDirectory(for: sessionID).appendingPathComponent("audio", isDirectory: true)
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: audioDir,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        return !contents.isEmpty
     }
 
     private static func isInternalSessionTag(_ tag: String) -> Bool {

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -271,6 +271,61 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertNil(coordinator.pendingExternalCommand)
     }
 
+    func testFinalizeCurrentSessionCollapsesEmptyGhostSessionIntoRecentRealSession() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings,
+            scripted: []
+        )
+
+        let event = CalendarEvent(
+            id: "evt-ghost-merge",
+            title: "Payment Ops / Merchant stand up",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: true,
+            meetingURL: URL(string: "https://meet.example.com/payment-ops")
+        )
+
+        let realStartedAt = Date().addingTimeInterval(-180)
+        await coordinator.sessionRepository.seedSession(
+            id: "session_real",
+            records: [SessionRecord(speaker: .you, text: "Real meeting", timestamp: realStartedAt)],
+            startedAt: realStartedAt,
+            endedAt: realStartedAt.addingTimeInterval(120),
+            title: "Payment Ops / Merchant stand up"
+        )
+
+        controller.startSession(settings: settings, calendarEventOverride: event)
+
+        var sessionID: String?
+        for _ in 0..<20 {
+            sessionID = await coordinator.sessionRepository.getCurrentSessionID()
+            if sessionID != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        guard let ghostSessionID = sessionID else {
+            return XCTFail("Expected session ID after starting session")
+        }
+
+        controller.stopSession(settings: settings)
+        await controller.finalizeCurrentSession(settings: settings)
+
+        let sessions = await coordinator.sessionRepository.listSessions()
+        XCTAssertFalse(sessions.contains(where: { $0.id == ghostSessionID }))
+        XCTAssertTrue(sessions.contains(where: { $0.id == "session_real" }))
+        XCTAssertEqual(coordinator.lastEndedSession?.id, "session_real")
+
+        let mergedDetail = await coordinator.sessionRepository.loadSession(id: "session_real")
+        XCTAssertEqual(mergedDetail.calendarEvent?.id, event.id)
+    }
+
     func testRunningStateChangeCallbackFires() async {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -532,6 +532,95 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    func testReconcileGhostSessionMergesCalendarEventIntoRecentRealSession() async {
+        let calendarEvent = makeCalendarEvent()
+        let realStartedAt = Date().addingTimeInterval(-180)
+        let realEndedAt = realStartedAt.addingTimeInterval(60)
+
+        await repo.seedSession(
+            id: "session_real",
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: realStartedAt)],
+            startedAt: realStartedAt,
+            endedAt: realEndedAt,
+            title: "Customer Sync"
+        )
+
+        let ghostHandle = await repo.startSession()
+        await repo.finalizeSession(
+            sessionID: ghostHandle.sessionID,
+            metadata: SessionFinalizeMetadata(
+                endedAt: realEndedAt.addingTimeInterval(120),
+                utteranceCount: 0,
+                title: "Customer Sync",
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                templateSnapshot: nil,
+                utterances: [],
+                calendarEvent: calendarEvent
+            )
+        )
+
+        let mergedSessionID = await repo.reconcileGhostSession(sessionID: ghostHandle.sessionID)
+
+        XCTAssertEqual(mergedSessionID, "session_real")
+        let sessions = await repo.listSessions()
+        XCTAssertEqual(sessions.filter { $0.title == "Customer Sync" }.map(\.id), ["session_real"])
+
+        let mergedDetail = await repo.loadSession(id: "session_real")
+        XCTAssertEqual(mergedDetail.calendarEvent?.id, calendarEvent.id)
+
+        await repo.deleteSession(sessionID: "session_real")
+    }
+
+    func testReconcileGhostSessionKeepsEmptySessionWhenAudioArtifactsExist() async throws {
+        let calendarEvent = makeCalendarEvent()
+        let realStartedAt = Date().addingTimeInterval(-180)
+        let realEndedAt = realStartedAt.addingTimeInterval(60)
+
+        await repo.seedSession(
+            id: "session_real",
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: realStartedAt)],
+            startedAt: realStartedAt,
+            endedAt: realEndedAt,
+            title: "Customer Sync"
+        )
+
+        let ghostHandle = await repo.startSession()
+        await repo.finalizeSession(
+            sessionID: ghostHandle.sessionID,
+            metadata: SessionFinalizeMetadata(
+                endedAt: realEndedAt.addingTimeInterval(120),
+                utteranceCount: 0,
+                title: "Customer Sync",
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                templateSnapshot: nil,
+                utterances: [],
+                calendarEvent: calendarEvent
+            )
+        )
+
+        let audioDir = rootDir
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(ghostHandle.sessionID, isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+        try Data("mic".utf8).write(to: audioDir.appendingPathComponent("mic.caf"), options: .atomic)
+
+        let mergedSessionID = await repo.reconcileGhostSession(sessionID: ghostHandle.sessionID)
+
+        XCTAssertNil(mergedSessionID)
+        let sessions = await repo.listSessions()
+        XCTAssertTrue(sessions.contains(where: { $0.id == ghostHandle.sessionID }))
+        let realDetail = await repo.loadSession(id: "session_real")
+        XCTAssertNil(realDetail.calendarEvent)
+
+        await repo.deleteSession(sessionID: ghostHandle.sessionID)
+        await repo.deleteSession(sessionID: "session_real")
+    }
+
     func testBatchMetaPersistsEffectiveSystemSampleRate() async {
         let sessionID = "session_batch_meta"
         await repo.seedSession(


### PR DESCRIPTION
Fixes #413

## What changed
- collapse obviously empty duplicate sessions into the recent real session in the same meeting family
- preserve the ghost session's calendar metadata by copying it onto the surviving real session when needed
- skip the collapse when the empty session still has retained transcript or audio artifacts
- avoid kicking off batch retranscription for a ghost session that gets collapsed away

## Validation
- `swift test --package-path /Users/nima/dev/cloned/OpenOats-pr-collapse-ghost-sessions/OpenOats --filter SessionRepositoryTests`
- `swift test --package-path /Users/nima/dev/cloned/OpenOats-pr-collapse-ghost-sessions/OpenOats --filter LiveSessionControllerTests`
- `cd /Users/nima/dev/cloned/OpenOats-pr-collapse-ghost-sessions && SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`