### PR TITLE
Add manual batch re-transcribe and restore actions (#456)

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -36,6 +36,10 @@ struct NotesState {
     var audioFileURL: URL?
     /// Whether audio is currently playing.
     var isPlayingAudio: Bool = false
+    /// Whether retained batch audio exists for the selected session.
+    var canRetranscribeSelectedSession: Bool = false
+    /// Whether a pre-batch transcript backup exists for the selected session.
+    var hasOriginalTranscriptBackup: Bool = false
     /// Sessions whose notes were freshly generated while the user was on a different session.
     /// Cleared when the user opens that session. Used to show the blue "unread" indicator.
     var freshlyGeneratedSessionIDs: Set<String> = []
@@ -242,6 +246,8 @@ final class NotesController {
             state.selectedSessionDirectory = nil
             state.availableAudioSources = []
             state.audioFileURL = nil
+            state.canRetranscribeSelectedSession = false
+            state.hasOriginalTranscriptBackup = false
             return
         }
 
@@ -253,6 +259,8 @@ final class NotesController {
         state.loadedCalendarEvent = nil
         state.availableAudioSources = []
         state.audioFileURL = nil
+        state.canRetranscribeSelectedSession = false
+        state.hasOriginalTranscriptBackup = false
         state.selectedSessionDirectory = coordinator.sessionRepository.sessionsDirectoryURL
             .appendingPathComponent(sessionID, isDirectory: true)
         state.showingOriginal = false
@@ -267,7 +275,10 @@ final class NotesController {
         }
 
         Task {
-            let data = await coordinator.sessionRepository.loadSessionData(sessionID: sessionID)
+            async let sessionData = coordinator.sessionRepository.loadSessionData(sessionID: sessionID)
+            async let canRetranscribe = coordinator.sessionRepository.hasRetainedBatchAudio(sessionID: sessionID)
+            async let hasBackup = coordinator.sessionRepository.hasPreBatchTranscriptBackup(sessionID: sessionID)
+            let data = await sessionData
             let unsavedDraft = unsavedManualNotesDraftsBySessionID[sessionID]
 
             state.loadedNotes = data.notes
@@ -278,6 +289,8 @@ final class NotesController {
             state.loadedCalendarEvent = data.calendarEvent
             state.availableAudioSources = data.audioSources
             state.audioFileURL = data.audioURL
+            state.canRetranscribeSelectedSession = await canRetranscribe
+            state.hasOriginalTranscriptBackup = await hasBackup
 
             let session = state.sessionHistory.first { $0.id == sessionID }
             let familySelection = session.map { Self.meetingFamilySelection(for: $0, calendarEvent: data.calendarEvent) }
@@ -357,6 +370,8 @@ final class NotesController {
         state.loadedCalendarEvent = nil
         state.availableAudioSources = []
         state.audioFileURL = nil
+        state.canRetranscribeSelectedSession = false
+        state.hasOriginalTranscriptBackup = false
         state.selectedSessionDirectory = nil
         state.showingOriginal = false
         coordinator.batchTextCleaner.cancel()
@@ -649,6 +664,37 @@ final class NotesController {
 
     func toggleShowingOriginal() {
         state.showingOriginal.toggle()
+    }
+
+    func rerunBatchTranscription(model: TranscriptionModel, settings: AppSettings) {
+        guard let sessionID = state.selectedSessionID,
+              state.canRetranscribeSelectedSession,
+              let batchAudioTranscriber = coordinator.batchAudioTranscriber else { return }
+
+        let notesDirectory = URL(fileURLWithPath: settings.notesFolderPath)
+        Task {
+            await batchAudioTranscriber.process(
+                sessionID: sessionID,
+                model: model,
+                locale: settings.locale,
+                sessionRepository: coordinator.sessionRepository,
+                notesDirectory: notesDirectory,
+                enableDiarization: settings.enableDiarization,
+                diarizationVariant: settings.diarizationVariant
+            )
+            await reloadSessionAfterTranscriptMutation(sessionID: sessionID)
+        }
+    }
+
+    func restoreOriginalTranscript() {
+        guard let sessionID = state.selectedSessionID,
+              state.hasOriginalTranscriptBackup else { return }
+
+        Task {
+            let restored = await coordinator.sessionRepository.restorePreBatchTranscript(sessionID: sessionID)
+            guard restored else { return }
+            await reloadSessionAfterTranscriptMutation(sessionID: sessionID)
+        }
     }
 
     // MARK: - Session Management
@@ -952,6 +998,13 @@ final class NotesController {
         } else {
             unsavedManualNotesDraftsBySessionID[sessionID] = state.manualNotesDraft
         }
+    }
+
+    private func reloadSessionAfterTranscriptMutation(sessionID: String) async {
+        await coordinator.loadHistory()
+        await loadHistory()
+        guard state.selectedSessionID == sessionID else { return }
+        selectSession(sessionID)
     }
 
     func loadHistory() async {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -1206,6 +1206,31 @@ actor SessionRepository {
         )
     }
 
+    func hasRetainedBatchAudio(sessionID: String) -> Bool {
+        let urls = batchAudioURLs(sessionID: sessionID)
+        return urls.mic != nil || urls.sys != nil
+    }
+
+    func hasPreBatchTranscriptBackup(sessionID: String) -> Bool {
+        let backupURL = sessionDirectory(for: sessionID).appendingPathComponent("transcript.pre-batch.jsonl")
+        guard FileManager.default.fileExists(atPath: backupURL.path),
+              let data = try? Data(contentsOf: backupURL)
+        else {
+            return false
+        }
+        return !data.isEmpty
+    }
+
+    @discardableResult
+    func restorePreBatchTranscript(sessionID: String) -> Bool {
+        let backupURL = sessionDirectory(for: sessionID).appendingPathComponent("transcript.pre-batch.jsonl")
+        guard let content = try? String(contentsOf: backupURL, encoding: .utf8) else { return false }
+        let records = parseJSONL(content)
+        guard !records.isEmpty else { return false }
+        saveFinalTranscript(sessionID: sessionID, records: records)
+        return true
+    }
+
     func cleanupBatchAudio(sessionID: String) {
         let fm = FileManager.default
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -26,6 +26,7 @@ struct NotesView: View {
     @State private var editingTags: [String] = []
     @State private var newTagText: String = ""
     @State private var availableTags: [String] = []
+    @State private var confirmRestoreOriginalTranscript = false
 
     enum DetailViewMode: String, CaseIterable {
         case transcript = "Transcript"
@@ -123,6 +124,18 @@ struct NotesView: View {
             appleNotesSyncState = .idle
             appleNotesLastSyncDate = controller.state.selectedSessionID
                 .flatMap { AppleNotesService.lastSyncDate(for: $0) }
+        }
+        .confirmationDialog(
+            "Restore original transcript?",
+            isPresented: $confirmRestoreOriginalTranscript,
+            titleVisibility: .visible
+        ) {
+            Button("Restore Original Transcript") {
+                controller.restoreOriginalTranscript()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This replaces the current transcript with the saved pre-batch version for this session.")
         }
         .sheet(
             isPresented: Binding(
@@ -1726,6 +1739,11 @@ struct NotesView: View {
                 notesToolbarActions(controller: controller, state: state)
             }
 
+            if state.selectedSessionID != nil,
+               (state.canRetranscribeSelectedSession || state.hasOriginalTranscriptBackup) {
+                transcriptMaintenanceMenu(controller: controller, state: state)
+            }
+
             if !state.availableAudioSources.isEmpty {
                 audioPlaybackButton(controller: controller, state: state)
             }
@@ -1881,6 +1899,70 @@ struct NotesView: View {
         .buttonStyle(.bordered)
         .fixedSize()
         .help(state.isPlayingAudio ? "Pause audio recording" : "Play audio recording")
+    }
+
+    @ViewBuilder
+    private func transcriptMaintenanceMenu(controller: NotesController, state: NotesState) -> some View {
+        let isBatchBusy = coordinator.batchStatus != .idle
+
+        Menu {
+            if state.canRetranscribeSelectedSession {
+                Button {
+                    container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
+                    controller.rerunBatchTranscription(model: settings.batchTranscriptionModel, settings: settings)
+                } label: {
+                    Label(
+                        "Re-transcribe with \(settings.batchTranscriptionModel.displayName)",
+                        systemImage: "arrow.trianglehead.2.clockwise.rotate.90"
+                    )
+                }
+                .disabled(isBatchBusy)
+
+                if TranscriptionModel.batchSuitableModels.count > 1 {
+                    Menu("Re-transcribe with…") {
+                        ForEach(TranscriptionModel.batchSuitableModels) { model in
+                            Button {
+                                container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
+                                controller.rerunBatchTranscription(model: model, settings: settings)
+                            } label: {
+                                Label(model.displayName, systemImage: model == settings.batchTranscriptionModel ? "checkmark" : "")
+                            }
+                            .disabled(isBatchBusy)
+                        }
+                    }
+                    .disabled(isBatchBusy)
+                }
+
+                Divider()
+
+                Label(
+                    settings.enableDiarization
+                        ? "Speaker diarization: \(settings.diarizationVariant.displayName)"
+                        : "Speaker diarization off",
+                    systemImage: settings.enableDiarization ? "person.2" : "person.2.slash"
+                )
+                .foregroundStyle(.secondary)
+            }
+
+            if state.hasOriginalTranscriptBackup {
+                if state.canRetranscribeSelectedSession {
+                    Divider()
+                }
+                Button {
+                    confirmRestoreOriginalTranscript = true
+                } label: {
+                    Label("Restore original transcript", systemImage: "clock.arrow.circlepath")
+                }
+                .disabled(isBatchBusy)
+            }
+        } label: {
+            Label("Transcript", systemImage: "text.badge.star")
+                .font(.system(size: 12))
+        }
+        .menuStyle(.button)
+        .buttonStyle(.bordered)
+        .fixedSize()
+        .help("Re-transcribe this session or restore the pre-batch transcript")
     }
 
     @ViewBuilder

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -122,8 +122,8 @@ struct NotesView: View {
         }
         .onChange(of: controller.state.selectedSessionID) {
             appleNotesSyncState = .idle
-            appleNotesLastSyncDate = controller.state.selectedSessionID
-                .flatMap { AppleNotesService.lastSyncDate(for: $0) }
+            let sid = controller.state.selectedSessionID
+            appleNotesLastSyncDate = sid.flatMap { AppleNotesService.lastSyncDate(for: $0) }
         }
         .confirmationDialog(
             "Restore original transcript?",

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -97,35 +97,8 @@ struct NotesView: View {
     @ViewBuilder
     private func mainContent(controller: NotesController) -> some View {
         let state = controller.state
-        HStack(spacing: 0) {
-            sidebar(controller: controller, state: state)
-                .frame(width: 250)
-            Divider()
-            detailContent(controller: controller, state: state)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-        .onChange(of: coordinator.lastEndedSession?.id) {
-            Task { await controller.handleLastEndedSessionChanged() }
-        }
-        .onChange(of: coordinator.sessionHistory.count) {
-            Task { await controller.loadHistory() }
-        }
-        .onChange(of: coordinator.requestedNotesNavigation?.id) {
-            if controller.handleRequestedSessionSelection() {
-                detailViewMode = .notes
-            }
-        }
-        .onChange(of: state.selectedMeetingFamily?.key) {
-            meetingFamilyBottomTab = .history
-            isMeetingFamilyBottomCollapsed = false
-            pendingMeetingFamilyFolderChange = nil
-        }
-        .onChange(of: controller.state.selectedSessionID) {
-            appleNotesSyncState = .idle
-            let sid = controller.state.selectedSessionID
-            appleNotesLastSyncDate = sid.flatMap { AppleNotesService.lastSyncDate(for: $0) }
-        }
-        .confirmationDialog(
+        mainLayout(controller: controller, state: state)
+            .confirmationDialog(
             "Restore original transcript?",
             isPresented: $confirmRestoreOriginalTranscript,
             titleVisibility: .visible
@@ -187,6 +160,38 @@ struct NotesView: View {
                 }
         } message: { pendingChange in
             Text(meetingFamilyFolderChangeMessage(for: pendingChange))
+        }
+    }
+
+    @ViewBuilder
+    private func mainLayout(controller: NotesController, state: NotesState) -> some View {
+        HStack(spacing: 0) {
+            sidebar(controller: controller, state: state)
+                .frame(width: 250)
+            Divider()
+            detailContent(controller: controller, state: state)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .onChange(of: coordinator.lastEndedSession?.id) {
+            Task { await controller.handleLastEndedSessionChanged() }
+        }
+        .onChange(of: coordinator.sessionHistory.count) {
+            Task { await controller.loadHistory() }
+        }
+        .onChange(of: coordinator.requestedNotesNavigation?.id) {
+            if controller.handleRequestedSessionSelection() {
+                detailViewMode = .notes
+            }
+        }
+        .onChange(of: state.selectedMeetingFamily?.key) {
+            meetingFamilyBottomTab = .history
+            isMeetingFamilyBottomCollapsed = false
+            pendingMeetingFamilyFolderChange = nil
+        }
+        .onChange(of: controller.state.selectedSessionID) {
+            appleNotesSyncState = .idle
+            let sid = controller.state.selectedSessionID
+            appleNotesLastSyncDate = sid.flatMap { AppleNotesService.lastSyncDate(for: $0) }
         }
     }
 

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -181,6 +181,60 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(controller.state.audioFileURL?.lastPathComponent, "sys.caf")
     }
 
+    func testSelectSessionLoadsBatchTranscriptActionsWhenArtifactsExist() async throws {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_batch_transcript_actions"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID)
+
+        let audioDir = coordinator.sessionRepository.sessionsDirectoryURL
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+        try Data("sys".utf8).write(to: audioDir.appendingPathComponent("sys.caf"))
+        try Data("live".utf8).write(
+            to: coordinator.sessionRepository.sessionsDirectoryURL
+                .appendingPathComponent(sessionID, isDirectory: true)
+                .appendingPathComponent("transcript.pre-batch.jsonl")
+        )
+
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertTrue(controller.state.canRetranscribeSelectedSession)
+        XCTAssertTrue(controller.state.hasOriginalTranscriptBackup)
+    }
+
+    func testRestoreOriginalTranscriptReloadsSelectedSession() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_restore_transcript"
+
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: sessionID,
+            utterances: [SessionRecord(speaker: .you, text: "Original live", timestamp: Date(timeIntervalSince1970: 1_700_000_000))]
+        )
+
+        await coordinator.sessionRepository.saveFinalTranscript(
+            sessionID: sessionID,
+            records: [SessionRecord(speaker: .them, text: "Batch overwrite", timestamp: Date(timeIntervalSince1970: 1_700_000_030))],
+            backupCurrentTranscript: true
+        )
+        await coordinator.loadHistory()
+
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+        XCTAssertEqual(controller.state.loadedTranscript.map(\.text), ["Batch overwrite"])
+        XCTAssertTrue(controller.state.hasOriginalTranscriptBackup)
+
+        controller.restoreOriginalTranscript()
+        try? await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertEqual(controller.state.loadedTranscript.map(\.text), ["Original live"])
+    }
+
     func testGenerateNotesUpdatesStatus() async {
         let (root, notes) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -611,6 +611,49 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    func testRestorePreBatchTranscriptRestoresBackupIntoFinalTranscript() async {
+        let sessionID = "session_restore_pre_batch"
+        let startedAt = Date(timeIntervalSince1970: 1_000)
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Live transcript", timestamp: startedAt)],
+            startedAt: startedAt
+        )
+
+        await repo.saveFinalTranscript(
+            sessionID: sessionID,
+            records: [SessionRecord(speaker: .them, text: "Batch transcript", timestamp: startedAt.addingTimeInterval(15))],
+            backupCurrentTranscript: true
+        )
+
+        let restored = await repo.restorePreBatchTranscript(sessionID: sessionID)
+        XCTAssertTrue(restored)
+
+        let transcript = await repo.loadTranscript(sessionID: sessionID)
+        XCTAssertEqual(transcript.map(\.text), ["Live transcript"])
+
+        let sessions = await repo.listSessions()
+        let saved = sessions.first(where: { $0.id == sessionID })
+        XCTAssertEqual(saved?.utteranceCount, 1)
+        XCTAssertEqual(saved?.startedAt, startedAt)
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
+    func testRestorePreBatchTranscriptReturnsFalseWhenBackupMissing() async {
+        let sessionID = "session_restore_missing"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Live transcript", timestamp: Date())],
+            startedAt: Date()
+        )
+
+        let restored = await repo.restorePreBatchTranscript(sessionID: sessionID)
+        XCTAssertFalse(restored)
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
     func testReconcileGhostSessionMergesCalendarEventIntoRecentRealSession() async {
         let calendarEvent = makeCalendarEvent()
         let realStartedAt = Date().addingTimeInterval(-180)


### PR DESCRIPTION
Cherry-pick of #456 by @kkarimi, rebased onto main to resolve conflicts.

## Summary
- Surface session-level transcript maintenance actions in the Notes detail toolbar
- Allow manual batch re-transcription of ended sessions that still retain batch audio, including one-off model selection
- Allow restoring the saved pre-batch transcript when `transcript.pre-batch.jsonl` exists
- Reload the selected session after rerun or restore so transcript state updates immediately

Closes #455

Co-authored-by: Nima Karimi <nima@karimi.info>