### PR TITLE
Update Homebrew cask for 1.60.1

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.60.0"
-  sha256 "289ec4fa9f75d8816d706e7cf8f4b725ef9dde25ee183229f3bd0fd22f8472d1"
+  version "1.60.1"
+  sha256 "07e71770b858ae38d4749b769e13843cc4030e43c0bc82abdc2df417a02777e9"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Bump cask version from 1.60.0 to 1.60.1
- Update SHA256 to match the 1.60.1 DMG

Automated cask update from the release workflow.