### PR TITLE
fix: raise LLM request timeout to 300s to unblock slow completions

### DIFF
--- a/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
@@ -77,6 +77,10 @@ actor OpenRouterClient {
 
                     var urlRequest = URLRequest(url: targetURL)
                     urlRequest.httpMethod = "POST"
+                    // Idle timeout between streamed bytes. Must cover cold-start of local models
+                    // (Ollama/MLX) and first-token latency of reasoning models, which routinely
+                    // exceed URLRequest's 60s default.
+                    urlRequest.timeoutInterval = 300
                     urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
                     if let apiKey, !apiKey.isEmpty {
                         urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
@@ -142,6 +146,9 @@ actor OpenRouterClient {
         )
         var urlRequest = URLRequest(url: targetURL)
         urlRequest.httpMethod = "POST"
+        // Total request timeout — covers gate / judge / structured-JSON calls that may hit
+        // slow local models or reasoning models. Default 60s is too aggressive in practice.
+        urlRequest.timeoutInterval = 300
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let apiKey, !apiKey.isEmpty {
             urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")


### PR DESCRIPTION
## Summary

- `OpenRouterClient` was constructing `URLRequest` without setting `timeoutInterval`, so it silently inherited Foundation's default of 60 seconds. For `URLSession.bytes(for:)` that default acts as the **idle-between-bytes** timeout, not a total budget — any >60s gap before the next chunk kills an otherwise healthy stream.
- Notes generation hits this reliably against cold Ollama/MLX models, reasoning models with long hidden chain-of-thought, and long transcripts where first-token latency exceeds 60s. Symptom: `URLError.timedOut` surfacing as `notesGenerationStatus = .error(...)` in `NotesView`.
- Fix sets `urlRequest.timeoutInterval = 300` on both the streaming path (`streamCompletion`) and the non-streaming path (`complete`, used by the gate / judge / structured-JSON callers in the suggestion + sidecast pipelines), which are vulnerable to the same default.

## Why 300s

- Long enough to cover realistic cold-start + first-token latency on local Ollama/MLX and reasoning models with extended thinking budgets.
- Short enough to give up on a genuinely dead TCP connection.
- For streaming, remember this is the *idle* timeout between bytes — the clock resets on each chunk, so it does not cap legitimately long completions.

## Test plan

- [x] `swift build -c debug` — clean
- [x] `./scripts/build_swift_app.sh` — builds, signs, installs to `/Applications/OpenOats.app`
- [ ] Reproduce original bug: point notes generation at a freshly-loaded large Ollama model (e.g. `llama3.1:70b`) or an OpenRouter reasoning model on a long transcript and confirm 60s timeout no longer fires
- [ ] Confirm no regressions on a fast cloud model (suggestions / sidecast gate still responsive)
- [ ] Optional: add a unit test that injects a stream which pauses >60s before yielding bytes and asserts the stream completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)