### PR TITLE
Polish manual no-transcript notes flow

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -237,7 +237,7 @@ final class NotesController {
             state.loadedNotes = data.notes
             state.manualNotesDraft = unsavedDraft ?? data.notes?.markdown ?? ""
             state.savedManualNotesMarkdown = data.notes?.markdown ?? ""
-            state.isEditingManualNotes = data.notes != nil || unsavedDraft != nil
+            state.isEditingManualNotes = unsavedDraft != nil
             state.loadedTranscript = data.transcript
             state.loadedCalendarEvent = data.calendarEvent
             state.audioFileURL = data.audioURL
@@ -531,7 +531,7 @@ final class NotesController {
 
     func discardManualNotesDraft() {
         state.manualNotesDraft = state.savedManualNotesMarkdown
-        state.isEditingManualNotes = state.loadedNotes != nil || !state.savedManualNotesMarkdown.isEmpty
+        state.isEditingManualNotes = false
         if let sessionID = state.selectedSessionID {
             unsavedManualNotesDraftsBySessionID.removeValue(forKey: sessionID)
         }
@@ -561,7 +561,7 @@ final class NotesController {
             state.loadedNotes = notes
             state.manualNotesDraft = notes.markdown
             state.savedManualNotesMarkdown = notes.markdown
-            state.isEditingManualNotes = true
+            state.isEditingManualNotes = false
             unsavedManualNotesDraftsBySessionID.removeValue(forKey: sessionID)
         }
     }

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -1557,7 +1557,16 @@ struct NotesView: View {
     @ViewBuilder
     private func notesToolbarActions(controller: NotesController, state: NotesState) -> some View {
         if controller.isManualNotesSession {
-            if state.isEditingManualNotes || state.loadedNotes != nil {
+            if state.isEditingManualNotes {
+                imageInsertMenu(controller: controller, state: state)
+            } else if state.loadedNotes != nil {
+                Button {
+                    controller.startManualNotesEditing()
+                } label: {
+                    Label("Edit Notes", systemImage: "square.and.pencil")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.bordered)
                 imageInsertMenu(controller: controller, state: state)
             }
         } else if let notes = state.loadedNotes {
@@ -1685,7 +1694,13 @@ struct NotesView: View {
             generatingView(controller: controller, state: state)
         case .idle, .completed, .error:
             if state.loadedTranscript.isEmpty {
-                notesNoTranscriptState(controller: controller, state: state)
+                if state.isEditingManualNotes {
+                    notesNoTranscriptState(controller: controller, state: state)
+                } else if let notes = state.loadedNotes {
+                    notesContentView(notes, sessionDirectory: state.selectedSessionDirectory)
+                } else {
+                    notesNoTranscriptState(controller: controller, state: state)
+                }
             } else if let notes = state.loadedNotes {
                 notesContentView(notes, sessionDirectory: state.selectedSessionDirectory)
             } else {
@@ -1698,7 +1713,7 @@ struct NotesView: View {
     private func notesNoTranscriptState(controller: NotesController, state: NotesState) -> some View {
         let isEmbeddedMeetingFamilyDetail = state.selectedMeetingFamily != nil
 
-        if state.loadedNotes != nil || state.isEditingManualNotes {
+        if state.isEditingManualNotes {
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
                     HStack(spacing: 8) {

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -219,10 +219,12 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(savedNotes?.markdown, "Manual notes for a failed recording.")
         XCTAssertEqual(controller.state.loadedNotes?.markdown, "Manual notes for a failed recording.")
         XCTAssertFalse(controller.hasUnsavedManualNotesChanges)
+        XCTAssertFalse(controller.state.isEditingManualNotes)
 
         controller.selectSession(sessionID)
         try? await Task.sleep(for: .milliseconds(200))
         XCTAssertEqual(controller.state.manualNotesDraft, "Manual notes for a failed recording.")
+        XCTAssertFalse(controller.state.isEditingManualNotes)
     }
 
     func testInsertImagePreservesUnsavedManualNotesDraft() async {


### PR DESCRIPTION
## Summary
This follows up on #418 with a small UX fix for manual notes on sessions without transcripts.

## What changed
- exit manual edit mode after saving manual notes
- exit manual edit mode after reverting a manual draft
- show saved manual notes in the normal notes reader state
- add an explicit `Edit Notes` action to re-enter editing for no-transcript sessions

## Why
After saving manual notes, the Notes tab stayed in the special no-transcript helper state with `Save Notes` / `Revert` still visible. That made the session feel half-saved and looked broken.

Fixes #420

## Validation
- `swift test --package-path OpenOats --filter NotesControllerTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`