### PR TITLE
Add default folders for meeting families

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -404,6 +404,12 @@ final class LiveSessionController {
             )
         )
 
+        if let settings,
+           let event = endingMetadata?.calendarEvent,
+           let folderPath = settings.meetingFamilyPreferences(for: event)?.folderPath {
+            await coordinator.sessionRepository.updateSessionFolder(sessionID: sessionID, folderPath: folderPath)
+        }
+
         // 5. Build index for UI state
         let index = SessionIndex(
             id: sessionID,

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -801,6 +801,39 @@ final class NotesController {
         }
     }
 
+    func setMeetingFamilyFolderPreference(_ folderPath: String?) {
+        guard let settings,
+              let selection = state.selectedMeetingFamily else { return }
+        settings.setMeetingFamilyFolderPreference(folderPath, forHistoryKey: selection.key)
+    }
+
+    func applyMeetingFamilyFolderPreference(
+        _ folderPath: String?,
+        moveExistingSessions: Bool,
+        forHistoryKey historyKey: String? = nil
+    ) {
+        guard let settings else { return }
+        let key = historyKey ?? state.selectedMeetingFamily?.key
+        guard let key, !key.isEmpty else { return }
+
+        settings.setMeetingFamilyFolderPreference(folderPath, forHistoryKey: key)
+
+        guard moveExistingSessions else { return }
+
+        let sessionIDs = MeetingHistoryResolver.matchingSessions(
+            forHistoryKey: key,
+            sessionHistory: state.sessionHistory,
+            aliases: settings.meetingHistoryAliasesByKey
+        ).map(\.id)
+
+        Task {
+            for sessionID in sessionIDs {
+                await coordinator.sessionRepository.updateSessionFolder(sessionID: sessionID, folderPath: folderPath)
+            }
+            await loadHistory()
+        }
+    }
+
     // MARK: - Accessors
 
     /// Templates available for generation.

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -921,6 +921,29 @@ final class SettingsStore {
         meetingFamilyPreferencesByKey = preferences
     }
 
