### PR TITLE
Update Homebrew cask for 1.57.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.56.2"
-  sha256 "a0c511024fd386151809184c4797278d3a52c6351230fd07aeea985df91c091f"
+  version "1.57.0"
+  sha256 "29ec76c56d3860d45852378e3c5a061f26b81825cbf1b1e41f85eee7750d6387"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Bump cask version from 1.56.2 to 1.57.0
- Update SHA256 to match the released DMG

Automated post-release cask update from the `release-dmg` workflow.