### PR TITLE
Fix local model cache path stability across app updates

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/OpenOatsLocalModelStore.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/OpenOatsLocalModelStore.swift
@@ -1,0 +1,253 @@
+import FluidAudio
+import Foundation
+
+enum OpenOatsLocalModelStore {
+    static func parakeetDirectory(
+        for version: AsrModelVersion,
+        baseDirectory: URL = defaultBaseDirectory(),
+        fluidAudioModelsRoot: URL = MLModelConfigurationUtils.defaultModelsDirectory()
+    ) -> URL {
+        let wrapper = baseDirectory
+            .appendingPathComponent("parakeet", isDirectory: true)
+            .appendingPathComponent(stableName(for: version), isDirectory: true)
+            .appendingPathComponent("current", isDirectory: true)
+
+        _ = migrateParakeetIfNeeded(
+            version: version,
+            wrapperDirectory: wrapper,
+            fluidAudioModelsRoot: fluidAudioModelsRoot
+        )
+        return wrapper
+    }
+
+    static func qwen3Directory(
+        variant: Qwen3AsrVariant = .f32,
+        baseDirectory: URL = defaultBaseDirectory(),
+        fluidAudioModelsRoot: URL = MLModelConfigurationUtils.defaultModelsDirectory()
+    ) -> URL {
+        let target = baseDirectory
+            .appendingPathComponent("qwen3-asr", isDirectory: true)
+            .appendingPathComponent(variant.rawValue, isDirectory: true)
+
+        _ = migrateQwen3IfNeeded(
+            variant: variant,
+            targetDirectory: target,
+            fluidAudioModelsRoot: fluidAudioModelsRoot
+        )
+        return target
+    }
+
+    static func clearParakeetCache(
+        for version: AsrModelVersion,
+        baseDirectory: URL = defaultBaseDirectory(),
+        fluidAudioModelsRoot: URL = MLModelConfigurationUtils.defaultModelsDirectory()
+    ) {
+        let fileManager = FileManager.default
+        let wrapper = baseDirectory
+            .appendingPathComponent("parakeet", isDirectory: true)
+            .appendingPathComponent(stableName(for: version), isDirectory: true)
+        try? fileManager.removeItem(at: wrapper)
+        parakeetMigrationCandidates(for: version, fluidAudioModelsRoot: fluidAudioModelsRoot).forEach {
+            try? fileManager.removeItem(at: $0)
+        }
+    }
+
+    static func clearQwen3Cache(
+        variant: Qwen3AsrVariant = .f32,
+        baseDirectory: URL = defaultBaseDirectory(),
+        fluidAudioModelsRoot: URL = MLModelConfigurationUtils.defaultModelsDirectory()
+    ) {
+        let fileManager = FileManager.default
+        let target = baseDirectory
+            .appendingPathComponent("qwen3-asr", isDirectory: true)
+            .appendingPathComponent(variant.rawValue, isDirectory: true)
+        try? fileManager.removeItem(at: target)
+        qwen3MigrationCandidates(for: variant, fluidAudioModelsRoot: fluidAudioModelsRoot).forEach {
+            try? fileManager.removeItem(at: $0)
+        }
+    }
+
+    static func migrateDownloadedQwen3Models(
+        from sourceDirectory: URL,
+        variant: Qwen3AsrVariant = .f32,
+        baseDirectory: URL = defaultBaseDirectory(),
+        fluidAudioModelsRoot: URL = MLModelConfigurationUtils.defaultModelsDirectory()
+    ) -> URL {
+        let target = baseDirectory
+            .appendingPathComponent("qwen3-asr", isDirectory: true)
+            .appendingPathComponent(variant.rawValue, isDirectory: true)
+
+        moveDirectoryIfNeeded(from: sourceDirectory, to: target)
+        _ = migrateQwen3IfNeeded(
+            variant: variant,
+            targetDirectory: target,
+            fluidAudioModelsRoot: fluidAudioModelsRoot
+        )
+        return target
+    }
+
+    static func defaultBaseDirectory(appSupportDirectory: URL? = nil) -> URL {
+        let fileManager = FileManager.default
+        let appSupport =
+            appSupportDirectory
+            ?? fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        return appSupport
+            .appendingPathComponent("OpenOats", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            .appendingPathComponent("Transcription", isDirectory: true)
+    }
+
+    private static func migrateParakeetIfNeeded(
+        version: AsrModelVersion,
+        wrapperDirectory: URL,
+        fluidAudioModelsRoot: URL
+    ) -> URL {
+        let fileManager = FileManager.default
+        let targetDirectory = parakeetRepoDirectory(for: version, wrapperDirectory: wrapperDirectory)
+        if fileManager.fileExists(atPath: targetDirectory.path) {
+            return wrapperDirectory
+        }
+
+        for candidate in parakeetMigrationCandidates(for: version, fluidAudioModelsRoot: fluidAudioModelsRoot) {
+            if fileManager.fileExists(atPath: candidate.path) {
+                moveDirectoryIfNeeded(from: candidate, to: targetDirectory)
+                break
+            }
+        }
+
+        return wrapperDirectory
+    }
+
+    private static func migrateQwen3IfNeeded(
+        variant: Qwen3AsrVariant,
+        targetDirectory: URL,
+        fluidAudioModelsRoot: URL
+    ) -> URL {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: targetDirectory.path) {
+            return targetDirectory
+        }
+
+        for candidate in qwen3MigrationCandidates(for: variant, fluidAudioModelsRoot: fluidAudioModelsRoot) {
+            if fileManager.fileExists(atPath: candidate.path) {
+                moveDirectoryIfNeeded(from: candidate, to: targetDirectory)
+                break
+            }
+        }
+
+        return targetDirectory
+    }
+
+    private static func parakeetMigrationCandidates(
+        for version: AsrModelVersion,
+        fluidAudioModelsRoot: URL
+    ) -> [URL] {
+        candidateDirectories(
+            currentRelativePath: parakeetCurrentRelativePath(for: version),
+            legacyRelativePath: parakeetLegacyRelativePath(for: version),
+            root: fluidAudioModelsRoot
+        )
+    }
+
+    private static func qwen3MigrationCandidates(
+        for variant: Qwen3AsrVariant,
+        fluidAudioModelsRoot: URL
+    ) -> [URL] {
+        candidateDirectories(
+            currentRelativePath: variant.repo.folderName,
+            legacyRelativePath: variant.repo.name,
+            root: fluidAudioModelsRoot
+        )
+    }
+
+    private static func candidateDirectories(
+        currentRelativePath: String,
+        legacyRelativePath: String,
+        root: URL
+    ) -> [URL] {
+        var seen: Set<String> = []
+        return [currentRelativePath, legacyRelativePath]
+            .map { append(relativePath: $0, to: root) }
+            .filter { url in
+                let key = url.standardizedFileURL.path
+                return seen.insert(key).inserted
+            }
+    }
+
+    private static func parakeetRepoDirectory(for version: AsrModelVersion, wrapperDirectory: URL) -> URL {
+        wrapperDirectory
+            .deletingLastPathComponent()
+            .appendingPathComponent(parakeetCurrentRelativePath(for: version), isDirectory: true)
+    }
+
+    private static func moveDirectoryIfNeeded(from source: URL, to destination: URL) {
+        let fileManager = FileManager.default
+        guard source.standardizedFileURL != destination.standardizedFileURL else { return }
+        guard fileManager.fileExists(atPath: source.path) else { return }
+        guard !fileManager.fileExists(atPath: destination.path) else { return }
+
+        try? fileManager.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        do {
+            try fileManager.moveItem(at: source, to: destination)
+        } catch {
+            do {
+                try fileManager.copyItem(at: source, to: destination)
+                try? fileManager.removeItem(at: source)
+            } catch {
+                return
+            }
+        }
+    }
+
+    private static func parakeetCurrentRelativePath(for version: AsrModelVersion) -> String {
+        switch version {
+        case .v2:
+            return Repo.parakeetV2.folderName
+        case .v3:
+            return Repo.parakeet.folderName
+        case .tdtCtc110m:
+            return Repo.parakeetTdtCtc110m.folderName
+        case .ctcZhCn:
+            return Repo.parakeetCtcZhCn.folderName
+        }
+    }
+
+    private static func parakeetLegacyRelativePath(for version: AsrModelVersion) -> String {
+        switch version {
+        case .v2:
+            return Repo.parakeetV2.name
+        case .v3:
+            return Repo.parakeet.name
+        case .tdtCtc110m:
+            return Repo.parakeetTdtCtc110m.name
+        case .ctcZhCn:
+            return Repo.parakeetCtcZhCn.name
+        }
+    }
+
+    private static func append(relativePath: String, to base: URL) -> URL {
+        relativePath
+            .split(separator: "/")
+            .reduce(base) { partial, component in
+                partial.appendingPathComponent(String(component), isDirectory: true)
+            }
+    }
+
+    private static func stableName(for version: AsrModelVersion) -> String {
+        switch version {
+        case .v2:
+            return "parakeet-v2"
+        case .v3:
+            return "parakeet-v3"
+        case .tdtCtc110m:
+            return "parakeet-tdt-ctc-110m"
+        case .ctcZhCn:
+            return "parakeet-ctc-zh-cn"
+        }
+    }
+}