+    func setMeetingFamilyFolderPreference(_ folderPath: String?, for event: CalendarEvent) {
+        setMeetingFamilyFolderPreference(
+            folderPath,
+            forHistoryKey: MeetingHistoryResolver.historyKey(for: event)
+        )
+    }
+
+    func setMeetingFamilyFolderPreference(_ folderPath: String?, forHistoryKey historyKey: String) {
+        let key = canonicalMeetingHistoryKey(forHistoryKey: historyKey)
+        guard !key.isEmpty else { return }
+
+        var preferences = meetingFamilyPreferencesByKey
+        var value = preferences[key] ?? MeetingFamilyPreferences()
+        value.folderPath = Self.normalizeMeetingFamilyFolderPath(folderPath)
+
+        if value.isEmpty {
+            preferences.removeValue(forKey: key)
+        } else {
+            preferences[key] = value
+        }
+        meetingFamilyPreferencesByKey = preferences
+    }
+
     func linkMeetingHistoryAlias(from aliasHistoryKey: String, to canonicalHistoryKey: String) {
         let aliasKey = MeetingHistoryResolver.historyKey(for: aliasHistoryKey)
         let targetKey = canonicalMeetingHistoryKey(forHistoryKey: canonicalHistoryKey)
@@ -1343,10 +1366,21 @@ final class SettingsStore {
         for (rawKey, rawValue) in preferences {
             let normalizedKey = rawKey.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             guard !normalizedKey.isEmpty else { continue }
-            guard !rawValue.isEmpty else { continue }
-            result[normalizedKey] = rawValue
+            let normalizedValue = MeetingFamilyPreferences(
+                templateID: rawValue.templateID,
+                folderPath: normalizeMeetingFamilyFolderPath(rawValue.folderPath)
+            )
+            guard !normalizedValue.isEmpty else { continue }
+            result[normalizedKey] = normalizedValue
         }
         return result
+    }
+
+    private static func normalizeMeetingFamilyFolderPath(_ folderPath: String?) -> String? {
+        guard let normalized = NotesFolderDefinition.normalizePath(folderPath ?? "") else { return nil }
+        let componentCount = normalized.split(separator: "/").count
+        guard componentCount <= 2 else { return nil }
+        return normalized
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -52,9 +52,10 @@ struct NotesFolderDefinition: Identifiable, Codable, Equatable, Sendable {
 
 struct MeetingFamilyPreferences: Codable, Equatable, Sendable {
     var templateID: UUID?
+    var folderPath: String?
 
     var isEmpty: Bool {
-        templateID == nil
+        templateID == nil && folderPath == nil
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -11,6 +11,8 @@ struct NotesView: View {
     @State private var renameText: String = ""
     @FocusState private var renameFieldFocused: Bool
     @State private var creatingFolderForSessionID: String?
+    @State private var creatingFolderForMeetingFamilyKey: String?
+    @State private var pendingMeetingFamilyFolderChange: PendingMeetingFamilyFolderChange?
     @State private var newFolderPath: String = ""
     @State private var newFolderColor: NotesFolderColor = .orange
     @FocusState private var newFolderFieldFocused: Bool
@@ -37,6 +39,13 @@ struct NotesView: View {
     @State private var detailViewMode: DetailViewMode = .transcript
     @State private var meetingFamilyBottomTab: MeetingFamilyBottomTab = .history
     @State private var isMeetingFamilyBottomCollapsed = false
+
+    private struct PendingMeetingFamilyFolderChange: Equatable {
+        let historyKey: String
+        let familyTitle: String
+        let folderPath: String?
+        let existingMeetingCount: Int
+    }
 
     var body: some View {
         Group {
@@ -98,6 +107,7 @@ struct NotesView: View {
         .onChange(of: state.selectedMeetingFamily?.key) {
             meetingFamilyBottomTab = .history
             isMeetingFamilyBottomCollapsed = false
+            pendingMeetingFamilyFolderChange = nil
         }
         .sheet(
             isPresented: Binding(
@@ -118,6 +128,37 @@ struct NotesView: View {
             if let sessionID = creatingFolderForSessionID {
                 newFolderSheet(controller: controller, sessionID: sessionID)
             }
+        }
+        .sheet(
+            isPresented: Binding(
+                get: { creatingFolderForMeetingFamilyKey != nil },
+                set: { if !$0 { cancelCreateFolder() } }
+            )
+        ) {
+            meetingFamilyFolderSheetContent(controller: controller)
+        }
+        .confirmationDialog(
+            "Update default folder?",
+            isPresented: Binding(
+                get: { pendingMeetingFamilyFolderChange != nil },
+                set: { if !$0 { pendingMeetingFamilyFolderChange = nil } }
+            ),
+            titleVisibility: .visible,
+            presenting: pendingMeetingFamilyFolderChange
+        ) { pendingChange in
+                Button("Future meetings only") {
+                    applyPendingMeetingFamilyFolderChange(controller: controller, moveExistingSessions: false)
+                }
+
+                Button(moveExistingMeetingsTitle(for: pendingChange)) {
+                    applyPendingMeetingFamilyFolderChange(controller: controller, moveExistingSessions: true)
+                }
+
+                Button("Cancel", role: .cancel) {
+                    pendingMeetingFamilyFolderChange = nil
+                }
+        } message: { pendingChange in
+            Text(meetingFamilyFolderChangeMessage(for: pendingChange))
         }
     }
 
@@ -424,11 +465,63 @@ struct NotesView: View {
 
     @ViewBuilder
     private func newFolderSheet(controller: NotesController, sessionID: String) -> some View {
+        folderEditorSheet(
+            title: "New Folder",
+            subtitle: "Use `/` to create subfolders inside your Notes list.",
+            saveDisabled: NotesFolderDefinition.normalizePath(newFolderPath) == nil,
+            onSave: {
+                commitCreateFolder(controller: controller, sessionID: sessionID)
+            }
+        )
+        .accessibilityIdentifier("notes.newFolderSheet")
+    }
+
+    @ViewBuilder
+    private func meetingFamilyFolderSheet(
+        controller: NotesController,
+        selection: MeetingFamilySelection,
+        historyCount: Int
+    ) -> some View {
+        folderEditorSheet(
+            title: "New Default Folder",
+            subtitle: "Use a top-level folder and at most one subfolder, like `Work` or `Work/1:1s`.",
+            saveDisabled: normalizedMeetingFamilyFolderPath(newFolderPath) == nil,
+            onSave: {
+                commitCreateFolder(
+                    controller: controller,
+                    selection: selection,
+                    historyCount: historyCount
+                )
+            }
+        )
+    }
+
+    @ViewBuilder
+    private func meetingFamilyFolderSheetContent(controller: NotesController) -> some View {
+        if let meetingFamilyKey = creatingFolderForMeetingFamilyKey {
+            let selection = controller.state.selectedMeetingFamily
+            if let selection, selection.key == meetingFamilyKey {
+                meetingFamilyFolderSheet(
+                    controller: controller,
+                    selection: selection,
+                    historyCount: controller.state.meetingHistoryEntries.count
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func folderEditorSheet(
+        title: String,
+        subtitle: String,
+        saveDisabled: Bool,
+        onSave: @escaping () -> Void
+    ) -> some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("New Folder")
+            Text(title)
                 .font(.headline)
 
-            Text("Use `/` to create subfolders inside your Notes list.")
+            Text(subtitle)
                 .font(.system(size: 12))
                 .foregroundStyle(.secondary)
 
@@ -440,7 +533,7 @@ struct NotesView: View {
                     newFolderFieldFocused = true
                 }
                 .onSubmit {
-                    commitCreateFolder(controller: controller, sessionID: sessionID)
+                    onSave()
                 }
 
             VStack(alignment: .leading, spacing: 8) {
@@ -485,16 +578,15 @@ struct NotesView: View {
                 .keyboardShortcut(.cancelAction)
 
                 Button("Create") {
-                    commitCreateFolder(controller: controller, sessionID: sessionID)
+                    onSave()
                 }
                 .keyboardShortcut(.defaultAction)
-                .disabled(NotesFolderDefinition.normalizePath(newFolderPath) == nil)
+                .disabled(saveDisabled)
                 .accessibilityIdentifier("notes.newFolderSheet.saveButton")
             }
         }
         .padding(20)
         .frame(width: 360)
-        .accessibilityIdentifier("notes.newFolderSheet")
     }
 
     @ViewBuilder
@@ -557,6 +649,13 @@ struct NotesView: View {
         creatingFolderForSessionID = session.id
     }
 
+    private func beginCreateFolder(for selection: MeetingFamilySelection) {
+        let preferredFolderPath = settings.meetingFamilyPreferences(forHistoryKey: selection.key)?.folderPath
+        newFolderPath = preferredFolderPath ?? ""
+        newFolderColor = folderDefinition(for: preferredFolderPath)?.color ?? .orange
+        creatingFolderForMeetingFamilyKey = selection.key
+    }
+
     private func commitCreateFolder(controller: NotesController, sessionID: String) {
         guard let normalizedPath = NotesFolderDefinition.normalizePath(newFolderPath) else { return }
         var folders = settings.notesFolders
@@ -570,8 +669,31 @@ struct NotesView: View {
         cancelCreateFolder()
     }
 
+    private func commitCreateFolder(
+        controller: NotesController,
+        selection: MeetingFamilySelection,
+        historyCount: Int
+    ) {
+        guard let normalizedPath = normalizedMeetingFamilyFolderPath(newFolderPath) else { return }
+        var folders = settings.notesFolders
+        if let existingIndex = folders.firstIndex(where: { $0.path.caseInsensitiveCompare(normalizedPath) == .orderedSame }) {
+            folders[existingIndex].color = newFolderColor
+        } else {
+            folders.append(NotesFolderDefinition(path: normalizedPath, color: newFolderColor))
+        }
+        settings.notesFolders = folders
+        cancelCreateFolder()
+        requestMeetingFamilyFolderChange(
+            controller: controller,
+            selection: selection,
+            folderPath: normalizedPath,
+            historyCount: historyCount
+        )
+    }
+
     private func cancelCreateFolder() {
         creatingFolderForSessionID = nil
+        creatingFolderForMeetingFamilyKey = nil
         newFolderFieldFocused = false
         newFolderPath = ""
         newFolderColor = .orange
@@ -689,6 +811,75 @@ struct NotesView: View {
         case .red:
             return .red
         }
+    }
+
+    private func requestMeetingFamilyFolderChange(
+        controller: NotesController,
+        selection: MeetingFamilySelection,
+        folderPath: String?,
+        historyCount: Int
+    ) {
+        let currentFolderPath = settings.meetingFamilyPreferences(forHistoryKey: selection.key)?.folderPath
+        guard currentFolderPath != folderPath else { return }
+
+        if historyCount > 0 {
+            pendingMeetingFamilyFolderChange = PendingMeetingFamilyFolderChange(
+                historyKey: selection.key,
+                familyTitle: selection.title,
+                folderPath: folderPath,
+                existingMeetingCount: historyCount
+            )
+            return
+        }
+
+        controller.applyMeetingFamilyFolderPreference(
+            folderPath,
+            moveExistingSessions: false,
+            forHistoryKey: selection.key
+        )
+    }
+
+    private func applyPendingMeetingFamilyFolderChange(
+        controller: NotesController,
+        moveExistingSessions: Bool
+    ) {
+        guard let pendingChange = pendingMeetingFamilyFolderChange else { return }
+        controller.applyMeetingFamilyFolderPreference(
+            pendingChange.folderPath,
+            moveExistingSessions: moveExistingSessions,
+            forHistoryKey: pendingChange.historyKey
+        )
+        pendingMeetingFamilyFolderChange = nil
+    }
+
+    private func moveExistingMeetingsTitle(for pendingChange: PendingMeetingFamilyFolderChange) -> String {
+        let count = pendingChange.existingMeetingCount
+        return count == 1 ? "Move 1 saved meeting too" : "Move \(count) saved meetings too"
+    }
+
+    private func meetingFamilyFolderChangeMessage(for pendingChange: PendingMeetingFamilyFolderChange) -> String {
+        let destination = folderDisplayName(for: pendingChange.folderPath)
+        let count = pendingChange.existingMeetingCount
+        let noun = count == 1 ? "saved meeting" : "saved meetings"
+        return "Use \(destination) for future meetings in \"\(pendingChange.familyTitle)\", or move the existing \(count) \(noun) there too."
+    }
+
+    private func folderDisplayName(for folderPath: String?) -> String {
+        folderDefinition(for: folderPath)?.displayName ?? "My notes"
+    }
+
+    private func normalizedMeetingFamilyFolderPath(_ rawPath: String) -> String? {
+        guard let normalized = NotesFolderDefinition.normalizePath(rawPath) else { return nil }
+        return normalized.split(separator: "/").count <= 2 ? normalized : nil
+    }
+
+    private func meetingFamilyFolderChoices(including preferredFolderPath: String?) -> [NotesFolderDefinition] {
+        settings.notesFolders
+            .filter {
+                $0.path.split(separator: "/").count <= 2
+                    || $0.path.localizedCaseInsensitiveCompare(preferredFolderPath ?? "") == .orderedSame
+            }
+            .sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
     }
 
     // MARK: - Tag Editor Popover
@@ -834,6 +1025,7 @@ struct NotesView: View {
                     ScrollView {
                         VStack(alignment: .leading, spacing: 18) {
                             meetingFamilyOverviewSection(
+                                controller: controller,
                                 state: state,
                                 selection: selection,
                                 historyCount: state.meetingHistoryEntries.count
@@ -1009,10 +1201,15 @@ struct NotesView: View {
 
     @ViewBuilder
     private func meetingFamilyOverviewSection(
+        controller: NotesController,
         state: NotesState,
         selection: MeetingFamilySelection,
         historyCount: Int
     ) -> some View {
+        let preferredFolderPath = settings.meetingFamilyPreferences(forHistoryKey: selection.key)?.folderPath
+        let preferredFolder = folderDefinition(for: preferredFolderPath)
+        let folders = meetingFamilyFolderChoices(including: preferredFolderPath)
+
         if let event = selection.upcomingEvent {
             let prepNotes = Binding(
                 get: { settings.meetingPrepNotes(for: event) },
@@ -1030,8 +1227,16 @@ struct NotesView: View {
                             Text(CalendarEventDisplay.timeRange(for: event))
                             if let calendarTitle = event.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
                                !calendarTitle.isEmpty {
-                                Text("Calendar: \(calendarTitle)")
+                                Text(calendarTitle)
                             }
+                            meetingFamilyFolderMenu(
+                                controller: controller,
+                                selection: selection,
+                                historyCount: historyCount,
+                                preferredFolderPath: preferredFolderPath,
+                                preferredFolder: preferredFolder,
+                                folders: folders
+                            )
                         }
                         .font(.system(size: 13))
                         .foregroundStyle(.secondary)
@@ -1061,17 +1266,7 @@ struct NotesView: View {
                     }
                 }
 
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack(spacing: 6) {
-                        Text("Prep notes")
-                            .font(.system(size: 12, weight: .medium))
-                        if !prepNotes.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                            Circle()
-                                .fill(Color.accentColor)
-                                .frame(width: 5, height: 5)
-                        }
-                    }
-
+                VStack(alignment: .leading, spacing: 0) {
                     TextEditor(text: prepNotes)
                         .font(.system(size: 12))
                         .scrollContentBackground(.hidden)
@@ -1079,6 +1274,16 @@ struct NotesView: View {
                         .padding(6)
                         .background(Color(nsColor: .textBackgroundColor).opacity(0.65))
                         .clipShape(RoundedRectangle(cornerRadius: 8))
+                        .overlay(alignment: .topLeading) {
+                            if prepNotes.wrappedValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                                Text("Add prep notes…")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.tertiary)
+                                    .padding(.leading, 11)
+                                    .padding(.top, 10)
+                                    .allowsHitTesting(false)
+                            }
+                        }
                 }
             }
             .padding(18)
@@ -1101,8 +1306,16 @@ struct NotesView: View {
                     Text("\(historyCount) saved meeting\(historyCount == 1 ? "" : "s")")
                     if let calendarTitle = selection.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
                        !calendarTitle.isEmpty {
-                        Text("Calendar: \(calendarTitle)")
+                        Text(calendarTitle)
                     }
+                    meetingFamilyFolderMenu(
+                        controller: controller,
+                        selection: selection,
+                        historyCount: historyCount,
+                        preferredFolderPath: preferredFolderPath,
+                        preferredFolder: preferredFolder,
+                        folders: folders
+                    )
                 }
                 .font(.system(size: 13))
                 .foregroundStyle(.secondary)
@@ -1117,6 +1330,103 @@ struct NotesView: View {
                     .strokeBorder(.quaternary, lineWidth: 1)
             )
         }
+    }
+
+    @ViewBuilder
+    private func meetingFamilyFolderMenu(
+        controller: NotesController,
+        selection: MeetingFamilySelection,
+        historyCount: Int,
+        preferredFolderPath: String?,
+        preferredFolder: NotesFolderDefinition?,
+        folders: [NotesFolderDefinition]
+    ) -> some View {
+        Menu {
+            Button {
+                requestMeetingFamilyFolderChange(
+                    controller: controller,
+                    selection: selection,
+                    folderPath: nil,
+                    historyCount: historyCount
+                )
+            } label: {
+                HStack {
+                    Image(systemName: "folder")
+                        .foregroundStyle(.secondary)
+                    Text("My notes")
+                    if preferredFolderPath == nil {
+                        Spacer()
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+
+            if !folders.isEmpty {
+                Divider()
+                ForEach(folders) { folder in
+                    Button {
+                        requestMeetingFamilyFolderChange(
+                            controller: controller,
+                            selection: selection,
+                            folderPath: folder.path,
+                            historyCount: historyCount
+                        )
+                    } label: {
+                        HStack {
+                            Image(systemName: "folder.fill")
+                                .foregroundStyle(folderColor(for: folder.color))
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text(folder.displayName)
+                                if let breadcrumb = folder.breadcrumb {
+                                    Text(breadcrumb)
+                                        .font(.system(size: 10))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            if preferredFolderPath == folder.path {
+                                Spacer()
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+
+            Divider()
+
+            Button {
+                beginCreateFolder(for: selection)
+            } label: {
+                HStack {
+                    Image(systemName: "folder.badge.plus")
+                    Text("New Folder…")
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: preferredFolderPath == nil ? "folder" : "folder.fill")
+                    .foregroundStyle(folderColor(for: preferredFolder?.color ?? .gray))
+                Text(folderDisplayName(for: preferredFolderPath))
+                    .lineLimit(1)
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+            }
+            .font(.system(size: 12, weight: .medium))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(Color(nsColor: .textBackgroundColor).opacity(0.55))
+            )
+            .overlay(
+                Capsule()
+                    .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+            )
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .fixedSize()
+        .help("Default folder for meetings like this")
     }
 
     @ViewBuilder
@@ -1187,7 +1497,7 @@ struct NotesView: View {
 
                         if let calendarTitle = selection.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
                            !calendarTitle.isEmpty {
-                            Text("Calendar: \(calendarTitle)")
+                            Text(calendarTitle)
                         }
                     }
                     .font(.system(size: 11))

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -271,6 +271,55 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertNil(coordinator.pendingExternalCommand)
     }
 
+    func testFinalizeCurrentSessionAppliesMeetingFamilyFolderPreference() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings,
+            scripted: [Utterance(text: "Hello", speaker: .you)]
+        )
+
+        let event = CalendarEvent(
+            id: "evt-folder",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: true,
+            meetingURL: URL(string: "https://meet.example.com/payment-ops")
+        )
+        settings.setMeetingFamilyFolderPreference("Work/Payments", for: event)
+
+        controller.startSession(settings: settings, calendarEventOverride: event)
+
+        var sessionID: String?
+        for _ in 0..<20 {
+            sessionID = await coordinator.sessionRepository.getCurrentSessionID()
+            if sessionID != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        guard let sessionID else {
+            return XCTFail("Expected session ID after starting session")
+        }
+
+        let utterance = Utterance(
+            text: "Follow up on merchant fees",
+            speaker: .you,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        _ = coordinator.transcriptStore.append(utterance)
+
+        controller.stopSession(settings: settings)
+        await controller.finalizeCurrentSession(settings: settings)
+
+        let detail = await coordinator.sessionRepository.loadSession(id: sessionID)
+        XCTAssertEqual(detail.index.folderPath, "Work/Payments")
+    }
+
     func testFinalizeCurrentSessionCollapsesEmptyGhostSessionIntoRecentRealSession() async {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)
@@ -325,7 +374,6 @@ final class LiveSessionControllerTests: XCTestCase {
         let mergedDetail = await coordinator.sessionRepository.loadSession(id: "session_real")
         XCTAssertEqual(mergedDetail.calendarEvent?.id, event.id)
     }
-
     func testRunningStateChangeCallbackFires() async {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -745,6 +745,41 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(controller.state.selectedTemplate?.id, TemplateStore.standUpID)
     }
 
+    func testApplyMeetingFamilyFolderPreferenceCanMoveExistingSessions() async {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+
+        await seedSession(coordinator: coordinator, sessionID: "current", title: "Weekly All Hands")
+        await seedSession(coordinator: coordinator, sessionID: "older", title: "Weekly All Hands")
+        await controller.loadHistory()
+
+        let event = CalendarEvent(
+            id: "evt_family_folder",
+            title: "Weekly All Hands",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        controller.showMeetingHistory(for: event)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        controller.applyMeetingFamilyFolderPreference("Work/All Hands", moveExistingSessions: true)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertEqual(settings.meetingFamilyPreferences(for: event)?.folderPath, "Work/All Hands")
+        XCTAssertEqual(
+            controller.state.sessionHistory
+                .filter { ["current", "older"].contains($0.id) }
+                .map(\.folderPath),
+            ["Work/All Hands", "Work/All Hands"]
+        )
+    }
+
     func testNormalizedNotesMarkdownPrependsFallbackHeadingWhenMissing() {
         let markdown = NotesController.normalizedNotesMarkdown(
             "## Summary\nHello",

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -457,6 +457,68 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(store.meetingFamilyPreferencesByKey.isEmpty)
     }
 
+    func testMeetingFamilyFolderPreferenceCanonicalizesThroughAliases() {
+        let store = makeStore()
+        store.meetingHistoryAliasesByKey = [
+            "payment ops": "payment ops merchant standup",
+        ]
+
+        let renamedEvent = CalendarEvent(
+            id: "evt-renamed",
+            title: "Payment Ops / Merchant standup",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+        let legacyEvent = CalendarEvent(
+            id: "evt-legacy",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        store.setMeetingFamilyFolderPreference("Work/Payments", for: renamedEvent)
+
+        XCTAssertEqual(
+            store.meetingFamilyPreferences(for: legacyEvent)?.folderPath,
+            "Work/Payments"
+        )
+        XCTAssertEqual(
+            store.meetingFamilyPreferencesByKey[MeetingHistoryResolver.historyKey(for: renamedEvent)]?.folderPath,
+            "Work/Payments"
+        )
+
+        store.setMeetingFamilyFolderPreference(nil, for: legacyEvent)
+        XCTAssertNil(store.meetingFamilyPreferences(for: renamedEvent))
+        XCTAssertTrue(store.meetingFamilyPreferencesByKey.isEmpty)
+    }
+
+    func testMeetingFamilyFolderPreferenceRejectsPathsDeeperThanOneSubfolder() {
+        let store = makeStore()
+        let event = CalendarEvent(
+            id: "evt",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        store.setMeetingFamilyFolderPreference("Work/Payments/Merchant Standup", for: event)
+
+        XCTAssertNil(store.meetingFamilyPreferences(for: event))
+        XCTAssertTrue(store.meetingFamilyPreferencesByKey.isEmpty)
+    }
+
     func testKbFolderURLWhenEmpty() {
         let store = makeStore()
         XCTAssertNil(store.kbFolderURL)


### PR DESCRIPTION
Closes #424

## Summary
- add a meeting-family default folder preference in settings
- surface the folder picker in the meeting-family header metadata row with folder color
- confirm whether a folder change should apply only to future meetings or also move saved meetings
- auto-apply the saved folder when future sessions in that family finalize

## UI
- keep the folder control in the header metadata row near time and calendar
- remove the visible `Prep notes` label and `Calendar:` prefixes from the same card
- keep the two-level folder limit in this workflow (`Work` or `Work/1:1s`)

## Validation
- `swift test --package-path OpenOats --filter SettingsStoreTests`
- `swift test --package-path OpenOats --filter NotesControllerTests`
- `swift test --package-path OpenOats --filter LiveSessionControllerTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`