### PR TITLE
Fix batch retranscription rate handling

### DIFF
--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -496,9 +496,17 @@ actor SessionRepository {
 
     // MARK: - Final Transcript
 
-    func saveFinalTranscript(sessionID: String, records: [SessionRecord]) {
+    func saveFinalTranscript(
+        sessionID: String,
+        records: [SessionRecord],
+        backupCurrentTranscript: Bool = false
+    ) {
         let dir = sessionDirectory(for: sessionID)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        if backupCurrentTranscript {
+            backupTranscriptForBatchOverwrite(sessionID: sessionID)
+        }
 
         var payload = Data()
         for record in records {
@@ -544,6 +552,32 @@ actor SessionRepository {
 
         // Mirror to notesFolderPath
         scheduleMirror(sessionID: sessionID)
+    }
+
+    private func backupTranscriptForBatchOverwrite(sessionID: String) {
+        let dir = sessionDirectory(for: sessionID)
+        let fm = FileManager.default
+        let finalURL = dir.appendingPathComponent("transcript.final.jsonl")
+        let liveURL = dir.appendingPathComponent("transcript.live.jsonl")
+        let backupURL = dir.appendingPathComponent("transcript.pre-batch.jsonl")
+
+        let sourceURL: URL?
+        if fm.fileExists(atPath: finalURL.path), let data = try? Data(contentsOf: finalURL), !data.isEmpty {
+            sourceURL = finalURL
+        } else if fm.fileExists(atPath: liveURL.path), let data = try? Data(contentsOf: liveURL), !data.isEmpty {
+            sourceURL = liveURL
+        } else {
+            sourceURL = nil
+        }
+
+        guard let sourceURL else { return }
+
+        try? fm.removeItem(at: backupURL)
+        do {
+            try fm.copyItem(at: sourceURL, to: backupURL)
+        } catch {
+            Log.sessionRepository.error("Failed to back up transcript before batch overwrite: \(error, privacy: .public)")
+        }
     }
 
     // MARK: - Notes

--- a/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
@@ -263,8 +263,11 @@ actor BatchAudioTranscriber {
                 let variant = LSEENDVariant(rawValue: diarizationVariant.rawValue) ?? .dihard3
                 try await dm.load(variant: variant)
                 // Process complete audio file through diarizer
-                let converter = AudioConverter(sampleRate: 16000)
-                let samples = try converter.resampleAudioFile(sysURL)
+                let samples = try BatchAudioSampleReader.readAll(
+                    url: sysURL,
+                    targetRate: 16000,
+                    overrideSampleRate: anchors?.sysSampleRate
+                )
                 try await dm.feedAudio(samples)
                 await dm.finalize()
                 batchDiarizer = dm
@@ -302,7 +305,11 @@ actor BatchAudioTranscriber {
         }
 
         // Atomic write of final transcript + full markdown regeneration via mirroring
-        await sessionRepository.saveFinalTranscript(sessionID: sessionID, records: allRecords)
+        await sessionRepository.saveFinalTranscript(
+            sessionID: sessionID,
+            records: allRecords,
+            backupCurrentTranscript: true
+        )
         // Retain batch stems/metadata for a bounded rerun/debug window.
         // SessionRepository purges expired retained assets on startup.
 
@@ -337,7 +344,7 @@ actor BatchAudioTranscriber {
         let resolvedSampleRate = sampleRate ?? fileSampleRate
 
         // Process in 30-second chunks
-        let chunkFrames = Int64(30.0 * fileSampleRate)
+        let chunkFrames = Int64(30.0 * resolvedSampleRate)
         var records: [SessionRecord] = []
         var frameOffset: Int64 = 0
 
@@ -348,7 +355,8 @@ actor BatchAudioTranscriber {
             let chunk = try readChunk(
                 file: audioFile,
                 startFrame: frameOffset,
-                frameCount: AVAudioFrameCount(framesToRead)
+                frameCount: AVAudioFrameCount(framesToRead),
+                overrideSampleRate: sampleRate
             )
 
             guard !chunk.isEmpty else {
@@ -366,7 +374,7 @@ actor BatchAudioTranscriber {
                 guard !text.isEmpty else { continue }
 
                 // Calculate timestamp from frame position
-                let sampleOffsetInFile = Double(frameOffset) + Double(segment.startSample) * fileSampleRate / 16000.0
+                let sampleOffsetInFile = Double(frameOffset) + Double(segment.startSample) * resolvedSampleRate / 16000.0
                 let timeOffset = sampleOffsetInFile / resolvedSampleRate
                 let timestamp = resolvedStartDate.addingTimeInterval(timeOffset)
 
@@ -374,7 +382,7 @@ actor BatchAudioTranscriber {
                 let resolvedSpeaker: Speaker
                 if let dm = diarizationManager {
                     let endSample = segment.startSample + segment.samples.count
-                    let segEndOffset = Double(frameOffset) + Double(endSample) * fileSampleRate / 16000.0
+                    let segEndOffset = Double(frameOffset) + Double(endSample) * resolvedSampleRate / 16000.0
                     let segEndTime = segEndOffset / resolvedSampleRate
                     resolvedSpeaker = await dm.dominantSpeaker(from: timeOffset, to: segEndTime)
                 } else {
@@ -404,78 +412,16 @@ actor BatchAudioTranscriber {
     private func readChunk(
         file: AVAudioFile,
         startFrame: Int64,
-        frameCount: AVAudioFrameCount
+        frameCount: AVAudioFrameCount,
+        overrideSampleRate: Double? = nil
     ) throws -> [Float] {
-        let srcFormat = file.processingFormat
         file.framePosition = startFrame
-
-        guard let readBuf = AVAudioPCMBuffer(pcmFormat: srcFormat, frameCapacity: frameCount) else {
-            return []
-        }
-        try file.read(into: readBuf)
-
-        let targetFormat = AVAudioFormat(
-            commonFormat: .pcmFormatFloat32,
-            sampleRate: 16000,
-            channels: 1,
-            interleaved: false
-        )!
-
-        // Fast path: already at target format
-        if srcFormat.sampleRate == 16000 && srcFormat.channelCount == 1
-            && srcFormat.commonFormat == .pcmFormatFloat32 {
-            guard let data = readBuf.floatChannelData else { return [] }
-            return Array(UnsafeBufferPointer(start: data[0], count: Int(readBuf.frameLength)))
-        }
-
-        // Downmix to mono first if needed
-        var inputBuffer = readBuf
-        if srcFormat.channelCount > 1, let src = readBuf.floatChannelData {
-            let monoFormat = AVAudioFormat(
-                commonFormat: .pcmFormatFloat32,
-                sampleRate: srcFormat.sampleRate,
-                channels: 1,
-                interleaved: false
-            )!
-            if let monoBuf = AVAudioPCMBuffer(pcmFormat: monoFormat, frameCapacity: readBuf.frameCapacity),
-               let dst = monoBuf.floatChannelData?[0] {
-                monoBuf.frameLength = readBuf.frameLength
-                let channels = Int(srcFormat.channelCount)
-                let scale = 1.0 / Float(channels)
-                for i in 0..<Int(readBuf.frameLength) {
-                    var sum: Float = 0
-                    for ch in 0..<channels { sum += src[ch][i] }
-                    dst[i] = sum * scale
-                }
-                inputBuffer = monoBuf
-            }
-        }
-
-        // Resample via AVAudioConverter
-        guard let converter = AVAudioConverter(from: inputBuffer.format, to: targetFormat) else {
-            // If conversion not possible, try direct extraction
-            guard let data = inputBuffer.floatChannelData else { return [] }
-            return Array(UnsafeBufferPointer(start: data[0], count: Int(inputBuffer.frameLength)))
-        }
-
-        let ratio = 16000.0 / inputBuffer.format.sampleRate
-        let outFrames = AVAudioFrameCount(Double(inputBuffer.frameLength) * ratio) + 1
-        guard let outBuf = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outFrames) else {
-            return []
-        }
-
-        nonisolated(unsafe) var consumed = false
-        nonisolated(unsafe) let inputRef = inputBuffer
-        var convError: NSError?
-        converter.convert(to: outBuf, error: &convError) { _, status in
-            if consumed { status.pointee = .endOfStream; return nil }
-            consumed = true
-            status.pointee = .haveData
-            return inputRef
-        }
-
-        guard let data = outBuf.floatChannelData else { return [] }
-        return Array(UnsafeBufferPointer(start: data[0], count: Int(outBuf.frameLength)))
+        return try BatchAudioSampleReader.readChunk(
+            from: file,
+            frameCount: frameCount,
+            targetRate: 16000,
+            overrideSampleRate: overrideSampleRate
+        )
     }
 
     // MARK: - VAD
@@ -572,6 +518,136 @@ actor BatchAudioTranscriber {
         )
     }
 
+}
+
+enum BatchAudioSampleReader {
+    static func readAll(
+        url: URL,
+        targetRate: Double,
+        overrideSampleRate: Double? = nil
+    ) throws -> [Float] {
+        let file = try AVAudioFile(forReading: url)
+        guard file.length > 0 else { return [] }
+        file.framePosition = 0
+        return try readChunk(
+            from: file,
+            frameCount: AVAudioFrameCount(file.length),
+            targetRate: targetRate,
+            overrideSampleRate: overrideSampleRate
+        )
+    }
+
+    static func readChunk(
+        from file: AVAudioFile,
+        frameCount: AVAudioFrameCount,
+        targetRate: Double,
+        overrideSampleRate: Double? = nil
+    ) throws -> [Float] {
+        let srcFormat = file.processingFormat
+        guard let readBuf = AVAudioPCMBuffer(pcmFormat: srcFormat, frameCapacity: frameCount) else {
+            return []
+        }
+        try file.read(into: readBuf)
+        return resample(readBuf, targetRate: targetRate, overrideSampleRate: overrideSampleRate)
+    }
+
+    static func resample(
+        _ readBuf: AVAudioPCMBuffer,
+        targetRate: Double,
+        overrideSampleRate: Double? = nil
+    ) -> [Float] {
+        let srcFormat = readBuf.format
+        guard readBuf.frameLength > 0 else { return [] }
+
+        let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: targetRate,
+            channels: 1,
+            interleaved: false
+        )!
+
+        if overrideSampleRate == nil,
+           srcFormat.sampleRate == targetRate,
+           srcFormat.channelCount == 1,
+           srcFormat.commonFormat == .pcmFormatFloat32
+        {
+            return extractSamples(from: readBuf)
+        }
+
+        let converterInput: AVAudioPCMBuffer
+        let converterSrcFormat: AVAudioFormat
+        if let overrideSampleRate, overrideSampleRate != srcFormat.sampleRate {
+            guard let retaggedFormat = AVAudioFormat(
+                commonFormat: srcFormat.commonFormat,
+                sampleRate: overrideSampleRate,
+                channels: srcFormat.channelCount,
+                interleaved: srcFormat.isInterleaved
+            ),
+            let retaggedBuffer = AVAudioPCMBuffer(
+                pcmFormat: retaggedFormat,
+                frameCapacity: readBuf.frameCapacity
+            )
+            else {
+                return extractMonoSamples(from: readBuf)
+            }
+            retaggedBuffer.frameLength = readBuf.frameLength
+            if let src = readBuf.floatChannelData, let dst = retaggedBuffer.floatChannelData {
+                for ch in 0..<Int(srcFormat.channelCount) {
+                    memcpy(dst[ch], src[ch], Int(readBuf.frameLength) * MemoryLayout<Float>.size)
+                }
+            }
+            converterInput = retaggedBuffer
+            converterSrcFormat = retaggedFormat
+        } else {
+            converterInput = readBuf
+            converterSrcFormat = srcFormat
+        }
+
+        guard let converter = AVAudioConverter(from: converterSrcFormat, to: targetFormat) else {
+            return extractMonoSamples(from: converterInput)
+        }
+
+        let ratio = targetRate / converterSrcFormat.sampleRate
+        let outFrames = AVAudioFrameCount(Double(converterInput.frameLength) * ratio) + 1
+        guard let outBuf = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: outFrames) else {
+            return []
+        }
+
+        nonisolated(unsafe) var consumed = false
+        nonisolated(unsafe) let inputRef = converterInput
+        var convError: NSError?
+        converter.convert(to: outBuf, error: &convError) { _, status in
+            if consumed {
+                status.pointee = .endOfStream
+                return nil
+            }
+            consumed = true
+            status.pointee = .haveData
+            return inputRef
+        }
+
+        return extractSamples(from: outBuf)
+    }
+
+    private static func extractSamples(from buffer: AVAudioPCMBuffer) -> [Float] {
+        let count = Int(buffer.frameLength)
+        guard count > 0, let data = buffer.floatChannelData?[0] else { return [] }
+        return Array(UnsafeBufferPointer(start: data, count: count))
+    }
+
+    private static func extractMonoSamples(from buffer: AVAudioPCMBuffer) -> [Float] {
+        let count = Int(buffer.frameLength)
+        guard count > 0, let data = buffer.floatChannelData else { return [] }
+        let channels = Int(buffer.format.channelCount)
+        if channels <= 1 { return extractSamples(from: buffer) }
+
+        let scale = 1.0 / Float(channels)
+        return (0..<count).map { i in
+            var sum: Float = 0
+            for ch in 0..<channels { sum += data[ch][i] }
+            return sum * scale
+        }
+    }
 }
 
 // MARK: - JSONDecoder Extension

--- a/OpenOats/Tests/OpenOatsTests/BatchAudioTranscriberTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/BatchAudioTranscriberTests.swift
@@ -1,0 +1,61 @@
+import AVFoundation
+import XCTest
+@testable import OpenOatsKit
+
+final class BatchAudioTranscriberTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUp() {
+        super.setUp()
+        tempDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("OpenOatsBatchAudioTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: tempDir)
+        super.tearDown()
+    }
+
+    func testReadAllHonorsOverrideSampleRateForMismatchedBatchAudio() throws {
+        let audioURL = tempDir.appendingPathComponent("sys.caf")
+        let declaredRate = 48_000.0
+        let effectiveRate = 24_000.0
+        let durationSeconds = 4.0
+        let frameCount = AVAudioFrameCount(effectiveRate * durationSeconds)
+
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: declaredRate,
+            channels: 1,
+            interleaved: false
+        )!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frameCount)!
+        buffer.frameLength = frameCount
+        if let data = buffer.floatChannelData?[0] {
+            for i in 0..<Int(frameCount) {
+                let phase = Float(i) / Float(effectiveRate) * 440 * 2 * .pi
+                data[i] = sin(phase) * 0.5
+            }
+        }
+
+        let file = try AVAudioFile(forWriting: audioURL, settings: format.settings)
+        try file.write(from: buffer)
+
+        let withoutOverride = try BatchAudioSampleReader.readAll(
+            url: audioURL,
+            targetRate: 16_000
+        )
+        let withOverride = try BatchAudioSampleReader.readAll(
+            url: audioURL,
+            targetRate: 16_000,
+            overrideSampleRate: effectiveRate
+        )
+
+        XCTAssertFalse(withOverride.isEmpty)
+        XCTAssertGreaterThan(withOverride.count, withoutOverride.count * 3 / 2)
+        XCTAssertEqual(withOverride.count, Int(durationSeconds * 16_000), accuracy: 3_000)
+        XCTAssertEqual(withoutOverride.count, Int(durationSeconds * 8_000), accuracy: 3_000)
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -551,6 +551,66 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    func testSaveFinalTranscriptBacksUpLiveTranscriptWhenRequested() async {
+        let sessionID = "session_backup_live"
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Original live", timestamp: startedAt)],
+            startedAt: startedAt
+        )
+
+        await repo.saveFinalTranscript(
+            sessionID: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Batch final", timestamp: startedAt.addingTimeInterval(30))],
+            backupCurrentTranscript: true
+        )
+
+        let backupURL = rootDir
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("transcript.pre-batch.jsonl")
+
+        let backup = try? String(contentsOf: backupURL, encoding: .utf8)
+        XCTAssertNotNil(backup)
+        XCTAssertTrue(backup?.contains("Original live") == true)
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
+    func testSaveFinalTranscriptBacksUpExistingFinalTranscriptWhenRequested() async {
+        let sessionID = "session_backup_final"
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Original live", timestamp: startedAt)],
+            startedAt: startedAt
+        )
+
+        await repo.saveFinalTranscript(
+            sessionID: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Original final", timestamp: startedAt.addingTimeInterval(10))]
+        )
+
+        await repo.saveFinalTranscript(
+            sessionID: sessionID,
+            records: [SessionRecord(speaker: .them, text: "New final", timestamp: startedAt.addingTimeInterval(20))],
+            backupCurrentTranscript: true
+        )
+
+        let backupURL = rootDir
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("transcript.pre-batch.jsonl")
+
+        let backup = try? String(contentsOf: backupURL, encoding: .utf8)
+        XCTAssertNotNil(backup)
+        XCTAssertTrue(backup?.contains("Original final") == true)
+        XCTAssertFalse(backup?.contains("New final") == true)
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
     func testReconcileGhostSessionMergesCalendarEventIntoRecentRealSession() async {
         let calendarEvent = makeCalendarEvent()
         let realStartedAt = Date().addingTimeInterval(-180)


### PR DESCRIPTION
Addresses #450

## Summary
- decode retained system batch audio using the effective recorded sample rate instead of the wrong CAF header rate
- feed diarization the corrected 16 kHz system audio so speaker attribution stays aligned with retranscription
- preserve the pre-batch transcript in `transcript.pre-batch.jsonl` before overwriting `transcript.final.jsonl`

## Validation
- `swift test --package-path OpenOats --filter SessionRepositoryTests`
- `swift test --package-path OpenOats --filter BatchAudioTranscriberTests`
- `swift test --package-path OpenOats --filter AudioRecorderTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`

## Notes
- this addresses the destructive overwrite and sped-up batch decode path from #450
- manual rerun UX and any separate raw-audio playback polish can stay on the issue for follow-up
