### PR TITLE
Clarify knowledge base retrieval in settings and setup

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -496,10 +496,18 @@ private struct TranscriptionSettingsTab: View {
 private struct IntelligenceSettingsTab: View {
     @Bindable var settings: AppSettings
 
+    private var knowledgeBaseConfigured: Bool {
+        !settings.kbFolderPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
     var body: some View {
         ScrollView {
             Form {
-                Section("LLM Provider") {
+                Section("Notes generation") {
+                    Text("Choose the model OpenOats uses to generate meeting notes and other writing tasks. This is separate from knowledge-base retrieval.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+
                     Picker("Provider", selection: $settings.llmProvider) {
                         ForEach(LLMProvider.allCases) { provider in
                             Text(provider.displayName).tag(provider)
@@ -538,34 +546,71 @@ private struct IntelligenceSettingsTab: View {
                     }
                 }
 
-                Section("Embedding Provider") {
-                    Picker("Provider", selection: $settings.embeddingProvider) {
-                        ForEach(EmbeddingProvider.allCases) { provider in
-                            Text(provider.displayName).tag(provider)
+                Section("Knowledge Base") {
+                    Text("Optional. Point this to a folder of reference material such as docs, notes, PRDs, or customer context. OpenOats reads this folder to find relevant background during meetings. It is separate from where your meeting notes are organized.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+
+                    HStack {
+                        Text(settings.kbFolderPath.isEmpty ? "Not set" : settings.kbFolderPath)
+                            .font(.system(size: 12))
+                            .foregroundStyle(settings.kbFolderPath.isEmpty ? .tertiary : .primary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+
+                        Spacer()
+
+                        if !settings.kbFolderPath.isEmpty {
+                            Button("Clear") {
+                                settings.kbFolderPath = ""
+                            }
+                            .font(.system(size: 12))
+                        }
+
+                        Button("Choose...") {
+                            chooseKBFolder()
                         }
                     }
-                    .font(.system(size: 12))
+                }
 
-                    switch settings.embeddingProvider {
-                    case .voyageAI:
-                        SecureField("API Key", text: $settings.voyageApiKey)
-                            .font(.system(size: 12, design: .monospaced))
-                    case .ollama:
-                        OllamaModelField(modelName: $settings.ollamaEmbedModel, baseURL: settings.ollamaBaseURL, placeholder: "e.g. nomic-embed-text")
+                Section("Knowledge base retrieval") {
+                    if knowledgeBaseConfigured {
+                        Text("Choose how OpenOats indexes and searches your Knowledge Base folder. This affects knowledge retrieval during meetings, not note generation. Indexed chunks and vectors are still cached locally on this Mac.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
 
-                        if settings.llmProvider != .ollama && settings.llmProvider != .mlx {
-                            TextField("Ollama URL", text: $settings.ollamaBaseURL, prompt: Text("http://localhost:11434"))
+                        Picker("Provider", selection: $settings.embeddingProvider) {
+                            ForEach(EmbeddingProvider.allCases) { provider in
+                                Text(provider.displayName).tag(provider)
+                            }
+                        }
+                        .font(.system(size: 12))
+
+                        switch settings.embeddingProvider {
+                        case .voyageAI:
+                            SecureField("Voyage AI Key", text: $settings.voyageApiKey)
+                                .font(.system(size: 12, design: .monospaced))
+                        case .ollama:
+                            OllamaModelField(modelName: $settings.ollamaEmbedModel, baseURL: settings.ollamaBaseURL, placeholder: "e.g. nomic-embed-text")
+
+                            if settings.llmProvider != .ollama && settings.llmProvider != .mlx {
+                                TextField("Ollama URL", text: $settings.ollamaBaseURL, prompt: Text("http://localhost:11434"))
+                                    .font(.system(size: 12, design: .monospaced))
+                            }
+                        case .openAICompatible:
+                            TextField("Endpoint URL", text: $settings.openAIEmbedBaseURL, prompt: Text("http://localhost:8080"))
+                                .font(.system(size: 12, design: .monospaced))
+
+                            SecureField("API Key (optional)", text: $settings.openAIEmbedApiKey)
+                                .font(.system(size: 12, design: .monospaced))
+
+                            TextField("Model", text: $settings.openAIEmbedModel, prompt: Text("e.g. text-embedding-3-small"))
                                 .font(.system(size: 12, design: .monospaced))
                         }
-                    case .openAICompatible:
-                        TextField("Endpoint URL", text: $settings.openAIEmbedBaseURL, prompt: Text("http://localhost:8080"))
-                            .font(.system(size: 12, design: .monospaced))
-
-                        SecureField("API Key (optional)", text: $settings.openAIEmbedApiKey)
-                            .font(.system(size: 12, design: .monospaced))
-
-                        TextField("Model", text: $settings.openAIEmbedModel, prompt: Text("e.g. text-embedding-3-small"))
-                            .font(.system(size: 12, design: .monospaced))
+                    } else {
+                        Text("Choose a Knowledge Base folder above to turn on retrieval settings. These controls are only used for Knowledge Base features such as relevant context and suggestions.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
                     }
                 }
 
@@ -595,33 +640,6 @@ private struct IntelligenceSettingsTab: View {
                         Text("Real-time suggestions currently reuse the active provider model for this provider.")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)
-                    }
-                }
-
-                Section("Knowledge Base") {
-                    Text("Optional. Point this to a folder of notes, docs, or reference material (.md, .txt). During meetings, OpenOats searches this folder to surface relevant context and talking points.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-
-                    HStack {
-                        Text(settings.kbFolderPath.isEmpty ? "Not set" : settings.kbFolderPath)
-                            .font(.system(size: 12))
-                            .foregroundStyle(settings.kbFolderPath.isEmpty ? .tertiary : .primary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-
-                        Spacer()
-
-                        if !settings.kbFolderPath.isEmpty {
-                            Button("Clear") {
-                                settings.kbFolderPath = ""
-                            }
-                            .font(.system(size: 12))
-                        }
-
-                        Button("Choose...") {
-                            chooseKBFolder()
-                        }
                     }
                 }
 

--- a/OpenOats/Sources/OpenOats/Wizard/ProviderSetupStepView.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/ProviderSetupStepView.swift
@@ -114,8 +114,12 @@ struct ProviderSetupStepView: View {
 
             if viewModel.intent == .fullCopilot {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("Voyage AI key (optional)")
+                    Text("Voyage AI key (optional, for knowledge retrieval)")
                         .font(.system(size: 12, weight: .medium))
+
+                    Text("Only needed if you want OpenOats to search a Knowledge Base folder for relevant context during meetings. This does not improve note generation directly.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
 
                     HStack(spacing: 8) {
                         TextField("pa-...", text: $viewModel.voyageKeyInput)

--- a/OpenOats/Sources/OpenOats/Wizard/RecommendationEngine.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/RecommendationEngine.swift
@@ -306,17 +306,17 @@ enum RecommendationEngine {
         case .cloudEN, .cloudMulti:
             details.append("LLM: Gemini 3 Flash via OpenRouter")
             if intent == .fullCopilot {
-                details.append("Embeddings: Voyage AI")
+                details.append("Knowledge retrieval: Voyage AI")
             }
         case .localENLight, .localMultiLight:
             details.append("LLM: Phi 3.5 Mini via Ollama")
             if intent == .fullCopilot {
-                details.append("Embeddings: nomic-embed-text via Ollama")
+                details.append("Knowledge retrieval: nomic-embed-text via Ollama")
             }
         case .localENFull, .localMultiFull:
             details.append("LLM: Qwen3 8B via Ollama")
             if intent == .fullCopilot {
-                details.append("Embeddings: nomic-embed-text via Ollama")
+                details.append("Knowledge retrieval: nomic-embed-text via Ollama")
             }
         case .transcriptEN, .transcriptMulti:
             break

--- a/OpenOats/Tests/OpenOatsTests/RecommendationEngineTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/RecommendationEngineTests.swift
@@ -83,6 +83,7 @@ final class RecommendationEngineTests: XCTestCase {
         XCTAssertEqual(recommendation.profile, .cloudEN)
         XCTAssertEqual(recommendation.embeddingProvider, .voyageAI)
         XCTAssertTrue(recommendation.suggestionPanelEnabled)
+        XCTAssertTrue(recommendation.detailLines.contains("Knowledge retrieval: Voyage AI"))
     }
 
     func testCloudMultiLowRAM() {
@@ -175,6 +176,7 @@ final class RecommendationEngineTests: XCTestCase {
         XCTAssertEqual(recommendation.embeddingProvider, .ollama)
         XCTAssertEqual(recommendation.ollamaEmbedModel, "nomic-embed-text")
         XCTAssertTrue(recommendation.suggestionPanelEnabled)
+        XCTAssertTrue(recommendation.detailLines.contains("Knowledge retrieval: nomic-embed-text via Ollama"))
     }
 
     func testLocalNotesDoesNotIncludeEmbedding() {


### PR DESCRIPTION
Fixes #451

## Summary
- separate `Notes generation` from `Knowledge base retrieval` wording in the Intelligence settings tab
- only expand retrieval-provider controls once a Knowledge Base folder is configured, while keeping the capability visible
- clarify in setup and recommendation summaries that Voyage / embedding providers are for knowledge retrieval, not note generation

## Validation
- swift test --package-path OpenOats --filter RecommendationEngineTests
- swift build -c debug --package-path OpenOats
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh
- targeted settings smoke: `testSettingsSmokeShowsCorePickers`

## Notes
The full UI smoke suite on current upstream `main` still has the unrelated `testSessionSmokeShowsEndedBanner` hittability flake unless the separate live-control fix branch is also present. This PR does not touch that path.