### PR TITLE
Reuse abandoned empty meeting session rows

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -322,12 +322,18 @@ final class LiveSessionController {
         }
 
         let templateID = coordinator.selectedTemplate?.id
-        let handle = await coordinator.sessionRepository.startSession(
-            config: SessionStartConfig(
-                templateID: templateID,
-                templateSnapshot: coordinator.sessionTemplateSnapshot
-            )
+        let startConfig = SessionStartConfig(
+            templateID: templateID,
+            templateSnapshot: coordinator.sessionTemplateSnapshot,
+            title: metadata.title ?? metadata.calendarEvent?.title,
+            calendarEvent: metadata.calendarEvent
         )
+        let handle: SessionHandle
+        if let resumed = await coordinator.sessionRepository.resumeAbandonedSession(config: startConfig) {
+            handle = resumed
+        } else {
+            handle = await coordinator.sessionRepository.startSession(config: startConfig)
+        }
         _currentSessionID = handle.sessionID
         let initialScratchpad = pendingInitialScratchpad?.trimmingCharacters(in: .whitespacesAndNewlines)
         pendingInitialScratchpad = nil

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -11,10 +11,19 @@ typealias SessionIndexEntry = SessionIndex
 struct SessionStartConfig: Sendable {
     let templateID: UUID?
     let templateSnapshot: TemplateSnapshot?
+    let title: String?
+    let calendarEvent: CalendarEvent?
 
-    init(templateID: UUID? = nil, templateSnapshot: TemplateSnapshot? = nil) {
+    init(
+        templateID: UUID? = nil,
+        templateSnapshot: TemplateSnapshot? = nil,
+        title: String? = nil,
+        calendarEvent: CalendarEvent? = nil
+    ) {
         self.templateID = templateID
         self.templateSnapshot = templateSnapshot
+        self.title = title
+        self.calendarEvent = calendarEvent
     }
 }
 
@@ -230,25 +239,47 @@ actor SessionRepository {
         let fm = FileManager.default
         try? fm.createDirectory(at: sessionDir, withIntermediateDirectories: true)
 
-        // Create transcript.live.jsonl and keep handle open
-        let liveFile = sessionDir.appendingPathComponent("transcript.live.jsonl")
-        fm.createFile(atPath: liveFile.path, contents: nil,
-                      attributes: [.posixPermissions: 0o600])
-        do {
-            liveFileHandle = try FileHandle(forWritingTo: liveFile)
-        } catch {
-            reportWriteError("Failed to open live transcript file: \(error.localizedDescription)")
-        }
+        openLiveTranscriptFileHandle(sessionID: sessionID)
 
         // Write initial session.json
         let metadata = SessionMetadata(
             id: sessionID,
             startedAt: Date(),
             templateSnapshot: config.templateSnapshot,
+            title: config.title,
             utteranceCount: 0,
-            hasNotes: false
+            hasNotes: false,
+            calendarEvent: config.calendarEvent
         )
         writeSessionMetadata(metadata, sessionID: sessionID)
+
+        return SessionHandle(sessionID: sessionID)
+    }
+
+    @discardableResult
+    func resumeAbandonedSession(
+        config: SessionStartConfig,
+        maximumGap: TimeInterval = 6 * 60 * 60
+    ) -> SessionHandle? {
+        guard let sessionID = resumableSessionID(config: config, maximumGap: maximumGap) else {
+            return nil
+        }
+
+        currentSessionID = sessionID
+        hasReportedWriteError = false
+        liveUtteranceCount = 0
+        openLiveTranscriptFileHandle(sessionID: sessionID)
+
+        if var metadata = loadSessionMetadataFile(sessionID: sessionID) {
+            metadata.templateSnapshot = config.templateSnapshot ?? metadata.templateSnapshot
+            if let title = config.title {
+                metadata.title = title
+            }
+            if let calendarEvent = config.calendarEvent {
+                metadata.calendarEvent = calendarEvent
+            }
+            writeSessionMetadata(metadata, sessionID: sessionID)
+        }
 
         return SessionHandle(sessionID: sessionID)
     }
@@ -948,6 +979,51 @@ actor SessionRepository {
         NotesFolderDefinition.normalizePath(folderPath ?? "")
     }
 
+    private func resumableSessionID(
+        config: SessionStartConfig,
+        maximumGap: TimeInterval
+    ) -> String? {
+        let referenceTitle = config.title ?? config.calendarEvent?.title
+        let historyKey = MeetingHistoryResolver.historyKey(for: referenceTitle ?? "")
+        guard !historyKey.isEmpty else { return nil }
+
+        let referenceDate = config.calendarEvent?.startDate ?? Date()
+        let referenceEventID = config.calendarEvent?.id
+
+        let candidates = listSessions().compactMap { candidate -> (id: String, exactEventMatch: Bool, gap: TimeInterval)? in
+            guard candidate.endedAt == nil,
+                  candidate.utteranceCount == 0,
+                  candidate.hasNotes == false,
+                  !sessionHasMeaningfulArtifacts(sessionID: candidate.id),
+                  let metadata = loadSessionMetadataFile(sessionID: candidate.id) else {
+                return nil
+            }
+
+            let gap = abs(metadata.startedAt.timeIntervalSince(referenceDate))
+            guard gap <= maximumGap else { return nil }
+
+            if let referenceEventID,
+               metadata.calendarEvent?.id == referenceEventID {
+                return (candidate.id, true, gap)
+            }
+
+            let candidateTitle = metadata.title ?? metadata.calendarEvent?.title
+            guard MeetingHistoryResolver.historyKey(for: candidateTitle ?? "") == historyKey else {
+                return nil
+            }
+
+            return (candidate.id, false, gap)
+        }
+        .sorted { lhs, rhs in
+            if lhs.exactEventMatch != rhs.exactEventMatch {
+                return lhs.exactEventMatch && !rhs.exactEventMatch
+            }
+            return lhs.gap < rhs.gap
+        }
+
+        return candidates.first?.id
+    }
+
     private func sessionHasMeaningfulArtifacts(sessionID: String) -> Bool {
         if !loadTranscript(sessionID: sessionID).isEmpty { return true }
         if !loadLiveTranscript(sessionID: sessionID).isEmpty { return true }
@@ -1411,6 +1487,29 @@ actor SessionRepository {
         guard !hasReportedWriteError else { return }
         hasReportedWriteError = true
         onWriteError?(message)
+    }
+
+    private func openLiveTranscriptFileHandle(sessionID: String) {
+        try? liveFileHandle?.close()
+        liveFileHandle = nil
+
+        let liveFile = sessionDirectory(for: sessionID).appendingPathComponent("transcript.live.jsonl")
+        let fm = FileManager.default
+        if !fm.fileExists(atPath: liveFile.path) {
+            fm.createFile(
+                atPath: liveFile.path,
+                contents: nil,
+                attributes: [.posixPermissions: 0o600]
+            )
+        }
+
+        do {
+            let handle = try FileHandle(forWritingTo: liveFile)
+            handle.seekToEndOfFile()
+            liveFileHandle = handle
+        } catch {
+            reportWriteError("Failed to open live transcript file: \(error.localizedDescription)")
+        }
     }
 
     @discardableResult

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -143,6 +143,50 @@ final class LiveSessionControllerTests: XCTestCase {
         }
     }
 
+    func testStartSessionReusesAbandonedMeetingStubForSameCalendarEvent() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        let now = Date()
+        let event = CalendarEvent(
+            id: "evt-resume-stub",
+            title: "Payment Ops / Merchant stand up",
+            startDate: now.addingTimeInterval(-120),
+            endDate: now.addingTimeInterval(780),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: true,
+            meetingURL: URL(string: "https://meet.example.com/payment-ops")
+        )
+
+        let repository = SessionRepository(rootDirectory: dirs.root)
+        let abandonedHandle = await repository.startSession(
+            config: SessionStartConfig(
+                templateSnapshot: nil,
+                title: event.title,
+                calendarEvent: event
+            )
+        )
+        await repository.endSession()
+
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings,
+            scripted: [Utterance(text: "Recovered", speaker: .you)]
+        )
+
+        controller.startSession(settings: settings, calendarEventOverride: event)
+
+        var activeSessionID: String?
+        for _ in 0..<20 {
+            activeSessionID = await coordinator.sessionRepository.getCurrentSessionID()
+            if activeSessionID != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        XCTAssertEqual(activeSessionID, abandonedHandle.sessionID)
+    }
+
     func testStartSessionInitializesServicesOnDemand() async {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -70,6 +70,25 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: handle.sessionID)
     }
 
