### PR TITLE
Allow manual notes for sessions without transcripts

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -14,6 +14,9 @@ struct NotesState {
     var linkingMeetingSuggestionKey: String?
     var loadedTranscript: [SessionRecord] = []
     var loadedNotes: GeneratedNotes?
+    var manualNotesDraft: String = ""
+    var savedManualNotesMarkdown: String = ""
+    var isEditingManualNotes: Bool = false
     var loadedCalendarEvent: CalendarEvent?
     var notesGenerationStatus: GenerationStatus = .idle
     var cleanupStatus: CleanupStatus = .idle
@@ -110,6 +113,7 @@ final class NotesController {
     /// Observation polling task for engine state mapping.
     @ObservationIgnored nonisolated(unsafe) private var engineObservationTask: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var meetingHistoryPreviewTask: Task<Void, Never>?
+    @ObservationIgnored private var unsavedManualNotesDraftsBySessionID: [String: String] = [:]
 
     /// The session ID that triggered the currently in-progress generation, if any.
     /// Used to prevent bleeding status/content onto a different session when the user switches mid-generation.
@@ -185,6 +189,7 @@ final class NotesController {
     // MARK: - Session Selection
 
     func selectSession(_ sessionID: String?) {
+        persistCurrentManualNotesDraftIfNeeded()
         cancelMeetingHistoryPreviewHydration()
         state.selectedSessionID = sessionID
         state.selectedMeetingFamily = nil
@@ -195,6 +200,9 @@ final class NotesController {
 
         guard let sessionID else {
             state.loadedNotes = nil
+            state.manualNotesDraft = ""
+            state.savedManualNotesMarkdown = ""
+            state.isEditingManualNotes = false
             state.loadedTranscript = []
             state.loadedCalendarEvent = nil
             state.selectedSessionDirectory = nil
@@ -203,6 +211,9 @@ final class NotesController {
         }
 
         state.loadedNotes = nil
+        state.manualNotesDraft = ""
+        state.savedManualNotesMarkdown = ""
+        state.isEditingManualNotes = false
         state.loadedTranscript = []
         state.loadedCalendarEvent = nil
         state.audioFileURL = nil
@@ -221,8 +232,12 @@ final class NotesController {
 
         Task {
             let data = await coordinator.sessionRepository.loadSessionData(sessionID: sessionID)
+            let unsavedDraft = unsavedManualNotesDraftsBySessionID[sessionID]
 
             state.loadedNotes = data.notes
+            state.manualNotesDraft = unsavedDraft ?? data.notes?.markdown ?? ""
+            state.savedManualNotesMarkdown = data.notes?.markdown ?? ""
+            state.isEditingManualNotes = data.notes != nil || unsavedDraft != nil
             state.loadedTranscript = data.transcript
             state.loadedCalendarEvent = data.calendarEvent
             state.audioFileURL = data.audioURL
@@ -245,6 +260,7 @@ final class NotesController {
     }
 
     func showMeetingFamily(for event: CalendarEvent) {
+        persistCurrentManualNotesDraftIfNeeded()
         cancelMeetingHistoryPreviewHydration()
         state.selectedSessionID = nil
         let selection = Self.meetingFamilySelection(for: event)
@@ -255,6 +271,9 @@ final class NotesController {
         stopAudio()
 
         state.loadedNotes = nil
+        state.manualNotesDraft = ""
+        state.savedManualNotesMarkdown = ""
+        state.isEditingManualNotes = false
         state.loadedTranscript = []
         state.loadedCalendarEvent = nil
         state.selectedSessionDirectory = nil
@@ -288,9 +307,13 @@ final class NotesController {
 
     func showCurrentMeetingFamilyOverview() {
         guard state.selectedMeetingFamily != nil else { return }
+        persistCurrentManualNotesDraftIfNeeded()
         state.selectedSessionID = nil
         stopAudio()
         state.loadedNotes = nil
+        state.manualNotesDraft = ""
+        state.savedManualNotesMarkdown = ""
+        state.isEditingManualNotes = false
         state.loadedTranscript = []
         state.loadedCalendarEvent = nil
         state.audioFileURL = nil
@@ -419,6 +442,9 @@ final class NotesController {
             if state.selectedSessionID == sessionID {
                 // User is still on this session — update UI directly
                 state.loadedNotes = notes
+                state.manualNotesDraft = notes.markdown
+                state.savedManualNotesMarkdown = notes.markdown
+                state.isEditingManualNotes = notes.markdown.isEmpty == false || state.loadedTranscript.isEmpty
                 state.notesGenerationStatus = .completed
             } else {
                 // User has moved away — show the blue "unread" badge in the sidebar
@@ -454,28 +480,89 @@ final class NotesController {
                 sessionID: sessionID, imageData: imageData
             )
             let imageRef = "\n\n![](images/\(filename))\n"
+            let isManualNotesSession = state.loadedTranscript.isEmpty
 
             if let existing = state.loadedNotes {
+                let baseMarkdown = isManualNotesSession ? state.manualNotesDraft : existing.markdown
                 let updated = GeneratedNotes(
                     template: existing.template,
                     generatedAt: existing.generatedAt,
-                    markdown: existing.markdown + imageRef
+                    markdown: baseMarkdown + imageRef
                 )
                 await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: updated)
                 state.loadedNotes = updated
+                state.manualNotesDraft = updated.markdown
+                state.savedManualNotesMarkdown = updated.markdown
             } else {
                 let template = state.selectedTemplate
                     ?? coordinator.templateStore.template(for: TemplateStore.genericID)
                     ?? TemplateStore.builtInTemplates.first!
+                let baseMarkdown = isManualNotesSession ? state.manualNotesDraft : ""
                 let notes = GeneratedNotes(
                     template: coordinator.templateStore.snapshot(of: template),
                     generatedAt: Date(),
-                    markdown: "![](images/\(filename))"
+                    markdown: baseMarkdown + (baseMarkdown.isEmpty ? "" : "\n\n") + "![](images/\(filename))"
                 )
                 await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
                 state.loadedNotes = notes
+                state.manualNotesDraft = notes.markdown
+                state.savedManualNotesMarkdown = notes.markdown
                 await loadHistory()
             }
+        }
+    }
+
+    // MARK: - Manual Notes
+
+    func updateManualNotesDraft(_ markdown: String) {
+        state.manualNotesDraft = markdown
+        state.isEditingManualNotes = true
+        guard let sessionID = state.selectedSessionID else { return }
+        if markdown == state.savedManualNotesMarkdown {
+            unsavedManualNotesDraftsBySessionID.removeValue(forKey: sessionID)
+        } else {
+            unsavedManualNotesDraftsBySessionID[sessionID] = markdown
+        }
+    }
+
+    func startManualNotesEditing() {
+        state.isEditingManualNotes = true
+    }
+
+    func discardManualNotesDraft() {
+        state.manualNotesDraft = state.savedManualNotesMarkdown
+        state.isEditingManualNotes = state.loadedNotes != nil || !state.savedManualNotesMarkdown.isEmpty
+        if let sessionID = state.selectedSessionID {
+            unsavedManualNotesDraftsBySessionID.removeValue(forKey: sessionID)
+        }
+    }
+
+    func saveManualNotes() {
+        guard let sessionID = state.selectedSessionID else { return }
+
+        let template = state.loadedNotes.flatMap { existing in
+            coordinator.templateStore.template(for: existing.template.id)
+        } ?? state.selectedTemplate
+            ?? coordinator.templateStore.template(for: TemplateStore.genericID)
+            ?? TemplateStore.builtInTemplates.first!
+        let existingGeneratedAt = state.loadedNotes?.generatedAt
+        let markdown = state.manualNotesDraft
+
+        Task {
+            let notes = GeneratedNotes(
+                template: coordinator.templateStore.snapshot(of: template),
+                generatedAt: existingGeneratedAt ?? Date(),
+                markdown: markdown
+            )
+            await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
+            await loadHistory()
+
+            guard state.selectedSessionID == sessionID else { return }
+            state.loadedNotes = notes
+            state.manualNotesDraft = notes.markdown
+            state.savedManualNotesMarkdown = notes.markdown
+            state.isEditingManualNotes = true
+            unsavedManualNotesDraftsBySessionID.removeValue(forKey: sessionID)
         }
     }
 
@@ -743,6 +830,15 @@ final class NotesController {
         return title.isEmpty ? "Untitled" : title
     }
 
+    var isManualNotesSession: Bool {
+        state.selectedSessionID != nil && state.loadedTranscript.isEmpty
+    }
+
+    var hasUnsavedManualNotesChanges: Bool {
+        guard isManualNotesSession else { return false }
+        return state.manualNotesDraft != state.savedManualNotesMarkdown
+    }
+
     // MARK: - Private
 
     private func selectedTemplate(
@@ -768,6 +864,15 @@ final class NotesController {
 
         return coordinator.templateStore.template(for: TemplateStore.genericID)
             ?? TemplateStore.builtInTemplates.first
+    }
+
+    private func persistCurrentManualNotesDraftIfNeeded() {
+        guard let sessionID = state.selectedSessionID, state.loadedTranscript.isEmpty else { return }
+        if state.manualNotesDraft.isEmpty || state.manualNotesDraft == state.savedManualNotesMarkdown {
+            unsavedManualNotesDraftsBySessionID.removeValue(forKey: sessionID)
+        } else {
+            unsavedManualNotesDraftsBySessionID[sessionID] = state.manualNotesDraft
+        }
     }
 
     func loadHistory() async {

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -1556,7 +1556,11 @@ struct NotesView: View {
 
     @ViewBuilder
     private func notesToolbarActions(controller: NotesController, state: NotesState) -> some View {
-        if let notes = state.loadedNotes {
+        if controller.isManualNotesSession {
+            if state.isEditingManualNotes || state.loadedNotes != nil {
+                imageInsertMenu(controller: controller, state: state)
+            }
+        } else if let notes = state.loadedNotes {
             Menu {
                 ForEach(controller.availableTemplates) { template in
                     Button {
@@ -1579,9 +1583,10 @@ struct NotesView: View {
             .help(controller.isAnyGenerationInProgress
                 ? "Generating notes for \"\(controller.generatingSessionName)\"..."
                 : "Click to regenerate, or pick a different template")
+            imageInsertMenu(controller: controller, state: state)
+        } else {
+            imageInsertMenu(controller: controller, state: state)
         }
-
-        imageInsertMenu(controller: controller, state: state)
     }
 
     @ViewBuilder
@@ -1679,10 +1684,10 @@ struct NotesView: View {
         case .generating:
             generatingView(controller: controller, state: state)
         case .idle, .completed, .error:
-            if let notes = state.loadedNotes {
+            if state.loadedTranscript.isEmpty {
+                notesNoTranscriptState(controller: controller, state: state)
+            } else if let notes = state.loadedNotes {
                 notesContentView(notes, sessionDirectory: state.selectedSessionDirectory)
-            } else if state.loadedTranscript.isEmpty {
-                notesNoTranscriptState(state: state)
             } else {
                 notesEmptyState(controller: controller, state: state, sessionID: sessionID)
             }
@@ -1690,28 +1695,100 @@ struct NotesView: View {
     }
 
     @ViewBuilder
-    private func notesNoTranscriptState(state: NotesState) -> some View {
+    private func notesNoTranscriptState(controller: NotesController, state: NotesState) -> some View {
         let isEmbeddedMeetingFamilyDetail = state.selectedMeetingFamily != nil
 
-        if isEmbeddedMeetingFamilyDetail {
+        if state.loadedNotes != nil || state.isEditingManualNotes {
             ScrollView {
-                VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: 14) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "waveform")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        Text("No transcript was recorded for this session. You can still save manual notes.")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                    }
+
+                    HStack(spacing: 8) {
+                        Button {
+                            controller.saveManualNotes()
+                        } label: {
+                            Label("Save Notes", systemImage: "square.and.arrow.down")
+                        }
+                        .buttonStyle(OpenOatsProminentButtonStyle())
+                        .disabled(!controller.hasUnsavedManualNotesChanges)
+
+                        Button {
+                            controller.discardManualNotesDraft()
+                        } label: {
+                            Label("Revert", systemImage: "arrow.uturn.backward")
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(!controller.hasUnsavedManualNotesChanges)
+                    }
+                    .controlSize(.small)
+
+                    TextEditor(text: Binding(
+                        get: { state.manualNotesDraft },
+                        set: { controller.updateManualNotesDraft($0) }
+                    ))
+                    .font(.system(size: 13))
+                    .scrollContentBackground(.hidden)
+                    .frame(minHeight: isEmbeddedMeetingFamilyDetail ? 220 : 320)
+                    .padding(10)
+                    .background(Color(nsColor: .textBackgroundColor).opacity(0.85))
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .strokeBorder(.quaternary, lineWidth: 1)
+                    )
+                    .accessibilityIdentifier("notes.manualEditor")
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 24)
+            }
+        } else if isEmbeddedMeetingFamilyDetail {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
                     Text("No transcript")
                         .font(.system(size: 18, weight: .semibold))
                     Text("There are no recorded utterances to turn into notes for this session.")
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
+
+                    Button {
+                        controller.startManualNotesEditing()
+                    } label: {
+                        Label("Start writing notes", systemImage: "square.and.pencil")
+                    }
+                    .buttonStyle(OpenOatsProminentButtonStyle())
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .padding(.horizontal, 24)
                 .padding(.vertical, 24)
             }
         } else {
-            ContentUnavailableView(
-                "No Transcript",
-                systemImage: "waveform",
-                description: Text("There are no recorded utterances to turn into notes for this session.")
-            )
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("No transcript")
+                        .font(.system(size: 28, weight: .semibold))
+                    Text("There are no recorded utterances to turn into notes for this session.")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.secondary)
+
+                    Button {
+                        controller.startManualNotesEditing()
+                    } label: {
+                        Label("Start writing notes", systemImage: "square.and.pencil")
+                    }
+                    .buttonStyle(OpenOatsProminentButtonStyle())
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .padding(32)
+            }
         }
     }
 
@@ -2032,6 +2109,9 @@ struct NotesView: View {
         case .transcript:
             return state.loadedTranscript.isEmpty
         case .notes:
+            if state.loadedTranscript.isEmpty {
+                return state.manualNotesDraft.isEmpty
+            }
             return state.loadedNotes == nil
         }
     }
@@ -2183,7 +2263,7 @@ struct NotesView: View {
                 return "[\(Self.transcriptTimeFormatter.string(from: record.timestamp))] \(label): \(content)"
             }.joined(separator: "\n")
         case .notes:
-            text = state.loadedNotes?.markdown ?? ""
+            text = state.loadedTranscript.isEmpty ? state.manualNotesDraft : (state.loadedNotes?.markdown ?? "")
         }
 
         NSPasteboard.general.clearContents()

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -198,6 +198,75 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertTrue(savedNotes?.markdown.contains("Test Notes") ?? false)
     }
 
+    func testSaveManualNotesForSessionWithoutTranscript() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_manual_notes"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID, utterances: [])
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertTrue(controller.state.loadedTranscript.isEmpty)
+        XCTAssertNil(controller.state.loadedNotes)
+
+        controller.startManualNotesEditing()
+        controller.updateManualNotesDraft("Manual notes for a failed recording.")
+        controller.saveManualNotes()
+        try? await Task.sleep(for: .milliseconds(250))
+
+        let savedNotes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
+        XCTAssertEqual(savedNotes?.markdown, "Manual notes for a failed recording.")
+        XCTAssertEqual(controller.state.loadedNotes?.markdown, "Manual notes for a failed recording.")
+        XCTAssertFalse(controller.hasUnsavedManualNotesChanges)
+
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+        XCTAssertEqual(controller.state.manualNotesDraft, "Manual notes for a failed recording.")
+    }
+
+    func testInsertImagePreservesUnsavedManualNotesDraft() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_manual_notes_image"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID, utterances: [])
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        controller.startManualNotesEditing()
+        controller.updateManualNotesDraft("Prep observations")
+        controller.insertImage(imageData: Data([0x89, 0x50, 0x4E, 0x47]))
+        try? await Task.sleep(for: .milliseconds(250))
+
+        let savedNotes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
+        XCTAssertNotNil(savedNotes)
+        XCTAssertTrue(savedNotes?.markdown.contains("Prep observations") ?? false)
+        XCTAssertTrue(savedNotes?.markdown.contains("![](images/") ?? false)
+    }
+
+    func testUnsavedManualNotesDraftSurvivesSessionSwitch() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+
+        await seedSession(coordinator: coordinator, sessionID: "manual", title: "Manual Notes Session", utterances: [])
+        await seedSession(coordinator: coordinator, sessionID: "other", title: "Other Session")
+
+        controller.selectSession("manual")
+        try? await Task.sleep(for: .milliseconds(200))
+        controller.startManualNotesEditing()
+        controller.updateManualNotesDraft("Unsaved draft that should survive switching away.")
+
+        controller.selectSession("other")
+        try? await Task.sleep(for: .milliseconds(200))
+        controller.selectSession("manual")
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(controller.state.manualNotesDraft, "Unsaved draft that should survive switching away.")
+        XCTAssertTrue(controller.state.isEditingManualNotes)
+        XCTAssertNil(controller.state.loadedNotes)
+    }
+
     func testCleanupProgressMapsCorrectly() async {
         let (root, _) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)


### PR DESCRIPTION
Fixes #417

## Summary
- allow no-transcript sessions to become normal manual-notes sessions
- add a `Start writing notes` path in the Notes tab instead of a dead-end empty state
- save manual notes through the normal `notes.md` / `notes.meta.json` path
- keep unsaved drafts when switching to another session and back in the same window
- preserve unsaved manual drafts when inserting an image in that mode

## What stays the same
- AI note generation remains disabled when a session has no transcript
- this does not broaden the general notes editor beyond the no-transcript case

## Validation
- `swift test --package-path /Users/nima/dev/cloned/OpenOats-pr-manual-notes-no-transcript/OpenOats --filter NotesControllerTests`
- `swift build -c debug --package-path /Users/nima/dev/cloned/OpenOats-pr-manual-notes-no-transcript/OpenOats`
- `cd /Users/nima/dev/cloned/OpenOats-pr-manual-notes-no-transcript && SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
