### PR TITLE
fix: send ElevenLabs Scribe keyterms as repeated multipart fields

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
@@ -74,35 +74,14 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
 
         // 2. Build multipart/form-data body
         let boundary = UUID().uuidString
-        var body = Data()
-
-        body.appendMultipart(boundary: boundary, name: "model_id", value: "scribe_v2")
-
         let languageCode = locale.language.languageCode?.identifier ?? ""
-        if !languageCode.isEmpty {
-            body.appendMultipart(boundary: boundary, name: "language_code", value: languageCode)
-        }
-
-        body.appendMultipart(
+        let body = Self.buildMultipartBody(
             boundary: boundary,
-            name: "file",
-            filename: "audio.wav",
-            contentType: "audio/wav",
-            data: wavData
+            wavData: wavData,
+            languageCode: languageCode,
+            keyterms: keyterms,
+            removeFillerWords: removeFillerWords
         )
-
-        if !keyterms.isEmpty {
-            let jsonData = try JSONSerialization.data(withJSONObject: keyterms)
-            let jsonString = String(data: jsonData, encoding: .utf8) ?? "[]"
-            body.appendMultipart(boundary: boundary, name: "keyterms", value: jsonString)
-        }
-
-        if removeFillerWords {
-            body.appendMultipart(boundary: boundary, name: "no_verbatim", value: "true")
-        }
-
-        // Closing boundary
-        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
 
         // 3. POST to speech-to-text endpoint
         try Task.checkCancellation()
@@ -122,6 +101,8 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
                     throw CloudASRError.invalidAPIKey(backend: "ElevenLabs")
                 }
                 if !(200 ..< 300).contains(http.statusCode) {
+                    let errorBody = String(data: Data(responseData.prefix(2048)), encoding: .utf8) ?? "<non-utf8 body>"
+                    Self.log.error("ElevenLabs Scribe request failed: status \(http.statusCode, privacy: .public), body: \(errorBody, privacy: .private)")
                     throw CloudASRError.httpError(statusCode: http.statusCode)
                 }
             }
@@ -135,6 +116,50 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
 
         Self.log.info("ElevenLabs Scribe transcription completed")
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // MARK: - Multipart Body Builder (internal for tests)
+
+    /// Builds the multipart/form-data body posted to /v1/speech-to-text.
+    ///
+    /// `keyterms` are emitted as one multipart part per term, matching the
+    /// ElevenLabs JS SDK and the Speech-to-Text API reference. Sending a single
+    /// field with a JSON-array string as the value causes the server to validate
+    /// the whole literal as one keyterm, which fails with
+    /// `invalid_keyword` / "Some keyword contains invalid characters".
+    static func buildMultipartBody(
+        boundary: String,
+        wavData: Data,
+        languageCode: String,
+        keyterms: [String],
+        removeFillerWords: Bool
+    ) -> Data {
+        var body = Data()
+
+        body.appendMultipart(boundary: boundary, name: "model_id", value: "scribe_v2")
+
+        if !languageCode.isEmpty {
+            body.appendMultipart(boundary: boundary, name: "language_code", value: languageCode)
+        }
+
+        body.appendMultipart(
+            boundary: boundary,
+            name: "file",
+            filename: "audio.wav",
+            contentType: "audio/wav",
+            data: wavData
+        )
+
+        for keyterm in keyterms {
+            body.appendMultipart(boundary: boundary, name: "keyterms", value: keyterm)
+        }
+
+        if removeFillerWords {
+            body.appendMultipart(boundary: boundary, name: "no_verbatim", value: "true")
+        }
+
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        return body
     }
 
     // MARK: - Private: Keyterms Parser

