### PR TITLE
Make knowledge base indexing lazy on startup

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -56,9 +56,10 @@ final class LiveSessionController {
     private var observedAudioLevel: Float = 0
     private var observedSuggestions: [Suggestion] = []
     private var observedIsGenerating = false
-    private var observedKBFolderPath = ""
+    private var observedKBFolderPath: String?
     private var observedNotesFolderPath = ""
-    private var observedVoyageApiKey = ""
+    private var observedEmbeddingProvider: EmbeddingProvider?
+    private var observedVoyageApiKey: String?
     private var observedTranscriptionModel: TranscriptionModel = .parakeetV2
     private var observedInputDeviceID: AudioDeviceID = 0
     private var observedPendingExternalCommandID: UUID?
@@ -187,6 +188,11 @@ final class LiveSessionController {
             kb.clear()
             await kb.index(folderURL: url)
         }
+    }
+
+    func loadKBCacheIfAvailable(settings: AppSettings) {
+        guard let url = settings.kbFolderURL, let kb = coordinator.knowledgeBase else { return }
+        _ = kb.loadCachedStateIfAvailable(folderURL: url)
     }
 
     // MARK: - External Commands
@@ -640,12 +646,21 @@ final class LiveSessionController {
     private func synchronizeDerivedState(settings: AppSettings) {
         let currentState = state
 
-        if settings.kbFolderPath != observedKBFolderPath {
+        if let observedKBFolderPath {
+            if settings.kbFolderPath != observedKBFolderPath {
+                self.observedKBFolderPath = settings.kbFolderPath
+                if settings.kbFolderPath.isEmpty {
+                    coordinator.knowledgeBase?.clear()
+                } else {
+                    indexKBIfNeeded(settings: settings)
+                }
+            }
+        } else {
             observedKBFolderPath = settings.kbFolderPath
             if settings.kbFolderPath.isEmpty {
                 coordinator.knowledgeBase?.clear()
             } else {
-                indexKBIfNeeded(settings: settings)
+                loadKBCacheIfAvailable(settings: settings)
             }
         }
 
@@ -665,13 +680,34 @@ final class LiveSessionController {
             }
         }
 
-        if !settings.kbFolderPath.isEmpty,
-           settings.embeddingProvider == .voyageAI,
-           settings.voyageApiKey != observedVoyageApiKey {
-            observedVoyageApiKey = settings.voyageApiKey
-            indexKBIfNeeded(settings: settings)
-        } else if settings.kbFolderPath.isEmpty || settings.embeddingProvider != .voyageAI {
-            observedVoyageApiKey = ""
+        if settings.kbFolderPath.isEmpty {
+            observedEmbeddingProvider = nil
+            observedVoyageApiKey = nil
+        } else {
+            if let observedEmbeddingProvider {
+                if settings.embeddingProvider != observedEmbeddingProvider {
+                    self.observedEmbeddingProvider = settings.embeddingProvider
+                    indexKBIfNeeded(settings: settings)
+                }
+            } else {
+                observedEmbeddingProvider = settings.embeddingProvider
+            }
+
+            if settings.embeddingProvider == .voyageAI {
+                if settings.isSecretLoaded("voyageApiKey") {
+                    let voyageApiKey = settings.voyageApiKey
+                    if let observedVoyageApiKey {
+                        if voyageApiKey != observedVoyageApiKey {
+                            self.observedVoyageApiKey = voyageApiKey
+                            indexKBIfNeeded(settings: settings)
+                        }
+                    } else {
+                        observedVoyageApiKey = voyageApiKey
+                    }
+                }
+            } else {
+                observedVoyageApiKey = nil
+            }
         }
 
         if settings.transcriptionModel != observedTranscriptionModel {

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -1057,8 +1057,7 @@ final class NotesController {
 
         guard let settings,
               settings.kbFolderURL != nil,
-              let knowledgeBase = coordinator.knowledgeBase,
-              knowledgeBase.isIndexed else {
+              let knowledgeBase = coordinator.knowledgeBase else {
             return
         }
 

--- a/OpenOats/Sources/OpenOats/Intelligence/KnowledgeBase.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/KnowledgeBase.swift
@@ -40,6 +40,8 @@ private struct KBCache: Codable, Sendable {
     var entries: [String: [KBChunk]]
     /// Fingerprint of the embedding config used to produce these vectors.
     var embeddingConfigFingerprint: String?
+    /// Canonical folder path the cache was built from.
+    var folderPath: String?
 }
 
 enum KnowledgeBaseIndexingStatus: Equatable, Sendable {
@@ -185,6 +187,29 @@ final class KnowledgeBase {
         self.settings = settings
     }
 
+    /// Restore indexed chunks from disk without re-scanning the configured folder.
+    /// Returns true only when the cached embedding config and folder path match.
+    @discardableResult
+    func loadCachedStateIfAvailable(folderURL: URL) -> Bool {
+        let cache = loadCache()
+        let fingerprint = embeddingConfigFingerprint()
+        let canonicalFolderPath = Self.canonicalFolderPath(folderURL)
+
+        guard cache.embeddingConfigFingerprint == fingerprint,
+              cache.folderPath == canonicalFolderPath else {
+            return false
+        }
+
+        let cachedChunks = cache.entries.values.flatMap { $0 }
+        guard !cachedChunks.isEmpty else {
+            return false
+        }
+
+        finishIndexing(chunks: cachedChunks, fileCount: cache.entries.count)
+        indexingStatus = .idle
+        return true
+    }
+
     func index(folderURL: URL) async {
         let provider = settings.embeddingProvider
 
@@ -200,9 +225,14 @@ final class KnowledgeBase {
 
         // Load existing cache; invalidate if embedding config changed
         let fingerprint = embeddingConfigFingerprint()
+        let canonicalFolderPath = Self.canonicalFolderPath(folderURL)
         var cache = loadCache()
-        if cache.embeddingConfigFingerprint != fingerprint {
-            cache = KBCache(entries: [:], embeddingConfigFingerprint: fingerprint)
+        if cache.embeddingConfigFingerprint != fingerprint || cache.folderPath != canonicalFolderPath {
+            cache = KBCache(
+                entries: [:],
+                embeddingConfigFingerprint: fingerprint,
+                folderPath: canonicalFolderPath
+            )
         }
 
         // Move all blocking file I/O off the main thread
@@ -375,6 +405,8 @@ final class KnowledgeBase {
     /// Core search implementation. Returns chunk indices alongside results so callers
     /// don't need to re-scan the chunks array to locate matched entries.
     private func searchRaw(queries: [String], topK: Int) async -> [(chunkIndex: Int, result: KBResult)] {
+        await ensureSearchReady()
+
         let provider = settings.embeddingProvider
         guard isIndexed, !chunks.isEmpty else { return [] }
 
@@ -820,11 +852,23 @@ final class KnowledgeBase {
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 
+    private func ensureSearchReady() async {
+        guard !isIndexed, let folderURL = settings.kbFolderURL else { return }
+        if loadCachedStateIfAvailable(folderURL: folderURL) {
+            return
+        }
+        await index(folderURL: folderURL)
+    }
+
     // MARK: - Hashing
 
     private nonisolated static func sha256Static(_ string: String) -> String {
         let data = Data(string.utf8)
         let hash = SHA256.hash(data: data)
         return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    private nonisolated static func canonicalFolderPath(_ url: URL) -> String {
+        url.standardizedFileURL.path
     }
 }

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -29,6 +29,10 @@ final class SettingsStore {
         loadedSecretKeys.insert(key)
     }
 
+    func isSecretLoaded(_ key: String) -> Bool {
+        loadedSecretKeys.contains(key)
+    }
+
     // MARK: - AI Settings
 
     @ObservationIgnored nonisolated(unsafe) private var _llmProvider: LLMProvider

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -302,7 +302,6 @@ struct ContentView: View {
             overlayManager.defaults = container.defaults
             miniBarManager.defaults = container.defaults
             await container.seedIfNeeded(coordinator: coordinator)
-            controller.indexKBIfNeeded(settings: settings)
             controller.handlePendingExternalCommandIfPossible(settings: settings) {
                 openWindow(id: "notes")
             }

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -443,6 +443,52 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertFalse(tracker.loadedKeys.contains("voyageApiKey"))
     }
 
+    func testPollingDoesNotReadVoyageKeyOnStartupWhenKnowledgeBaseFolderSet() async {
+        let dirs = makeTempDirs()
+        let kbDirectory = dirs.root.appendingPathComponent("KnowledgeBase", isDirectory: true)
+        try? FileManager.default.createDirectory(at: kbDirectory, withIntermediateDirectories: true)
+
+        let tracker = SecretLoadTracker()
+        let secretStore = AppSecretStore(
+            loadValue: { key in
+                tracker.loadedKeys.append(key)
+                return key == "voyageApiKey" ? "pa-existing" : nil
+            },
+            saveValue: { _, _ in }
+        )
+        let settings = makeSettings(notesDirectory: dirs.notes, secretStore: secretStore)
+        settings.kbFolderPath = kbDirectory.path
+        settings.embeddingProvider = .voyageAI
+
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings
+        )
+        let knowledgeBase = KnowledgeBase(settings: settings)
+        coordinator.setViewServices(
+            knowledgeBase: knowledgeBase,
+            suggestionEngine: SuggestionEngine(
+                transcriptStore: coordinator.transcriptStore,
+                knowledgeBase: knowledgeBase,
+                settings: settings
+            ),
+            sidecastEngine: SidecastEngine(
+                transcriptStore: coordinator.transcriptStore,
+                knowledgeBase: knowledgeBase,
+                settings: settings
+            )
+        )
+
+        let task = Task {
+            await controller.runPollingLoop(settings: settings)
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+        task.cancel()
+
+        XCTAssertFalse(tracker.loadedKeys.contains("voyageApiKey"))
+    }
+
     func testFullSessionLifecycle() async {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)


### PR DESCRIPTION
Closes #437

## Summary
- stop forcing a full knowledge-base reindex during app startup
- restore cached KB state on first sync when the cache still matches the configured folder and embedding settings
- let KB-backed retrieval paths lazily load from cache or index on demand
- keep real reindexing for actual KB config changes such as folder, provider, or loaded Voyage key changes

## Why
The previous startup path treated a configured KB folder as a signal to immediately clear and rebuild the KB. That was too eager for the current product shape and could front-load provider work and secret access before the user entered any KB-backed flow.

## Validation
- `swift build -c debug --package-path OpenOats`
- `swift test --package-path OpenOats --filter 'LiveSessionControllerTests|KnowledgeBaseTests|NotesControllerTests'`\n- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`