### PR TITLE
Fix live control stopping active recordings

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -70,20 +70,35 @@ struct ControlBar: View {
             }
 
             HStack(spacing: 10) {
-                Button(action: onToggle) {
+                if isRunning {
                     HStack(spacing: 6) {
-                        if isRunning {
-                            // Pulsing dot when live, static when muted
-                            Circle()
-                                .fill(isMicMuted ? Color.red : Color.green)
-                                .frame(width: 8, height: 8)
-                                .scaleEffect(isMicMuted ? 1.0 : 1.0 + CGFloat(audioLevel) * 0.5)
-                                .animation(.easeOut(duration: 0.1), value: audioLevel)
+                        // Pulsing dot when live, static when muted
+                        Circle()
+                            .fill(isMicMuted ? Color.red : Color.green)
+                            .frame(width: 8, height: 8)
+                            .scaleEffect(isMicMuted ? 1.0 : 1.0 + CGFloat(audioLevel) * 0.5)
+                            .animation(.easeOut(duration: 0.1), value: audioLevel)
 
-                            Text(isMicMuted ? "Muted" : "Live")
-                                .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(isMicMuted ? .red : .primary)
-                        } else {
+                        Text(isMicMuted ? "Muted" : "Live")
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(isMicMuted ? .red : .primary)
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(isMicMuted ? Color.red.opacity(0.1) : Color.green.opacity(0.1))
+                    .clipShape(Capsule())
+                    .accessibilityIdentifier("app.controlBar.status")
+
+                    Button(action: onToggle) {
+                        Label("Stop", systemImage: "stop.fill")
+                            .font(.system(size: 12, weight: .semibold))
+                    }
+                    .buttonStyle(OpenOatsProminentButtonStyle(color: .red))
+                    .controlSize(.small)
+                    .accessibilityIdentifier("app.controlBar.stop")
+                } else {
+                    Button(action: onToggle) {
+                        HStack(spacing: 6) {
                             Image(systemName: "mic.fill")
                                 .font(.system(size: 11))
                                 .foregroundStyle(.white)
@@ -92,17 +107,14 @@ struct ControlBar: View {
                                 .font(.system(size: 12, weight: .semibold))
                                 .foregroundStyle(.white)
                         }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
+                        .background(Color.accentColor)
+                        .clipShape(Capsule())
                     }
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 7)
-                    // Avoid hover-driven local state here. On macOS 26 / Swift 6.2,
-                    // switching this button from Start to Live while the pointer is
-                    // over it can trip a SwiftUI executor crash in onHover handling.
-                    .background(isRunning ? (isMicMuted ? Color.red.opacity(0.1) : Color.green.opacity(0.1)) : Color.accentColor)
-                    .clipShape(Capsule())
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("app.controlBar.toggle")
                 }
-                .buttonStyle(.plain)
-                .accessibilityIdentifier("app.controlBar.toggle")
 
                 // Mute button + audio level bars when running
                 if isRunning {

--- a/UITests/OpenOatsUITests/SmokeTests.swift
+++ b/UITests/OpenOatsUITests/SmokeTests.swift
@@ -44,12 +44,11 @@ final class SmokeTests: XCTestCase {
         let toggle = element(in: app, identifier: "app.controlBar.toggle")
         XCTAssertTrue(toggle.waitForExistence(timeout: 5))
 
-        toggle.click()
-        XCTAssertTrue(waitForCondition(timeout: 5) {
-            self.element(in: app, identifier: "app.controlBar.toggle").label.contains("Live")
-        })
+        app.typeKey("l", modifierFlags: [.command, .shift])
+        let stop = element(in: app, identifier: "app.controlBar.stop")
+        XCTAssertTrue(stop.waitForExistence(timeout: 5))
 
-        toggle.click()
+        app.typeKey("l", modifierFlags: [.command, .shift])
         XCTAssertTrue(element(in: app, identifier: "app.sessionEndedBanner").waitForExistence(timeout: 5))
     }
 


### PR DESCRIPTION
Fixes #446

## Summary
- make the Live/Muted indicator in the control bar a non-interactive status chip while a meeting is running
- add an explicit red Stop button so stopping an active meeting is intentional
- update the UI smoke test to use the keyboard shortcut and verify the new stop control

## Validation
- swift build -c debug --package-path OpenOats
- ./scripts/build_swift_app.sh
- ./scripts/run_ui_smoke.sh