### PR TITLE
Make startup service initialization lazy

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppContainer.swift
+++ b/OpenOats/Sources/OpenOats/App/AppContainer.swift
@@ -24,7 +24,8 @@ final class AppContainer {
     private(set) var calendarManager: CalendarManager?
 
     private var didSeedInitialData = false
-    private var didInitializeServices = false
+    private var didInitializeViewServices = false
+    private var didInitializeRecordingServices = false
 
     init(
         mode: AppRuntimeMode,
@@ -125,7 +126,7 @@ final class AppContainer {
         }
     }
 
-    func makeServices(settings: AppSettings, coordinator: AppCoordinator) -> AppServices {
+    func makeViewServices(settings: AppSettings, coordinator: AppCoordinator) -> AppViewServices {
         let knowledgeBase = KnowledgeBase(settings: settings)
         let suggestionEngine = SuggestionEngine(
             transcriptStore: coordinator.transcriptStore,
@@ -138,6 +139,14 @@ final class AppContainer {
             settings: settings
         )
 
+        return AppViewServices(
+            knowledgeBase: knowledgeBase,
+            suggestionEngine: suggestionEngine,
+            sidecastEngine: sidecastEngine
+        )
+    }
+
+    func makeRecordingServices(settings: AppSettings, coordinator: AppCoordinator) -> AppRecordingServices {
         let transcriptionEngine: TranscriptionEngine
         switch mode {
         case .live:
@@ -153,10 +162,7 @@ final class AppContainer {
             )
         }
 
-        return AppServices(
-            knowledgeBase: knowledgeBase,
-            suggestionEngine: suggestionEngine,
-            sidecastEngine: sidecastEngine,
+        return AppRecordingServices(
             transcriptionEngine: transcriptionEngine,
             liveTranscriptCleaner: LiveTranscriptCleaner(
                 settings: settings,
@@ -167,20 +173,40 @@ final class AppContainer {
         )
     }
 
-    func ensureServicesInitialized(settings: AppSettings, coordinator: AppCoordinator) {
-        guard !didInitializeServices else { return }
-        didInitializeServices = true
+    func ensureViewServicesInitialized(settings: AppSettings, coordinator: AppCoordinator) {
+        if coordinator.knowledgeBase != nil {
+            didInitializeViewServices = true
+            return
+        }
+        guard !didInitializeViewServices else { return }
+        didInitializeViewServices = true
 
-        let services = makeServices(settings: settings, coordinator: coordinator)
-        coordinator.transcriptionEngine = services.transcriptionEngine
-        coordinator.liveTranscriptCleaner = services.liveTranscriptCleaner
-        coordinator.audioRecorder = services.audioRecorder
-        coordinator.batchAudioTranscriber = services.batchAudioTranscriber
+        let services = makeViewServices(settings: settings, coordinator: coordinator)
         coordinator.setViewServices(
             knowledgeBase: services.knowledgeBase,
             suggestionEngine: services.suggestionEngine,
             sidecastEngine: services.sidecastEngine
         )
+    }
+
+    func ensureRecordingServicesInitialized(settings: AppSettings, coordinator: AppCoordinator) {
+        if coordinator.transcriptionEngine != nil {
+            didInitializeRecordingServices = true
+            return
+        }
+        guard !didInitializeRecordingServices else { return }
+        didInitializeRecordingServices = true
+
+        let services = makeRecordingServices(settings: settings, coordinator: coordinator)
+        coordinator.transcriptionEngine = services.transcriptionEngine
+        coordinator.liveTranscriptCleaner = services.liveTranscriptCleaner
+        coordinator.audioRecorder = services.audioRecorder
+        coordinator.batchAudioTranscriber = services.batchAudioTranscriber
+    }
+
+    func ensureMeetingServicesInitialized(settings: AppSettings, coordinator: AppCoordinator) {
+        ensureViewServicesInitialized(settings: settings, coordinator: coordinator)
+        ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
     }
 
     /// Create and start the detection controller, wire the coordinator event loop.

--- a/OpenOats/Sources/OpenOats/App/AppLaunchContext.swift
+++ b/OpenOats/Sources/OpenOats/App/AppLaunchContext.swift
@@ -12,10 +12,13 @@ enum AppRuntimeMode {
     case uiTest(UITestScenario)
 }
 
-struct AppServices {
+struct AppViewServices {
     let knowledgeBase: KnowledgeBase
     let suggestionEngine: SuggestionEngine
     let sidecastEngine: SidecastEngine
+}
+
+struct AppRecordingServices {
     let transcriptionEngine: TranscriptionEngine
     let liveTranscriptCleaner: LiveTranscriptCleaner
     let audioRecorder: AudioRecorder

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -132,6 +132,7 @@ final class LiveSessionController {
         initialScratchpad: String? = nil
     ) {
         guard !state.isRunning else { return }
+        container.ensureMeetingServicesInitialized(settings: settings, coordinator: coordinator)
         coordinator.suggestionEngine?.clear()
         coordinator.sidecastEngine?.clear()
         let calEvent = calendarEventOverride ?? (settings.calendarIntegrationEnabled
@@ -147,12 +148,14 @@ final class LiveSessionController {
     }
 
     func confirmDownloadAndStart(settings: AppSettings) {
+        container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
         coordinator.transcriptionEngine?.downloadConfirmed = true
         startSession(settings: settings)
     }
 
     func downloadModelOnly(settings: AppSettings) {
         guard downloadTask == nil else { return }
+        container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
         downloadTask = Task {
             await coordinator.transcriptionEngine?.downloadModelOnly(
                 transcriptionModel: settings.transcriptionModel
@@ -203,6 +206,7 @@ final class LiveSessionController {
 
         switch request.command {
         case .startSession(let calendarEvent, let scratchpadSeed):
+            container.ensureMeetingServicesInitialized(settings: settings, coordinator: coordinator)
             guard coordinator.transcriptionEngine != nil,
                   (coordinator.suggestionEngine != nil || coordinator.sidecastEngine != nil) else { return }
             if !state.isRunning {

--- a/OpenOats/Sources/OpenOats/App/MenuBarController.swift
+++ b/OpenOats/Sources/OpenOats/App/MenuBarController.swift
@@ -8,6 +8,7 @@ final class MenuBarController {
     private let popover: NSPopover
     private let coordinator: AppCoordinator
     private let settings: AppSettings
+    private let onToggleMeeting: () -> Void
     private var iconUpdateTask: Task<Void, Never>?
 
     var onShowMainWindow: (() -> Void)?
@@ -16,10 +17,12 @@ final class MenuBarController {
     init(
         coordinator: AppCoordinator,
         settings: AppSettings,
-        onCheckForUpdates: @escaping () -> Void
+        onCheckForUpdates: @escaping () -> Void,
+        onToggleMeeting: @escaping () -> Void
     ) {
         self.coordinator = coordinator
         self.settings = settings
+        self.onToggleMeeting = onToggleMeeting
 
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
         self.popover = NSPopover()
@@ -30,6 +33,7 @@ final class MenuBarController {
         let popoverView = MenuBarPopoverView(
             coordinator: coordinator,
             settings: settings,
+            onToggleMeeting: onToggleMeeting,
             onShowMainWindow: { [weak self] in
                 self?.popover.performClose(nil)
                 self?.onShowMainWindow?()

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -150,6 +150,7 @@ extension OpenOatsRootApp {
 
         guard panel.runModal() == .OK, let fileURL = panel.url else { return }
 
+        container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
         guard let batchAudioTranscriber = coordinator.batchAudioTranscriber else { return }
 
         let model = settings.transcriptionModel
@@ -244,12 +245,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     ) {
         guard menuBarController == nil else { return }
 
-        container?.ensureServicesInitialized(settings: settings, coordinator: coordinator)
-
         let controller = MenuBarController(
             coordinator: coordinator,
             settings: settings,
-            onCheckForUpdates: checkForUpdates
+            onCheckForUpdates: checkForUpdates,
+            onToggleMeeting: { [weak self] in
+                self?.toggleMeeting()
+            }
         )
         controller.onShowMainWindow = showMainWindow
         controller.onQuitApp = { [weak self] in
@@ -431,6 +433,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func toggleMeeting() {
         guard let coordinator, let settings else { return }
         guard settings.hasAcknowledgedRecordingConsent else { return }
+
+        container?.ensureMeetingServicesInitialized(settings: settings, coordinator: coordinator)
 
         if coordinator.isRecording {
             coordinator.handle(.userStopped, settings: settings)

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -261,9 +261,6 @@ struct ContentView: View {
             if !hasCompletedOnboarding {
                 showOnboarding = true
             }
-            if coordinator.knowledgeBase == nil {
-                container.ensureServicesInitialized(settings: settings, coordinator: coordinator)
-            }
 
             // Create and wire the controller
             let controller = LiveSessionController(coordinator: coordinator, container: container)

--- a/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
+++ b/OpenOats/Sources/OpenOats/Views/MenuBarPopoverView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct MenuBarPopoverView: View {
     let coordinator: AppCoordinator
     let settings: AppSettings
+    let onToggleMeeting: () -> Void
     let onShowMainWindow: () -> Void
     let onCheckForUpdates: () -> Void
     let onShowSettings: () -> Void
@@ -125,9 +126,7 @@ struct MenuBarPopoverView: View {
     @ViewBuilder
     private var primaryAction: some View {
         if coordinator.isRecording {
-            Button(action: {
-                coordinator.handle(.userStopped, settings: settings)
-            }) {
+            Button(action: onToggleMeeting) {
                 Text("Stop Recording")
                     .font(.system(size: 13, weight: .medium))
                     .frame(maxWidth: .infinity)
@@ -140,7 +139,7 @@ struct MenuBarPopoverView: View {
                     onShowMainWindow()
                     return
                 }
-                coordinator.handle(.userStarted(.manual()), settings: settings)
+                onToggleMeeting()
             }) {
                 Text("Start Recording")
                     .font(.system(size: 13, weight: .medium))

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 
 struct NotesView: View {
     @Bindable var settings: AppSettings
+    @Environment(AppContainer.self) private var container
     @Environment(AppCoordinator.self) private var coordinator
     @Environment(\.openWindow) private var openWindow
     @State private var notesController: NotesController?
@@ -56,6 +57,9 @@ struct NotesView: View {
             }
         }
         .task {
+            if coordinator.knowledgeBase == nil {
+                container.ensureViewServicesInitialized(settings: settings, coordinator: coordinator)
+            }
             let controller = NotesController(coordinator: coordinator, settings: settings)
             notesController = controller
             await controller.loadHistory()

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -67,6 +67,30 @@ final class LiveSessionControllerTests: XCTestCase {
         return (controller, coordinator)
     }
 
+    private func makeUninitializedController(
+        root: URL,
+        notesDirectory: URL,
+        settings: AppSettings
+    ) -> (LiveSessionController, AppCoordinator) {
+        let transcriptStore = TranscriptStore()
+        let coordinator = AppCoordinator(
+            sessionRepository: SessionRepository(rootDirectory: root),
+            templateStore: TemplateStore(rootDirectory: root),
+            notesEngine: NotesEngine(mode: .scripted(markdown: "Test")),
+            transcriptStore: transcriptStore
+        )
+        let defaults = UserDefaults(suiteName: "com.openoats.tests.lazyservices.\(UUID().uuidString)") ?? .standard
+        let container = AppContainer(
+            mode: .uiTest(.launchSmoke),
+            defaults: defaults,
+            appSupportDirectory: root,
+            notesDirectory: notesDirectory
+        )
+        let controller = LiveSessionController(coordinator: coordinator, container: container)
+        coordinator.liveSessionController = controller
+        return (controller, coordinator)
+    }
+
     // MARK: - Tests
 
     func testStartSessionTransitionsStateToRecordingSynchronously() {
@@ -119,6 +143,36 @@ final class LiveSessionControllerTests: XCTestCase {
         }
     }
 
+    func testStartSessionInitializesServicesOnDemand() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        let (controller, coordinator) = makeUninitializedController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings
+        )
+
+        XCTAssertNil(coordinator.transcriptionEngine)
+        XCTAssertNil(coordinator.knowledgeBase)
+
+        controller.startSession(settings: settings)
+
+        XCTAssertNotNil(coordinator.transcriptionEngine)
+        XCTAssertNotNil(coordinator.knowledgeBase)
+
+        for _ in 0..<20 {
+            if coordinator.transcriptionEngine?.isRunning == true { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        XCTAssertTrue(coordinator.transcriptionEngine?.isRunning == true)
+        if case .recording = coordinator.state {
+            // expected
+        } else {
+            XCTFail("Expected recording state after on-demand initialization")
+        }
+    }
+
     func testStopSessionWhileIdleIsNoOp() {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)
@@ -136,7 +190,7 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertEqual(coordinator.state, .idle)
     }
 
-    func testDeepLinkStartRejectedWhenEngineNotReady() {
+    func testDeepLinkStartInitializesServicesOnDemand() {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)
         let transcriptStore = TranscriptStore()
@@ -159,12 +213,17 @@ final class LiveSessionControllerTests: XCTestCase {
         // Queue a start command
         coordinator.queueExternalCommand(.startSession())
 
-        // Try handling - should not start because engines are not ready
+        // Try handling - the controller should initialize services on demand.
         controller.handlePendingExternalCommandIfPossible(settings: settings, openNotesWindow: nil)
 
-        // Command should still be pending (not consumed)
-        XCTAssertNotNil(coordinator.pendingExternalCommand)
-        XCTAssertEqual(coordinator.state, .idle)
+        XCTAssertNil(coordinator.pendingExternalCommand)
+        XCTAssertNotNil(coordinator.transcriptionEngine)
+        XCTAssertNotNil(coordinator.knowledgeBase)
+        if case .recording = coordinator.state {
+            // expected
+        } else {
+            XCTFail("Expected .recording state after on-demand deep link start, got \(coordinator.state)")
+        }
     }
 
     func testDeepLinkStopRejectedWhenNotRunning() {


### PR DESCRIPTION
## Summary
- split service initialization into view and recording buckets
- stop eagerly building the full service graph during app startup
- initialize services on demand when starting meetings, importing audio, opening notes, or using the menu bar start action

## Testing
- swift build -c debug --package-path OpenOats
- swift test --package-path OpenOats --filter LiveSessionControllerTests
- swift test --package-path OpenOats --filter NotesControllerTests
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh
- swift test --package-path OpenOats *(fails on current main in pre-existing `MeetingDetectorTests` only)*

Closes #440