+    func testStartSessionPersistsInitialMeetingIdentity() async {
+        let calendarEvent = makeCalendarEvent()
+        let handle = await repo.startSession(
+            config: SessionStartConfig(
+                templateSnapshot: nil,
+                title: "Customer Sync",
+                calendarEvent: calendarEvent
+            )
+        )
+
+        let session = await repo.loadSession(id: handle.sessionID)
+        XCTAssertEqual(session.index.title, "Customer Sync")
+        XCTAssertEqual(session.calendarEvent?.id, calendarEvent.id)
+        XCTAssertEqual(session.calendarEvent?.calendarTitle, calendarEvent.calendarTitle)
+
+        await repo.endSession()
+        await repo.deleteSession(sessionID: handle.sessionID)
+    }
+
     // MARK: - appendLiveUtterance writes to JSONL
 
     func testAppendLiveUtteranceWritesToJSONL() async {
@@ -619,6 +638,93 @@ final class SessionRepositoryTests: XCTestCase {
 
         await repo.deleteSession(sessionID: ghostHandle.sessionID)
         await repo.deleteSession(sessionID: "session_real")
+    }
+
+    func testResumeAbandonedSessionReusesEmptyUnfinishedMeetingRow() async {
+        let now = Date()
+        let calendarEvent = CalendarEvent(
+            id: "event-resume",
+            title: "Customer Sync",
+            startDate: now.addingTimeInterval(-120),
+            endDate: now.addingTimeInterval(780),
+            calendarID: "calendar-123",
+            calendarTitle: "Customer Meetings",
+            calendarColorHex: "#3366FF",
+            organizer: "Aly",
+            participants: [],
+            isOnlineMeeting: true,
+            meetingURL: URL(string: "https://meet.example.com/customer-sync")
+        )
+        let originalHandle = await repo.startSession(
+            config: SessionStartConfig(
+                templateSnapshot: nil,
+                title: calendarEvent.title,
+                calendarEvent: calendarEvent
+            )
+        )
+        await repo.endSession()
+
+        let resumedHandle = await repo.resumeAbandonedSession(
+            config: SessionStartConfig(
+                templateSnapshot: nil,
+                title: calendarEvent.title,
+                calendarEvent: calendarEvent
+            )
+        )
+
+        XCTAssertEqual(resumedHandle?.sessionID, originalHandle.sessionID)
+        let currentSessionID = await repo.getCurrentSessionID()
+        XCTAssertEqual(currentSessionID, originalHandle.sessionID)
+
+        let utterance = Utterance(text: "Recovered recording", speaker: .you, timestamp: Date())
+        await repo.appendLiveUtterance(sessionID: originalHandle.sessionID, utterance: utterance)
+        await repo.endSession()
+
+        let liveTranscript = await repo.loadLiveTranscript(sessionID: originalHandle.sessionID)
+        XCTAssertEqual(liveTranscript.count, 1)
+        XCTAssertEqual(liveTranscript.first?.text, "Recovered recording")
+
+        await repo.deleteSession(sessionID: originalHandle.sessionID)
+    }
+
+    func testResumeAbandonedSessionSkipsRowsWithTranscriptArtifacts() async {
+        let now = Date()
+        let calendarEvent = CalendarEvent(
+            id: "event-resume-skip",
+            title: "Customer Sync",
+            startDate: now.addingTimeInterval(-120),
+            endDate: now.addingTimeInterval(780),
+            calendarID: "calendar-123",
+            calendarTitle: "Customer Meetings",
+            calendarColorHex: "#3366FF",
+            organizer: "Aly",
+            participants: [],
+            isOnlineMeeting: true,
+            meetingURL: URL(string: "https://meet.example.com/customer-sync")
+        )
+        let originalHandle = await repo.startSession(
+            config: SessionStartConfig(
+                templateSnapshot: nil,
+                title: calendarEvent.title,
+                calendarEvent: calendarEvent
+            )
+        )
+
+        let utterance = Utterance(text: "Existing transcript", speaker: .you, timestamp: Date())
+        await repo.appendLiveUtterance(sessionID: originalHandle.sessionID, utterance: utterance)
+        await repo.endSession()
+
+        let resumedHandle = await repo.resumeAbandonedSession(
+            config: SessionStartConfig(
+                templateSnapshot: nil,
+                title: calendarEvent.title,
+                calendarEvent: calendarEvent
+            )
+        )
+
+        XCTAssertNil(resumedHandle)
+
+        await repo.deleteSession(sessionID: originalHandle.sessionID)
     }
 
     func testBatchMetaPersistsEffectiveSystemSampleRate() async {


### PR DESCRIPTION
Fixes #447

## Summary
- persist meeting identity on the session row as soon as recording starts
- reuse an abandoned empty session stub for the same meeting family instead of creating a second row
- add regression coverage for repository reuse rules and the live-session start path

## Notes
This is a narrow reuse path for abandoned empty rows only. It does not attempt to resume a partially running live pipeline with real transcript or audio artifacts.

## Validation
- swift test --package-path OpenOats --filter SessionRepositoryTests
- swift test --package-path OpenOats --filter LiveSessionControllerTests
- swift build -c debug --package-path OpenOats
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh