### PR TITLE
Update Homebrew cask for 1.59.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.58.0"
-  sha256 "cbda4b697914ff18c34cac7a5992646a54d4eb9f54fdcef498c1b7aff131cb8e"
+  version "1.59.0"
+  sha256 "21adebd84ca30ef25a4af5dd33fcbc23929602ef876117d50446d52198414ae0"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Update Homebrew cask version to 1.59.0 and sha256 to match the latest release DMG

Automated update from the release-dmg workflow.