--- a/OpenOats/Tests/OpenOatsTests/ElevenLabsScribeBackendTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/ElevenLabsScribeBackendTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class ElevenLabsScribeBackendTests: XCTestCase {
+
+    private let boundary = "TEST-BOUNDARY"
+
+    func testKeytermsEmittedAsSeparateMultipartParts() {
+        let body = ElevenLabsScribeBackend.buildMultipartBody(
+            boundary: boundary,
+            wavData: Data(),
+            languageCode: "en",
+            keyterms: ["Alpha", "Beta Bravo", "Gamma"],
+            removeFillerWords: false
+        )
+        let text = String(data: body, encoding: .utf8) ?? ""
+
+        let values = extractMultipartValues(text, fieldName: "keyterms")
+        XCTAssertEqual(values, ["Alpha", "Beta Bravo", "Gamma"],
+                       "keyterms must be emitted as one multipart part per term")
+
+        // Regression guard: earlier code sent a single JSON-array value.
+        // That shape makes ElevenLabs Scribe reject every request with HTTP 400
+        // "Some keyword contains invalid characters".
+        XCTAssertFalse(text.contains("[\"Alpha\",\"Beta Bravo\",\"Gamma\"]"),
+                       "body must not contain JSON-array keyterms literal")
+    }
+
+    func testKeytermsOmittedWhenEmpty() {
+        let body = ElevenLabsScribeBackend.buildMultipartBody(
+            boundary: boundary,
+            wavData: Data(),
+            languageCode: "en",
+            keyterms: [],
+            removeFillerWords: false
+        )
+        let text = String(data: body, encoding: .utf8) ?? ""
+        XCTAssertFalse(text.contains("name=\"keyterms\""),
+                       "no keyterms part when vocabulary is empty")
+    }
+
+    // Extracts values for every multipart part matching `name="<fieldName>"`.
+    // Assumes the appendMultipart format used by ElevenLabsScribeBackend:
+    //   --<boundary>\r\n
+    //   Content-Disposition: form-data; name="<fieldName>"\r\n
+    //   \r\n
+    //   <value>\r\n
+    private func extractMultipartValues(_ body: String, fieldName: String) -> [String] {
+        let marker = "Content-Disposition: form-data; name=\"\(fieldName)\"\r\n\r\n"
+        var values: [String] = []
+        var cursor = body.startIndex
+        while let headerRange = body.range(of: marker, range: cursor..<body.endIndex) {
+            let valueStart = headerRange.upperBound
+            if let terminator = body.range(of: "\r\n--", range: valueStart..<body.endIndex) {
+                values.append(String(body[valueStart..<terminator.lowerBound]))
+                cursor = terminator.upperBound
+            } else {
+                break
+            }
+        }
+        return values
+    }
+}


### PR DESCRIPTION
## What

Fix HTTP 400 on every ElevenLabs Scribe request when Custom Vocabulary is non-empty. Also log response bodies on non-2xx so the next provider-side break isn't opaque.

## Why

The backend I added in #240 encodes `keyterms` as a single multipart field whose value is a JSON-literal array. ElevenLabs expects one part per term ([API ref](https://elevenlabs.io/docs/api-reference/speech-to-text/convert), [JS SDK](https://github.com/elevenlabs/elevenlabs-js)). The server reads our value as one keyterm whose brackets trip the validator:

```json
{"detail":{"code":"invalid_parameters","message":"Some keyword contains invalid characters","param":"keywords"}}
```

Any user with non-empty Custom Vocabulary on Scribe has been silently 400'ing every chunk since #240 shipped. The 400 body was discarded at the error path, so it only showed as `httpError(statusCode: 400)` in logs — hence the second hunk.

## Testing

Multipart construction extracted into `ElevenLabsScribeBackend.buildMultipartBody` (internal static, mirrors the `WAVEncoder` pattern) and covered by two unit tests: one asserts three keyterms produce three separate `name="keyterms"` parts, the other asserts the field is omitted entirely when vocabulary is empty. Full suite: 505 passed, 0 failed on `swift test`.

Live API (2026-04-22, 1.5s PCM16 WAV):

| Request | Result |
|---|---|
| `keyterms=["a","b","c"]` (before) | 400 |
| `keyterms=a`, `keyterms=b`, `keyterms=c` (after) | 200 |
