### PR TITLE
Update Homebrew cask for 1.56.2

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.56.1"
-  sha256 "c8bf264fb7982a61df88287ca6036e8ee9545ac28b3c7bb6c77e9022cfa2479e"
+  version "1.56.2"
+  sha256 "a0c511024fd386151809184c4797278d3a52c6351230fd07aeea985df91c091f"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Automated cask version bump from the release-dmg workflow.

- version: 1.56.1 → 1.56.2
- sha256 updated to match the new DMG