### PR TITLE
Update Homebrew cask for 1.60.4

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.60.3"
-  sha256 "7d7c8b9cd839380c45906f1aa3c7bcd03b48ced85e68b76ed1bb282dbcb36a23"
+  version "1.60.4"
+  sha256 "91ccefddd312e5aa4cc2ff6d878c14d9ad0b0a35c9a03da61ef05c4d0eb79caa"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Update `Casks/openoats.rb` version from 1.60.3 to 1.60.4
- Update SHA256 to match the v1.60.4 release DMG

Automated cask update from the `release-dmg` workflow.