### PR TITLE
Surface session audio in notes

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -28,7 +28,9 @@ struct NotesState {
     var tagFilter: String?
     /// Directory for the currently selected session (used for image loading).
     var selectedSessionDirectory: URL?
-    /// URL of the playable audio file for the selected session (nil if no audio).
+    /// All playable audio sources for the selected session.
+    var availableAudioSources: [SessionAudioSource] = []
+    /// URL of the currently selected playable audio source for the session (nil if no audio).
     var audioFileURL: URL?
     /// Whether audio is currently playing.
     var isPlayingAudio: Bool = false
@@ -84,6 +86,7 @@ struct MeetingHistorySelection: Equatable {
 struct MeetingHistoryEntry: Identifiable {
     let session: SessionIndex
     let notesPreview: String?
+    let hasAudio: Bool
 
     var id: String { session.id }
 }
@@ -206,6 +209,7 @@ final class NotesController {
             state.loadedTranscript = []
             state.loadedCalendarEvent = nil
             state.selectedSessionDirectory = nil
+            state.availableAudioSources = []
             state.audioFileURL = nil
             return
         }
@@ -216,6 +220,7 @@ final class NotesController {
         state.isEditingManualNotes = false
         state.loadedTranscript = []
         state.loadedCalendarEvent = nil
+        state.availableAudioSources = []
         state.audioFileURL = nil
         state.selectedSessionDirectory = coordinator.sessionRepository.sessionsDirectoryURL
             .appendingPathComponent(sessionID, isDirectory: true)
@@ -240,6 +245,7 @@ final class NotesController {
             state.isEditingManualNotes = unsavedDraft != nil
             state.loadedTranscript = data.transcript
             state.loadedCalendarEvent = data.calendarEvent
+            state.availableAudioSources = data.audioSources
             state.audioFileURL = data.audioURL
 
             let session = state.sessionHistory.first { $0.id == sessionID }
@@ -277,6 +283,7 @@ final class NotesController {
         state.loadedTranscript = []
         state.loadedCalendarEvent = nil
         state.selectedSessionDirectory = nil
+        state.availableAudioSources = []
         state.audioFileURL = nil
         state.showingOriginal = false
         state.selectedTemplate = selectedTemplate(
@@ -316,6 +323,7 @@ final class NotesController {
         state.isEditingManualNotes = false
         state.loadedTranscript = []
         state.loadedCalendarEvent = nil
+        state.availableAudioSources = []
         state.audioFileURL = nil
         state.selectedSessionDirectory = nil
         state.showingOriginal = false
@@ -325,25 +333,31 @@ final class NotesController {
 
     // MARK: - Audio Playback
 
-    func toggleAudioPlayback() {
-        guard let url = state.audioFileURL else { return }
+    func toggleAudioPlayback(source: SessionAudioSource? = nil) {
+        let targetURL = source?.url ?? state.audioFileURL ?? state.availableAudioSources.first?.url
+        guard let targetURL else { return }
 
-        if state.isPlayingAudio {
+        let currentPlayerURL = (audioPlayer?.currentItem?.asset as? AVURLAsset)?.url
+        state.audioFileURL = targetURL
+
+        if state.isPlayingAudio, currentPlayerURL == targetURL {
             audioPlayer?.pause()
             state.isPlayingAudio = false
             return
         }
 
-        if audioPlayer?.currentItem?.asset != AVURLAsset(url: url) {
+        if currentPlayerURL != targetURL {
             stopAudio()
-            let player = AVPlayer(url: url)
+            let player = AVPlayer(url: targetURL)
             audioPlayer = player
             playerObservation = NotificationCenter.default.addObserver(
                 forName: .AVPlayerItemDidPlayToEndTime,
                 object: player.currentItem,
                 queue: .main
             ) { [weak self] _ in
-                self?.state.isPlayingAudio = false
+                Task { @MainActor [weak self] in
+                    self?.state.isPlayingAudio = false
+                }
             }
         }
 
@@ -362,7 +376,7 @@ final class NotesController {
     }
 
     func revealAudioInFinder() {
-        guard let url = state.audioFileURL else { return }
+        guard let url = state.audioFileURL ?? state.availableAudioSources.first?.url else { return }
         NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
@@ -958,7 +972,7 @@ final class NotesController {
         cancelMeetingHistoryPreviewHydration()
 
         let sessions = matchingMeetingHistorySessions(for: selection)
-        let entries = sessions.map { MeetingHistoryEntry(session: $0, notesPreview: nil) }
+        let entries = sessions.map { MeetingHistoryEntry(session: $0, notesPreview: nil, hasAudio: false) }
         state.meetingHistoryEntries = entries
         state.relatedMeetingSuggestions = loadMeetingHistorySuggestions(
             for: selection,
@@ -980,6 +994,7 @@ final class NotesController {
                 if Task.isCancelled { return }
 
                 let notes = await coordinator.sessionRepository.loadNotes(sessionID: session.id)
+                let hasAudio = !(await coordinator.sessionRepository.audioSources(for: session.id)).isEmpty
                 let preview = notes.flatMap { Self.notesPreview(from: $0.markdown) }
 
                 guard state.selectedMeetingFamily?.key == selection.key else { return }
@@ -987,10 +1002,12 @@ final class NotesController {
                     continue
                 }
 
-                if state.meetingHistoryEntries[index].notesPreview != preview {
+                if state.meetingHistoryEntries[index].notesPreview != preview
+                    || state.meetingHistoryEntries[index].hasAudio != hasAudio {
                     state.meetingHistoryEntries[index] = MeetingHistoryEntry(
                         session: state.meetingHistoryEntries[index].session,
-                        notesPreview: preview
+                        notesPreview: preview,
+                        hasAudio: hasAudio
                     )
                 }
             }

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -342,6 +342,31 @@ struct GeneratedNotes: Codable, Sendable {
     let markdown: String
 }
 
+enum SessionAudioSourceKind: String, Sendable, Hashable {
+    case recording
+    case system
+    case microphone
+
+    var displayName: String {
+        switch self {
+        case .recording:
+            return "Recording"
+        case .system:
+            return "System audio"
+        case .microphone:
+            return "Microphone"
+        }
+    }
+}
+
+struct SessionAudioSource: Identifiable, Sendable, Hashable {
+    let kind: SessionAudioSourceKind
+    let url: URL
+
+    var id: String { "\(kind.rawValue):\(url.path)" }
+    var displayName: String { kind.displayName }
+}
+
 struct SessionIndex: Identifiable, Codable, Sendable {
     let id: String
     let startedAt: Date

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UniformTypeIdentifiers
 
 // MARK: - Supporting Types
 
@@ -1208,32 +1209,28 @@ actor SessionRepository {
 
     func getCurrentSessionID() -> String? { currentSessionID }
 
-    /// Returns the URL of the playable audio file for a session, if one exists.
-    /// Checks for merged M4A exports and imported audio files.
+    /// Returns the default playable audio source URL for a session, if one exists.
     func audioFileURL(for sessionID: String) -> URL? {
-        let audioDir = sessionDirectory(for: sessionID)
-            .appendingPathComponent("audio", isDirectory: true)
-        let fm = FileManager.default
-        guard fm.fileExists(atPath: audioDir.path) else { return nil }
+        audioSources(for: sessionID).first?.url
+    }
 
-        guard let contents = try? fm.contentsOfDirectory(
-            at: audioDir,
-            includingPropertiesForKeys: nil
-        ) else { return nil }
-
-        // Prefer M4A exports, then imported files — skip raw CAF and batch metadata
-        let skipExtensions: Set<String> = ["caf", "json"]
-        let playable = contents.filter { !skipExtensions.contains($0.pathExtension.lowercased()) }
-        return playable.first
+    func audioSources(for sessionID: String) -> [SessionAudioSource] {
+        SessionRepository.readAudioSources(dir: sessionDirectory(for: sessionID))
     }
 
     // MARK: - Concurrent Session Loading
 
-    /// Loads notes, transcript, audio URL, and persisted calendar context concurrently off the actor.
+    /// Loads notes, transcript, audio sources, and persisted calendar context concurrently off the actor.
     /// Prefer this over separate awaited calls to avoid sequential actor hops.
     nonisolated func loadSessionData(
         sessionID: String
-    ) async -> (notes: GeneratedNotes?, transcript: [SessionRecord], audioURL: URL?, calendarEvent: CalendarEvent?) {
+    ) async -> (
+        notes: GeneratedNotes?,
+        transcript: [SessionRecord],
+        audioURL: URL?,
+        audioSources: [SessionAudioSource],
+        calendarEvent: CalendarEvent?
+    ) {
         let sessDir = sessionsDirectoryURL
         let dir = sessDir.appendingPathComponent(sessionID, isDirectory: true)
 
@@ -1243,14 +1240,15 @@ actor SessionRepository {
         async let transcript = Task.detached(priority: .userInitiated) {
             SessionRepository.readTranscript(sessionID: sessionID, dir: dir, sessionsDirectory: sessDir)
         }.value
-        async let audioURL = Task.detached(priority: .userInitiated) {
-            SessionRepository.readAudioFileURL(dir: dir)
+        async let audioSources = Task.detached(priority: .userInitiated) {
+            SessionRepository.readAudioSources(dir: dir)
         }.value
         async let calendarEvent = Task.detached(priority: .userInitiated) {
             SessionRepository.readCalendarEvent(dir: dir)
         }.value
 
-        return await (notes, transcript, audioURL, calendarEvent)
+        let resolvedAudioSources = await audioSources
+        return await (notes, transcript, resolvedAudioSources.first?.url, resolvedAudioSources, calendarEvent)
     }
 
     private nonisolated static func readNotes(sessionID: String, dir: URL, sessionsDirectory: URL) -> GeneratedNotes? {
@@ -1307,14 +1305,66 @@ actor SessionRepository {
         return LegacySessionReader.loadTranscript(sessionID: sessionID, sessionsDirectory: sessionsDirectory)
     }
 
-    private nonisolated static func readAudioFileURL(dir: URL) -> URL? {
-        let audioDir = dir.appendingPathComponent("audio", isDirectory: true)
+    private nonisolated static func readAudioSources(dir: URL) -> [SessionAudioSource] {
         let fm = FileManager.default
-        guard fm.fileExists(atPath: audioDir.path),
-              let contents = try? fm.contentsOfDirectory(at: audioDir, includingPropertiesForKeys: nil)
+        let audioDir = dir.appendingPathComponent("audio", isDirectory: true)
+        var sources: [SessionAudioSource] = []
+
+        if let url = readPrimaryPlayableAudioURL(in: audioDir) ?? readPrimaryPlayableAudioURL(in: dir) {
+            sources.append(SessionAudioSource(kind: .recording, url: url))
+        }
+
+        let canonicalSystemURL = audioDir.appendingPathComponent("sys.caf")
+        let legacySystemURL = dir.appendingPathComponent("sys.caf")
+        if fm.fileExists(atPath: canonicalSystemURL.path) {
+            sources.append(SessionAudioSource(kind: .system, url: canonicalSystemURL))
+        } else if fm.fileExists(atPath: legacySystemURL.path) {
+            sources.append(SessionAudioSource(kind: .system, url: legacySystemURL))
+        }
+
+        let canonicalMicURL = audioDir.appendingPathComponent("mic.caf")
+        let legacyMicURL = dir.appendingPathComponent("mic.caf")
+        if fm.fileExists(atPath: canonicalMicURL.path) {
+            sources.append(SessionAudioSource(kind: .microphone, url: canonicalMicURL))
+        } else if fm.fileExists(atPath: legacyMicURL.path) {
+            sources.append(SessionAudioSource(kind: .microphone, url: legacyMicURL))
+        }
+
+        return sources
+    }
+
+    private nonisolated static func readPrimaryPlayableAudioURL(in dir: URL) -> URL? {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: dir.path),
+              let contents = try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
         else { return nil }
         let skipExtensions: Set<String> = ["caf", "json"]
-        return contents.filter { !skipExtensions.contains($0.pathExtension.lowercased()) }.first
+        let skipFilenames: Set<String> = [
+            "session.json",
+            "transcript.live.jsonl",
+            "transcript.final.jsonl",
+            "notes.md",
+            "notes.meta.json",
+            "batch-meta.json",
+            "mic.caf",
+            "sys.caf",
+        ]
+        return contents
+            .filter {
+                var isDirectory: ObjCBool = false
+                guard fm.fileExists(atPath: $0.path, isDirectory: &isDirectory), !isDirectory.boolValue else {
+                    return false
+                }
+                guard !skipFilenames.contains($0.lastPathComponent.lowercased()) else {
+                    return false
+                }
+                let pathExtension = $0.pathExtension.lowercased()
+                guard !skipExtensions.contains(pathExtension) else { return false }
+                guard let contentType = UTType(filenameExtension: pathExtension) else { return false }
+                return contentType.conforms(to: .audio)
+            }
+            .sorted { $0.lastPathComponent.localizedCaseInsensitiveCompare($1.lastPathComponent) == .orderedAscending }
+            .first
     }
 
     // MARK: - Private Helpers

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -1550,6 +1550,13 @@ struct NotesView: View {
                                             .font(.system(size: 11, weight: .medium))
                                             .foregroundStyle(folderColor(for: entry.session.folderPath))
                                     }
+
+                                    if entry.hasAudio {
+                                        Image(systemName: "waveform")
+                                            .font(.system(size: 11, weight: .medium))
+                                            .foregroundStyle(.secondary)
+                                            .help("Audio recording available")
+                                    }
                                 }
 
                                 HStack(spacing: 8) {
@@ -1657,7 +1664,7 @@ struct NotesView: View {
                 notesToolbarActions(controller: controller, state: state)
             }
 
-            if state.audioFileURL != nil {
+            if !state.availableAudioSources.isEmpty {
                 audioPlaybackButton(controller: controller, state: state)
             }
 
@@ -1774,14 +1781,24 @@ struct NotesView: View {
 
     @ViewBuilder
     private func audioPlaybackButton(controller: NotesController, state: NotesState) -> some View {
+        let sources = state.availableAudioSources
+        let selectedURL = state.audioFileURL ?? sources.first?.url
+
         Menu {
-            Button {
-                controller.toggleAudioPlayback()
-            } label: {
-                Label(
-                    state.isPlayingAudio ? "Pause" : "Play Recording",
-                    systemImage: state.isPlayingAudio ? "pause.fill" : "play.fill"
-                )
+            ForEach(sources) { source in
+                let isSelectedSource = selectedURL == source.url
+                let actionTitle = state.isPlayingAudio && isSelectedSource
+                    ? "Pause \(source.displayName)"
+                    : "Play \(source.displayName)"
+
+                Button {
+                    controller.toggleAudioPlayback(source: source)
+                } label: {
+                    Label(
+                        actionTitle,
+                        systemImage: state.isPlayingAudio && isSelectedSource ? "pause.fill" : "play.fill"
+                    )
+                }
             }
             Divider()
             Button {

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -160,6 +160,27 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(controller.state.loadedCalendarEvent?.participants.count, 2)
     }
 
+    func testSelectSessionLoadsRawAudioSources() async throws {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_raw_audio_sources"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID)
+
+        let audioDir = coordinator.sessionRepository.sessionsDirectoryURL
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+        try Data("sys".utf8).write(to: audioDir.appendingPathComponent("sys.caf"))
+        try Data("mic".utf8).write(to: audioDir.appendingPathComponent("mic.caf"))
+
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(controller.state.availableAudioSources.map(\.kind), [.system, .microphone])
+        XCTAssertEqual(controller.state.audioFileURL?.lastPathComponent, "sys.caf")
+    }
+
     func testGenerateNotesUpdatesStatus() async {
         let (root, notes) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -713,6 +713,30 @@ final class SessionRepositoryTests: XCTestCase {
         XCTAssertNil(meta)
     }
 
+    func testAudioSourcesExposeRawBatchAudioFiles() async throws {
+        let sessionID = "session_batch_audio_sources"
+        _ = try makeSessionWithBatchAudio(sessionID: sessionID)
+
+        let sources = await repo.audioSources(for: sessionID)
+        let defaultAudioURL = await repo.audioFileURL(for: sessionID)
+
+        XCTAssertEqual(sources.map(\.kind), [.system, .microphone])
+        XCTAssertEqual(sources.first?.url.lastPathComponent, "sys.caf")
+        XCTAssertEqual(sources.last?.url.lastPathComponent, "mic.caf")
+        XCTAssertEqual(defaultAudioURL?.lastPathComponent, "sys.caf")
+    }
+
+    func testAudioSourcesIgnoreTranscriptBackupFiles() async throws {
+        let sessionID = "session_ignores_transcript_backup"
+        let sessionDir = try makeSessionWithBatchAudio(sessionID: sessionID)
+        let backupURL = sessionDir.appendingPathComponent("transcript.live.jsonl.pre-cleanup.bak")
+        try Data().write(to: backupURL, options: .atomic)
+
+        let sources = await repo.audioSources(for: sessionID)
+
+        XCTAssertEqual(sources.map(\.kind), [.system, .microphone])
+    }
+
     // MARK: - moveToRecentlyDeleted
 
     func testMoveToRecentlyDeleted() async {


### PR DESCRIPTION
## Summary
- surface raw session audio in the Notes detail view
- expose audio availability on meeting history cards
- support playback for system and microphone recordings when a merged export does not exist

## Root cause
OpenOats only treated non-`.caf` files as playable session audio. Most live sessions only retain raw `audio/sys.caf` and `audio/mic.caf`, so the Notes UI reported no audio even when recordings existed on disk.

A second bug in the first pass was that transcript backup files in the session root could be misclassified as a generic recording source. This patch narrows primary recording detection to actual audio file types and ignores session artifacts.

## What changed
- added explicit `SessionAudioSource` handling for recording, system, and microphone sources
- updated session loading to return all available audio sources, not just a single URL
- updated the Notes toolbar playback menu to handle multiple sources cleanly
- added a waveform indicator to meeting history rows when audio exists
- added repository and controller regression tests for raw audio discovery and junk-file filtering

## Impact
Sessions that already have raw audio on disk now surface audio truthfully in Notes. Users can play the system or microphone recording directly, and meeting history gives a lightweight signal that audio is available for that session.

## Validation
- `swift test --package-path OpenOats --filter 'SessionRepositoryTests|NotesControllerTests'`
- `swift test --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
