### PR TITLE
Show knowledge base coverage for meeting families

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -10,6 +10,8 @@ struct NotesState {
     var selectedSessionID: String?
     var selectedMeetingFamily: MeetingFamilySelection?
     var meetingHistoryEntries: [MeetingHistoryEntry] = []
+    var meetingFamilyKnowledgeBaseCoverage: MeetingFamilyKnowledgeBaseCoverage?
+    var isMeetingFamilyKnowledgeBaseLoading: Bool = false
     var relatedMeetingSuggestions: [MeetingHistorySuggestion] = []
     var linkingMeetingSuggestionKey: String?
     var loadedTranscript: [SessionRecord] = []
@@ -98,6 +100,32 @@ struct MeetingHistorySuggestion: Identifiable, Equatable {
     var id: String { key }
 }
 
+struct MeetingFamilyKnowledgeBaseDocument: Identifiable, Equatable {
+    let relativePath: String
+    let title: String
+    let score: Double
+
+    var id: String { relativePath }
+}
+
+struct MeetingFamilyKnowledgeBaseCoverage: Equatable {
+    let documentCount: Int
+    let topDocuments: [MeetingFamilyKnowledgeBaseDocument]
+
+    var badgeText: String {
+        "Knowledge available"
+    }
+
+    var helpText: String {
+        guard !topDocuments.isEmpty else { return "Knowledge base context is available for this meeting family." }
+
+        let lines = topDocuments.enumerated().map { offset, document in
+            "\(offset + 1). \(document.title)"
+        }
+        return "Relevant knowledge base documents:\n" + lines.joined(separator: "\n")
+    }
+}
+
 // MARK: - Controller
 
 /// Owns all notes/history business logic previously embedded in NotesView.
@@ -113,6 +141,7 @@ final class NotesController {
     /// Observation polling task for engine state mapping.
     @ObservationIgnored nonisolated(unsafe) private var engineObservationTask: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var meetingHistoryPreviewTask: Task<Void, Never>?
+    @ObservationIgnored nonisolated(unsafe) private var meetingFamilyKnowledgeBaseTask: Task<Void, Never>?
     @ObservationIgnored private var unsavedManualNotesDraftsBySessionID: [String: String] = [:]
 
     /// The session ID that triggered the currently in-progress generation, if any.
@@ -133,6 +162,7 @@ final class NotesController {
     deinit {
         engineObservationTask?.cancel()
         meetingHistoryPreviewTask?.cancel()
+        meetingFamilyKnowledgeBaseTask?.cancel()
     }
 
     // MARK: - Lifecycle
@@ -191,6 +221,7 @@ final class NotesController {
     func selectSession(_ sessionID: String?) {
         persistCurrentManualNotesDraftIfNeeded()
         cancelMeetingHistoryPreviewHydration()
+        cancelMeetingFamilyKnowledgeBaseLoad()
         state.selectedSessionID = sessionID
         state.selectedMeetingFamily = nil
         state.meetingHistoryEntries = []
@@ -262,6 +293,7 @@ final class NotesController {
     func showMeetingFamily(for event: CalendarEvent) {
         persistCurrentManualNotesDraftIfNeeded()
         cancelMeetingHistoryPreviewHydration()
+        cancelMeetingFamilyKnowledgeBaseLoad()
         state.selectedSessionID = nil
         let selection = Self.meetingFamilySelection(for: event)
         state.selectedMeetingFamily = selection
@@ -956,6 +988,7 @@ final class NotesController {
 
     private func presentMeetingHistory(for selection: MeetingFamilySelection) {
         cancelMeetingHistoryPreviewHydration()
+        loadMeetingFamilyKnowledgeBaseCoverage(for: selection)
 
         let sessions = matchingMeetingHistorySessions(for: selection)
         let entries = sessions.map { MeetingHistoryEntry(session: $0, notesPreview: nil) }
@@ -1000,6 +1033,43 @@ final class NotesController {
     private func cancelMeetingHistoryPreviewHydration() {
         meetingHistoryPreviewTask?.cancel()
         meetingHistoryPreviewTask = nil
+    }
+
+    private func loadMeetingFamilyKnowledgeBaseCoverage(for selection: MeetingFamilySelection) {
+        cancelMeetingFamilyKnowledgeBaseLoad()
+
+        guard let settings,
+              settings.kbFolderURL != nil,
+              let knowledgeBase = coordinator.knowledgeBase,
+              knowledgeBase.isIndexed else {
+            return
+        }
+
+        let query = selection.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty,
+              query.localizedCaseInsensitiveCompare("Untitled") != .orderedSame else {
+            return
+        }
+
+        state.isMeetingFamilyKnowledgeBaseLoading = true
+
+        meetingFamilyKnowledgeBaseTask = Task { [weak self] in
+            guard let self else { return }
+
+            let packs = await knowledgeBase.searchContextPacks(queries: [query], topK: 5)
+            let coverage = Self.meetingFamilyKnowledgeBaseCoverage(from: packs)
+
+            guard state.selectedMeetingFamily?.key == selection.key else { return }
+            state.meetingFamilyKnowledgeBaseCoverage = coverage
+            state.isMeetingFamilyKnowledgeBaseLoading = false
+        }
+    }
+
+    private func cancelMeetingFamilyKnowledgeBaseLoad() {
+        meetingFamilyKnowledgeBaseTask?.cancel()
+        meetingFamilyKnowledgeBaseTask = nil
+        state.meetingFamilyKnowledgeBaseCoverage = nil
+        state.isMeetingFamilyKnowledgeBaseLoading = false
     }
 
     private func loadMeetingHistorySuggestions(
@@ -1092,6 +1162,60 @@ final class NotesController {
             calendarTitle: event.calendarTitle,
             upcomingEvent: event
         )
+    }
+
+    static func meetingFamilyKnowledgeBaseCoverage(
+        from contextPacks: [KBContextPack]
+    ) -> MeetingFamilyKnowledgeBaseCoverage? {
+        var bestDocumentsByPath: [String: MeetingFamilyKnowledgeBaseDocument] = [:]
+
+        for pack in contextPacks {
+            let key = (
+                !pack.relativePath.isEmpty
+                    ? pack.relativePath
+                    : (!pack.documentTitle.isEmpty ? pack.documentTitle : pack.matchedText)
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            guard !key.isEmpty else { continue }
+
+            let document = MeetingFamilyKnowledgeBaseDocument(
+                relativePath: pack.relativePath,
+                title: Self.meetingFamilyKnowledgeBaseDocumentTitle(from: pack),
+                score: pack.score
+            )
+
+            if let existing = bestDocumentsByPath[key], existing.score >= document.score {
+                continue
+            }
+            bestDocumentsByPath[key] = document
+        }
+
+        let documents = bestDocumentsByPath.values.sorted { lhs, rhs in
+            if lhs.score != rhs.score { return lhs.score > rhs.score }
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+        }
+
+        guard !documents.isEmpty else { return nil }
+
+        return MeetingFamilyKnowledgeBaseCoverage(
+            documentCount: documents.count,
+            topDocuments: Array(documents.prefix(3))
+        )
+    }
+
+    private static func meetingFamilyKnowledgeBaseDocumentTitle(from pack: KBContextPack) -> String {
+        let title = pack.documentTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !title.isEmpty {
+            return title
+        }
+
+        let relativePath = pack.relativePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !relativePath.isEmpty {
+            return URL(fileURLWithPath: relativePath).deletingPathExtension().lastPathComponent
+        }
+
+        return "Untitled document"
     }
 
     static func notesPreview(from markdown: String) -> String? {

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -1237,6 +1237,7 @@ struct NotesView: View {
                                 preferredFolder: preferredFolder,
                                 folders: folders
                             )
+                            meetingFamilyKnowledgeBaseSignal(state: state)
                         }
                         .font(.system(size: 13))
                         .foregroundStyle(.secondary)
@@ -1316,6 +1317,7 @@ struct NotesView: View {
                         preferredFolder: preferredFolder,
                         folders: folders
                     )
+                    meetingFamilyKnowledgeBaseSignal(state: state)
                 }
                 .font(.system(size: 13))
                 .foregroundStyle(.secondary)
@@ -1430,6 +1432,49 @@ struct NotesView: View {
     }
 
     @ViewBuilder
+    private func meetingFamilyKnowledgeBaseSignal(state: NotesState) -> some View {
+        if state.isMeetingFamilyKnowledgeBaseLoading {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Searching KB")
+            }
+            .font(.system(size: 12, weight: .medium))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(Color(nsColor: .textBackgroundColor).opacity(0.4))
+            )
+            .overlay(
+                Capsule()
+                    .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
+            )
+            .fixedSize()
+            .help("Looking for relevant knowledge base documents for this meeting family")
+        } else if let coverage = state.meetingFamilyKnowledgeBaseCoverage {
+            HStack(spacing: 6) {
+                Image(systemName: "books.vertical.fill")
+                    .foregroundStyle(.secondary)
+                Text(coverage.badgeText)
+            }
+            .font(.system(size: 12, weight: .medium))
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(Color(nsColor: .textBackgroundColor).opacity(0.4))
+            )
+            .overlay(
+                Capsule()
+                    .strokeBorder(Color.primary.opacity(0.06), lineWidth: 1)
+            )
+            .fixedSize()
+            .help(coverage.helpText)
+        }
+    }
+
+    @ViewBuilder
     private func focusedSessionDetail(controller: NotesController, state: NotesState, selection: MeetingFamilySelection) -> some View {
         VStack(spacing: 0) {
             detailToolbar(controller: controller, state: state)
@@ -1506,6 +1551,8 @@ struct NotesView: View {
             }
 
             Spacer(minLength: 0)
+
+            meetingFamilyKnowledgeBaseSignal(state: state)
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -780,6 +780,46 @@ final class NotesControllerTests: XCTestCase {
         )
     }
 
+    func testMeetingFamilyKnowledgeBaseCoverageDeduplicatesDocumentsByPath() {
+        let coverage = NotesController.meetingFamilyKnowledgeBaseCoverage(from: [
+            KBContextPack(
+                matchedText: "Merchant ops decisions",
+                relativePath: "ops/payment-ops.md",
+                documentTitle: "Payment Ops",
+                score: 0.91
+            ),
+            KBContextPack(
+                matchedText: "Older chunk",
+                relativePath: "ops/payment-ops.md",
+                documentTitle: "Payment Ops",
+                score: 0.44
+            ),
+            KBContextPack(
+                matchedText: "Platform notes",
+                relativePath: "platform/weekly.md",
+                documentTitle: "Weekly Platform",
+                score: 0.72
+            ),
+        ])
+
+        XCTAssertEqual(coverage?.documentCount, 2)
+        XCTAssertEqual(coverage?.topDocuments.map(\.title), ["Payment Ops", "Weekly Platform"])
+    }
+
+    func testMeetingFamilyKnowledgeBaseCoverageFallsBackToDocumentTitleWithoutPath() {
+        let coverage = NotesController.meetingFamilyKnowledgeBaseCoverage(from: [
+            KBContextPack(
+                matchedText: "Roadmap details",
+                relativePath: "",
+                documentTitle: "Roadmap",
+                score: 0.81
+            )
+        ])
+
+        XCTAssertEqual(coverage?.documentCount, 1)
+        XCTAssertEqual(coverage?.topDocuments.first?.title, "Roadmap")
+    }
+
     func testNormalizedNotesMarkdownPrependsFallbackHeadingWhenMissing() {
         let markdown = NotesController.normalizedNotesMarkdown(
             "## Summary\nHello",


### PR DESCRIPTION
Closes #427

## Summary
- run a lightweight title-only knowledge-base lookup when a meeting family is shown
- surface a compact `Knowledge available` signal in the meeting-family header
- keep the signal visible when focusing a past session inside the same family
- dedupe matches by document so the signal reflects coverage rather than chunk count noise

## Notes
- this is a passive coverage signal only
- it does not yet pin documents or inject them automatically into meeting-family notes generation
- the label intentionally emphasizes availability rather than document counts

## Validation
- `swift test --package-path OpenOats --filter NotesControllerTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`