### PR TITLE
Fix transcription settings tab crash when enumerating devices

### DIFF
--- a/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
@@ -319,7 +319,7 @@ final class MicCapture: @unchecked Sendable {
             status = AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, &name)
             guard status == noErr, let name else { continue }
 
-            result.append((id: deviceID, name: name.takeRetainedValue() as String))
+            result.append((id: deviceID, name: name.takeUnretainedValue() as String))
         }
 
         return result
@@ -336,7 +336,7 @@ final class MicCapture: @unchecked Sendable {
         var size = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
         let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &uid)
         guard status == noErr, let uid else { return nil }
-        return uid.takeRetainedValue() as String
+        return uid.takeUnretainedValue() as String
     }
 
     /// Query the nominal sample rate of a CoreAudio device directly from hardware.

--- a/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
@@ -316,7 +316,7 @@ final class SystemAudioCapture: @unchecked Sendable {
             var nameAddress = propertyAddress(selector: kAudioObjectPropertyName)
             var cfName: Unmanaged<CFString>?
             var nameSize = UInt32(MemoryLayout<Unmanaged<CFString>?>.size)
-            guard AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, &cfName) == noErr, let name = cfName?.takeRetainedValue() as String? else { continue }
+            guard AudioObjectGetPropertyData(deviceID, &nameAddress, 0, nil, &nameSize, &cfName) == noErr, let name = cfName?.takeUnretainedValue() as String? else { continue }
 
             result.append((id: deviceID, name: name))
         }
@@ -353,7 +353,7 @@ final class SystemAudioCapture: @unchecked Sendable {
         guard status == noErr, let uid else {
             throw CaptureError.outputDeviceUIDUnavailable(status)
         }
-        return uid.takeRetainedValue() as String
+        return uid.takeUnretainedValue() as String
     }
 
     private static func tapStreamDescription(for tapID: AudioObjectID) throws -> AudioStreamBasicDescription {


### PR DESCRIPTION
Fixes #337.

## Summary
- correct CoreAudio CFString ownership in microphone device enumeration
- correct CoreAudio CFString ownership in output device enumeration
- avoid over-releasing device name and UID values while building the transcription settings tab

## Why
Opening the Transcription settings tab enumerates input/output devices on appear. Those code paths were using `takeRetainedValue()` for CoreAudio-provided CFStrings, which is the wrong ownership assumption here and is a plausible source of the malloc corruption reported in #337.

## Validation
- `swift build -c debug`
- `swift test` *(current main still has unrelated `MeetingDetectorTests` failures)*
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`