--- a/OpenOats/Sources/OpenOats/Transcription/ParakeetBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/ParakeetBackend.swift
@@ -15,23 +15,29 @@ final class ParakeetBackend: TranscriptionBackend, @unchecked Sendable {
 
     func checkStatus() -> BackendStatus {
         let exists = AsrModels.modelsExist(
-            at: AsrModels.defaultCacheDirectory(for: version),
+            at: OpenOatsLocalModelStore.parakeetDirectory(for: version),
             version: version
         )
         return exists ? .ready : .needsDownload(prompt: "Transcription requires a one-time model download.")
     }
 
     func clearModelCache() {
-        let cacheDir = AsrModels.defaultCacheDirectory(for: version)
-        try? FileManager.default.removeItem(at: cacheDir)
+        OpenOatsLocalModelStore.clearParakeetCache(for: version)
     }
 
     func prepare(onStatus: @Sendable (String) -> Void, onProgress: @escaping @Sendable (Double) -> Void) async throws {
-        onStatus("Downloading \(displayName)...")
-        let models = try await AsrModels.downloadAndLoad(version: version) { progress in
-            onProgress(progress.fractionCompleted)
+        let models: AsrModels
+        let modelsDirectory = OpenOatsLocalModelStore.parakeetDirectory(for: version)
+        if AsrModels.modelsExist(at: modelsDirectory, version: version) {
+            onStatus("Initializing \(displayName)...")
+            models = try await AsrModels.load(from: modelsDirectory, version: version)
+        } else {
+            onStatus("Downloading \(displayName)...")
+            models = try await AsrModels.downloadAndLoad(to: modelsDirectory, version: version) { progress in
+                onProgress(progress.fractionCompleted)
+            }
+            onStatus("Initializing \(displayName)...")
         }
-        onStatus("Initializing \(displayName)...")
         let asr = AsrManager(config: .default)
         try await asr.loadModels(models)
         self.asrManager = asr

--- a/OpenOats/Sources/OpenOats/Transcription/Qwen3Backend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/Qwen3Backend.swift
@@ -5,24 +5,41 @@ import Foundation
 /// @unchecked Sendable: qwen3Manager is written once in prepare() before any transcribe() calls.
 final class Qwen3Backend: TranscriptionBackend, @unchecked Sendable {
     let displayName = "Qwen3 ASR 0.6B"
+    private let variant: Qwen3AsrVariant
     private var qwen3Manager: Qwen3AsrManager?
 
+    init(variant: Qwen3AsrVariant = .f32) {
+        self.variant = variant
+    }
+
     func checkStatus() -> BackendStatus {
-        let exists = Qwen3AsrModels.modelsExist(at: Qwen3AsrModels.defaultCacheDirectory())
+        let exists = Qwen3AsrModels.modelsExist(
+            at: OpenOatsLocalModelStore.qwen3Directory(variant: variant)
+        )
         return exists ? .ready : .needsDownload(prompt: "Qwen3 ASR requires a one-time model download.")
     }
 
     func clearModelCache() {
-        let cacheDir = Qwen3AsrModels.defaultCacheDirectory()
-        try? FileManager.default.removeItem(at: cacheDir)
+        OpenOatsLocalModelStore.clearQwen3Cache(variant: variant)
     }
 
     func prepare(onStatus: @Sendable (String) -> Void, onProgress: @escaping @Sendable (Double) -> Void) async throws {
-        onStatus("Downloading \(displayName)...")
-        let modelsDirectory = try await Qwen3AsrModels.download(progressHandler: { progress in
-            onProgress(progress.fractionCompleted)
-        })
-        onStatus("Initializing \(displayName)...")
+        let modelsDirectory = OpenOatsLocalModelStore.qwen3Directory(variant: variant)
+
+        if Qwen3AsrModels.modelsExist(at: modelsDirectory) {
+            onStatus("Initializing \(displayName)...")
+        } else {
+            onStatus("Downloading \(displayName)...")
+            let downloadedDirectory = try await Qwen3AsrModels.download(variant: variant, progressHandler: { progress in
+                onProgress(progress.fractionCompleted)
+            })
+            _ = OpenOatsLocalModelStore.migrateDownloadedQwen3Models(
+                from: downloadedDirectory,
+                variant: variant
+            )
+            onStatus("Initializing \(displayName)...")
+        }
+
         let qwen3 = Qwen3AsrManager()
         try await qwen3.loadModels(from: modelsDirectory)
         self.qwen3Manager = qwen3

--- a/OpenOats/Tests/OpenOatsTests/OpenOatsLocalModelStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/OpenOatsLocalModelStoreTests.swift
@@ -1,0 +1,128 @@
+import XCTest
+import FluidAudio
+@testable import OpenOatsKit
+
+final class OpenOatsLocalModelStoreTests: XCTestCase {
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenOatsLocalModelStoreTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+    }
+
+    func testParakeetDirectoryMigratesExistingFluidAudioCacheIntoStableStore() throws {
+        let baseDirectory = tempDirectory.appendingPathComponent("Base", isDirectory: true)
+        let fluidAudioRoot = tempDirectory.appendingPathComponent("FluidAudio", isDirectory: true)
+        let sourceDirectory = fluidAudioRoot.appendingPathComponent(Repo.parakeet.folderName, isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+        let marker = sourceDirectory.appendingPathComponent("marker.txt")
+        try Data("parakeet".utf8).write(to: marker)
+
+        let wrapper = OpenOatsLocalModelStore.parakeetDirectory(
+            for: .v3,
+            baseDirectory: baseDirectory,
+            fluidAudioModelsRoot: fluidAudioRoot
+        )
+
+        let migratedDirectory = wrapper
+            .deletingLastPathComponent()
+            .appendingPathComponent(Repo.parakeet.folderName, isDirectory: true)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: migratedDirectory.appendingPathComponent("marker.txt").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sourceDirectory.path))
+        XCTAssertEqual(
+            wrapper,
+            baseDirectory
+                .appendingPathComponent("parakeet", isDirectory: true)
+                .appendingPathComponent("parakeet-v3", isDirectory: true)
+                .appendingPathComponent("current", isDirectory: true)
+        )
+    }
+
+    func testQwen3DirectoryMigratesExistingFluidAudioCacheIntoStableStore() throws {
+        let baseDirectory = tempDirectory.appendingPathComponent("Base", isDirectory: true)
+        let fluidAudioRoot = tempDirectory.appendingPathComponent("FluidAudio", isDirectory: true)
+        let sourceDirectory = fluidAudioRoot.appendingPathComponent(Repo.qwen3Asr.folderName, isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+        try Data("qwen".utf8).write(to: sourceDirectory.appendingPathComponent("marker.txt"))
+
+        let target = OpenOatsLocalModelStore.qwen3Directory(
+            variant: .f32,
+            baseDirectory: baseDirectory,
+            fluidAudioModelsRoot: fluidAudioRoot
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: target.appendingPathComponent("marker.txt").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sourceDirectory.path))
+        XCTAssertEqual(
+            target,
+            baseDirectory
+                .appendingPathComponent("qwen3-asr", isDirectory: true)
+                .appendingPathComponent("f32", isDirectory: true)
+        )
+    }
+
+    func testMigrateDownloadedQwen3ModelsMovesDownloadedDirectoryIntoStableStore() throws {
+        let baseDirectory = tempDirectory.appendingPathComponent("Base", isDirectory: true)
+        let fluidAudioRoot = tempDirectory.appendingPathComponent("FluidAudio", isDirectory: true)
+        let downloadedDirectory = tempDirectory.appendingPathComponent("downloaded-qwen", isDirectory: true)
+        try FileManager.default.createDirectory(at: downloadedDirectory, withIntermediateDirectories: true)
+        try Data("qwen".utf8).write(to: downloadedDirectory.appendingPathComponent("marker.txt"))
+
+        let migrated = OpenOatsLocalModelStore.migrateDownloadedQwen3Models(
+            from: downloadedDirectory,
+            variant: .f32,
+            baseDirectory: baseDirectory,
+            fluidAudioModelsRoot: fluidAudioRoot
+        )
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: migrated.appendingPathComponent("marker.txt").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: downloadedDirectory.path))
+    }
+
+    func testClearModelCacheRemovesStableAndLegacyLocations() throws {
+        let baseDirectory = tempDirectory.appendingPathComponent("Base", isDirectory: true)
+        let fluidAudioRoot = tempDirectory.appendingPathComponent("FluidAudio", isDirectory: true)
+
+        let stableParakeet = OpenOatsLocalModelStore.parakeetDirectory(
+            for: .v3,
+            baseDirectory: baseDirectory,
+            fluidAudioModelsRoot: fluidAudioRoot
+        ).deletingLastPathComponent()
+        let legacyParakeet = fluidAudioRoot.appendingPathComponent(Repo.parakeet.name, isDirectory: true)
+        try FileManager.default.createDirectory(at: stableParakeet, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyParakeet, withIntermediateDirectories: true)
+
+        let stableQwen = OpenOatsLocalModelStore.qwen3Directory(
+            variant: .f32,
+            baseDirectory: baseDirectory,
+            fluidAudioModelsRoot: fluidAudioRoot
+        )
+        let legacyQwen = fluidAudioRoot.appendingPathComponent(Repo.qwen3Asr.name, isDirectory: true)
+        try FileManager.default.createDirectory(at: stableQwen, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyQwen, withIntermediateDirectories: true)
+
+        OpenOatsLocalModelStore.clearParakeetCache(
+            for: .v3,
+            baseDirectory: baseDirectory,
+            fluidAudioModelsRoot: fluidAudioRoot
+        )
+        OpenOatsLocalModelStore.clearQwen3Cache(
+            variant: .f32,
+            baseDirectory: baseDirectory,
+            fluidAudioModelsRoot: fluidAudioRoot
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stableParakeet.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyParakeet.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: stableQwen.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyQwen.path))
+    }
+}


### PR DESCRIPTION
## Summary
- move Parakeet and Qwen local model resolution onto an OpenOats-owned stable cache root
- migrate existing FluidAudio cache directories into the stable OpenOats path before checking readiness or loading
- clear both stable and pre-migration cache locations when the user explicitly clears a local model cache
- add focused migration tests for the stable model store

## Why
Users can end up being prompted to re-download local transcription models after upgrading because the app inherits FluidAudio cache folder naming changes. This keeps future model paths stable from the app side and performs a one-time migration into those paths.

Closes #376

## Validation
- swift test --package-path OpenOats --filter OpenOatsLocalModelStoreTests
- swift test --package-path OpenOats --filter TranscriptionBackendTests
- swift test --package-path OpenOats --filter TranscriptionEngineTests
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh