### PR TITLE
Add OpenPhone (Quo) to default meeting-app allowlist

### DIFF
--- a/OpenOats/Sources/OpenOats/Meeting/MeetingDetector.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/MeetingDetector.swift
@@ -388,5 +388,6 @@ actor MeetingDetector {
         MeetingAppEntry(bundleID: "com.hnc.Discord", displayName: "Discord"),
         MeetingAppEntry(bundleID: "net.whatsapp.WhatsApp", displayName: "WhatsApp"),
         MeetingAppEntry(bundleID: "com.google.Chrome.app.kjgfgldnnfobanmcafgkdilakhehfkbm", displayName: "Google Meet (PWA)"),
+        MeetingAppEntry(bundleID: "ca.illusive.openphone", displayName: "OpenPhone"),
     ]
 }


### PR DESCRIPTION
Closes #460

## Summary

- Add OpenPhone (`ca.illusive.openphone`, ships as "Quo" on macOS) to the default meeting-app allowlist in `MeetingDetector.swift`
- OpenPhone is a widely used VoIP business phone app in sales and SMB teams
- Consistent with existing allowlist entries for WhatsApp, Slack, and Discord

## Changes

One line addition to `defaultMeetingApps` array. No new dependencies, settings, or permissions.