### PR TITLE
Guard against bad batch transcript overwrites

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
@@ -1,6 +1,55 @@
 @preconcurrency import AVFoundation
 import FluidAudio
 
+struct BatchTranscriptOverwriteGuard {
+    private struct TranscriptStats {
+        let recordCount: Int
+        let nonWhitespaceCharacterCount: Int
+        let duration: TimeInterval
+
+        init(records: [SessionRecord]) {
+            recordCount = records.count
+            nonWhitespaceCharacterCount = records.reduce(into: 0) { total, record in
+                let text = record.cleanedText ?? record.text
+                total += text.unicodeScalars.reduce(into: 0) { count, scalar in
+                    if !CharacterSet.whitespacesAndNewlines.contains(scalar) {
+                        count += 1
+                    }
+                }
+            }
+            if let first = records.first?.timestamp, let last = records.last?.timestamp {
+                duration = max(0, last.timeIntervalSince(first))
+            } else {
+                duration = 0
+            }
+        }
+
+        var isSubstantial: Bool {
+            recordCount >= 4 || nonWhitespaceCharacterCount >= 120
+        }
+    }
+
+    static func rejectionReason(
+        existingRecords: [SessionRecord],
+        replacementRecords: [SessionRecord]
+    ) -> String? {
+        let existing = TranscriptStats(records: existingRecords)
+        guard existing.isSubstantial else { return nil }
+
+        let replacement = TranscriptStats(records: replacementRecords)
+        let characterCollapseThreshold = max(40, Int(Double(existing.nonWhitespaceCharacterCount) * 0.35))
+        let characterCollapse = replacement.nonWhitespaceCharacterCount < characterCollapseThreshold
+        let recordCollapse = replacement.recordCount * 3 < existing.recordCount
+        let durationCollapse = existing.duration >= 60 && replacement.duration < existing.duration * 0.4
+
+        guard characterCollapse && (recordCollapse || durationCollapse) else {
+            return nil
+        }
+
+        return "Batch re-transcription looks unreliable; kept existing transcript"
+    }
+}
+
 /// Offline two-pass transcription engine that processes recorded CAF files
 /// using a higher-quality model after a meeting ends.
 actor BatchAudioTranscriber {
@@ -297,10 +346,26 @@ actor BatchAudioTranscriber {
         // Interleave by timestamp
         var allRecords = micRecords + sysRecords
         allRecords.sort { $0.timestamp < $1.timestamp }
+        let existingRecords = await sessionRepository.loadTranscript(sessionID: sessionID)
 
         guard !allRecords.isEmpty else {
             Log.batchTranscription.warning("Batch transcription produced no records for \(sessionID, privacy: .public)")
-            status = .completed(sessionID: sessionID)
+            if existingRecords.isEmpty {
+                status = .failed("Batch re-transcription produced no speech")
+            } else {
+                status = .failed("Batch re-transcription produced no speech; kept existing transcript")
+            }
+            return
+        }
+
+        if let rejectionReason = BatchTranscriptOverwriteGuard.rejectionReason(
+            existingRecords: existingRecords,
+            replacementRecords: allRecords
+        ) {
+            Log.batchTranscription.warning(
+                "Skipping batch transcript overwrite for \(sessionID, privacy: .public): \(rejectionReason, privacy: .public)"
+            )
+            status = .failed(rejectionReason)
             return
         }
 

--- a/OpenOats/Tests/OpenOatsTests/BatchAudioTranscriberTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/BatchAudioTranscriberTests.swift
@@ -58,4 +58,88 @@ final class BatchAudioTranscriberTests: XCTestCase {
         XCTAssertEqual(withOverride.count, Int(durationSeconds * 16_000), accuracy: 3_000)
         XCTAssertEqual(withoutOverride.count, Int(durationSeconds * 8_000), accuracy: 3_000)
     }
+
+    func testOverwriteGuardRejectsClearlyCollapsedReplacementTranscript() {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let existing = makeRecords(
+            count: 8,
+            startedAt: startedAt,
+            spacing: 45,
+            text: "Discussed rollout blockers, merchant onboarding, dashboard regressions, and production follow-up."
+        )
+        let replacement = makeRecords(
+            count: 2,
+            startedAt: startedAt,
+            spacing: 20,
+            text: "Quick update."
+        )
+
+        let reason = BatchTranscriptOverwriteGuard.rejectionReason(
+            existingRecords: existing,
+            replacementRecords: replacement
+        )
+
+        XCTAssertEqual(reason, "Batch re-transcription looks unreliable; kept existing transcript")
+    }
+
+    func testOverwriteGuardAllowsComparableReplacementWithFewerSegments() {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let existing = makeRecords(
+            count: 8,
+            startedAt: startedAt,
+            spacing: 40,
+            text: "Reviewed customer issues, rollout readiness, pricing follow-ups, and ownership for the next sprint."
+        )
+        let replacement = makeRecords(
+            count: 3,
+            startedAt: startedAt,
+            spacing: 90,
+            text: "Reviewed customer issues, rollout readiness, pricing follow-ups, ownership, and next sprint planning in detail."
+        )
+
+        let reason = BatchTranscriptOverwriteGuard.rejectionReason(
+            existingRecords: existing,
+            replacementRecords: replacement
+        )
+
+        XCTAssertNil(reason)
+    }
+
+    func testOverwriteGuardIgnoresSmallExistingTranscript() {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let existing = makeRecords(
+            count: 2,
+            startedAt: startedAt,
+            spacing: 15,
+            text: "Tiny meeting."
+        )
+        let replacement = makeRecords(
+            count: 1,
+            startedAt: startedAt,
+            spacing: 10,
+            text: "Short."
+        )
+
+        let reason = BatchTranscriptOverwriteGuard.rejectionReason(
+            existingRecords: existing,
+            replacementRecords: replacement
+        )
+
+        XCTAssertNil(reason)
+    }
+
+    private func makeRecords(
+        count: Int,
+        startedAt: Date,
+        spacing: TimeInterval,
+        text: String
+    ) -> [SessionRecord] {
+        (0..<count).map { index in
+            SessionRecord(
+                speaker: index.isMultiple(of: 2) ? .you : .them,
+                text: text,
+                timestamp: startedAt.addingTimeInterval(Double(index) * spacing)
+            )
+        }
+    }
 }


### PR DESCRIPTION
Fixes #458

## Summary
- add a conservative guard before batch re-transcription overwrites an existing transcript
- fail the batch rerun when the new transcript clearly collapses relative to a substantial existing transcript
- treat empty batch output as a failure instead of a misleading completed state
- add focused overwrite-guard tests

## QA
- `swift test --package-path /Users/nima/dev/cloned/OpenOats/OpenOats --filter BatchAudioTranscriberTests`
- `swift test --package-path /Users/nima/dev/cloned/OpenOats/OpenOats --filter SessionRepositoryTests`
- `swift build -c debug --package-path /Users/nima/dev/cloned/OpenOats/OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`