### PR TITLE
Add diagnostics logging toggle and export flow

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -138,12 +138,17 @@ final class LiveSessionController {
         let calEvent = calendarEventOverride ?? (settings.calendarIntegrationEnabled
             ? container.calendarManager?.currentEvent()
             : nil)
+        DiagnosticsSupport.record(
+            category: "meeting",
+            message: "Start requested (calendarEvent=\(calEvent == nil ? "no" : "yes"))"
+        )
         pendingInitialScratchpad = initialScratchpad?.trimmingCharacters(in: .newlines)
         let metadata = MeetingMetadata.manual(calendarEvent: calEvent)
         coordinator.handle(.userStarted(metadata), settings: settings)
     }
 
     func stopSession(settings: AppSettings) {
+        DiagnosticsSupport.record(category: "meeting", message: "Stop requested")
         coordinator.handle(.userStopped, settings: settings)
     }
 
@@ -329,12 +334,19 @@ final class LiveSessionController {
             calendarEvent: metadata.calendarEvent
         )
         let handle: SessionHandle
+        let reusedAbandonedRow: Bool
         if let resumed = await coordinator.sessionRepository.resumeAbandonedSession(config: startConfig) {
             handle = resumed
+            reusedAbandonedRow = true
         } else {
             handle = await coordinator.sessionRepository.startSession(config: startConfig)
+            reusedAbandonedRow = false
         }
         _currentSessionID = handle.sessionID
+        DiagnosticsSupport.record(
+            category: "meeting",
+            message: "\(reusedAbandonedRow ? "Reused" : "Started") session \(handle.sessionID) model=\(settings?.transcriptionModel.rawValue ?? "unknown")"
+        )
         let initialScratchpad = pendingInitialScratchpad?.trimmingCharacters(in: .whitespacesAndNewlines)
         pendingInitialScratchpad = nil
         state.scratchpadText = initialScratchpad ?? ""
@@ -528,12 +540,20 @@ final class LiveSessionController {
            let mergedSessionID = await coordinator.sessionRepository.reconcileGhostSession(sessionID: sessionID) {
             effectiveIndex = await coordinator.sessionRepository.loadSession(id: mergedSessionID).index
             shouldRunBatchRetranscription = false
+            DiagnosticsSupport.record(
+                category: "meeting",
+                message: "Collapsed empty duplicate session \(sessionID) into \(mergedSessionID)"
+            )
         }
 
         // 8. Update UI state + refresh history
         coordinator.lastEndedSession = effectiveIndex
         coordinator.sessionTemplateSnapshot = nil
         _currentSessionID = nil
+        DiagnosticsSupport.record(
+            category: "meeting",
+            message: "Finalized session \(effectiveIndex.id) utterances=\(utteranceCount) batch=\(shouldRunBatchRetranscription ? "on" : "off")"
+        )
         await coordinator.loadHistory()
 
         // 9. Kick off batch transcription if enabled
@@ -563,6 +583,9 @@ final class LiveSessionController {
         coordinator.transcriptionEngine?.stop()
         coordinator.audioRecorder?.discardRecording()
         coordinator.transcriptStore.clear()
+        if let sessionID = _currentSessionID {
+            DiagnosticsSupport.record(category: "meeting", message: "Discarded session \(sessionID)")
+        }
         _currentSessionID = nil
         Task {
             await coordinator.sessionRepository.endSession()

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -21,6 +21,7 @@ public struct OpenOatsRootApp: App {
         self._container = State(initialValue: context.container)
         self.updaterController = context.updaterController
         self.defaults = context.container.defaults
+        DiagnosticsSupport.record(category: "app", message: "App initialized")
     }
 
     public var body: some Scene {
@@ -34,6 +35,7 @@ public struct OpenOatsRootApp: App {
                     appDelegate.settings = settings
                     appDelegate.defaults = defaults
                     appDelegate.container = container
+                    DiagnosticsSupport.record(category: "app", message: "Main window appeared")
                     if case .live = container.mode {
                         appDelegate.setupMenuBarIfNeeded(
                             coordinator: coordinator,

--- a/OpenOats/Sources/OpenOats/Intelligence/KnowledgeBase.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/KnowledgeBase.swift
@@ -421,7 +421,7 @@ final class KnowledgeBase {
         do {
             queryEmbeddings = try await embedTexts(validQueries, inputType: "query")
         } catch {
-            print("KB search embed error: \(error)")
+            Log.knowledgeBase.error("KB search embed error: \(error, privacy: .public)")
             return []
         }
 
@@ -466,7 +466,7 @@ final class KnowledgeBase {
                     ))
                 }
             } catch {
-                print("KB rerank error (falling back to cosine): \(error)")
+                Log.knowledgeBase.error("KB rerank error (falling back to cosine): \(error, privacy: .public)")
             }
         }
 

--- a/OpenOats/Sources/OpenOats/Intelligence/SidecastEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SidecastEngine.swift
@@ -104,7 +104,7 @@ final class SidecastEngine {
                     self.isGenerating = false
                 }
             } catch {
-                print("[SidecastEngine] generation failed: \(error)")
+                Log.sidecast.error("Generation failed: \(error, privacy: .public)")
                 await MainActor.run {
                     self.isGenerating = false
                 }

--- a/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
@@ -198,7 +198,7 @@ final class SuggestionEngine {
                 transcriptStore.markConversationStateUpdated(processedThrough: processedThroughUtteranceID)
             }
         } catch {
-            print("[SuggestionEngine] Background state update failed: \(error)")
+            Log.suggestionEngine.error("Background state update failed: \(error, privacy: .public)")
         }
     }
 
@@ -419,7 +419,7 @@ final class SuggestionEngine {
         } catch is CancellationError {
             markSuperseded(suggestionID)
         } catch {
-            print("[SuggestionEngine] Synthesis stream error: \(error)")
+            Log.suggestionEngine.error("Synthesis stream error: \(error, privacy: .public)")
             if !Task.isCancelled {
                 if let idx = activeSuggestions.firstIndex(where: { $0.id == suggestionID }),
                    activeSuggestions[idx].lifecycle != .superseded {

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -663,6 +663,17 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _diagnosticLoggingEnabled: Bool
+    var diagnosticLoggingEnabled: Bool {
+        get { access(keyPath: \.diagnosticLoggingEnabled); return _diagnosticLoggingEnabled }
+        set {
+            withMutation(keyPath: \.diagnosticLoggingEnabled) {
+                _diagnosticLoggingEnabled = newValue
+                defaults.set(newValue, forKey: "diagnosticLoggingEnabled")
+            }
+        }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _hasShownAutoDetectExplanation: Bool
     var hasShownAutoDetectExplanation: Bool {
         get { access(keyPath: \.hasShownAutoDetectExplanation); return _hasShownAutoDetectExplanation }
@@ -1202,6 +1213,7 @@ final class SettingsStore {
         self._silenceTimeoutMinutes = defaults.object(forKey: "silenceTimeoutMinutes") != nil
             ? defaults.integer(forKey: "silenceTimeoutMinutes") : 15
         self._detectionLogEnabled = defaults.bool(forKey: "detectionLogEnabled")
+        self._diagnosticLoggingEnabled = defaults.bool(forKey: "diagnosticLoggingEnabled")
         self._hasShownAutoDetectExplanation = defaults.bool(forKey: "hasShownAutoDetectExplanation")
         self._hasShownCameraDetectExplanation = defaults.bool(forKey: "hasShownCameraDetectExplanation")
         self._calendarIntegrationEnabled = defaults.bool(forKey: "calendarIntegrationEnabled")

--- a/OpenOats/Sources/OpenOats/Storage/TemplateStore.swift
+++ b/OpenOats/Sources/OpenOats/Storage/TemplateStore.swift
@@ -238,7 +238,7 @@ final class TemplateStore {
                 }
             }
         } catch {
-            print("TemplateStore: failed to load, using defaults: \(error)")
+            Log.templateStore.error("Failed to load templates, using defaults: \(error, privacy: .public)")
             templates = Self.builtInTemplates
         }
         save()
@@ -251,7 +251,7 @@ final class TemplateStore {
             try data.write(to: storageURL, options: .atomic)
             try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: storageURL.path)
         } catch {
-            print("TemplateStore: failed to save: \(error)")
+            Log.templateStore.error("Failed to save templates: \(error, privacy: .public)")
         }
     }
 }

--- a/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
@@ -95,9 +95,11 @@ actor BatchAudioTranscriber {
                 )
             } catch is CancellationError {
                 await self.setStatus(.cancelled)
+                DiagnosticsSupport.record(category: "batch", message: "Batch transcription cancelled for \(sessionID)")
                 Log.batchTranscription.info("Batch transcription cancelled for \(sessionID, privacy: .public)")
             } catch {
                 await self.setStatus(.failed(error.localizedDescription))
+                DiagnosticsSupport.record(category: "batch", message: "Batch transcription failed for \(sessionID): \(error.localizedDescription)")
                 Log.batchTranscription.error("Batch transcription failed: \(error, privacy: .public)")
             }
         }
@@ -140,10 +142,12 @@ actor BatchAudioTranscriber {
             } catch is CancellationError {
                 await self.setStatus(.cancelled)
                 await self.setIsImporting(false)
+                DiagnosticsSupport.record(category: "batch", message: "Audio import cancelled for \(sessionID)")
                 Log.batchTranscription.info("Audio import cancelled for \(sessionID, privacy: .public)")
             } catch {
                 await self.setStatus(.failed(error.localizedDescription))
                 await self.setIsImporting(false)
+                DiagnosticsSupport.record(category: "batch", message: "Audio import failed for \(sessionID): \(error.localizedDescription)")
                 Log.batchTranscription.error("Audio import failed: \(error, privacy: .public)")
             }
         }
@@ -159,6 +163,7 @@ actor BatchAudioTranscriber {
         sessionRepository: SessionRepository
     ) async throws {
         Log.batchTranscription.info("Starting audio import for \(sessionID, privacy: .public) from \(url.lastPathComponent, privacy: .public)")
+        DiagnosticsSupport.record(category: "batch", message: "Starting audio import for \(sessionID) model=\(model.rawValue)")
         status = .loading(model: model.displayName)
 
         // Prepare backend and VAD
@@ -204,6 +209,7 @@ actor BatchAudioTranscriber {
 
         guard !records.isEmpty else {
             Log.batchTranscription.warning("Audio import produced no records for \(sessionID, privacy: .public)")
+            DiagnosticsSupport.record(category: "batch", message: "Audio import produced no speech for \(sessionID)")
             status = .failed("No speech detected in the audio file")
             isImporting = false
             return
@@ -227,6 +233,7 @@ actor BatchAudioTranscriber {
 
         status = .completed(sessionID: sessionID)
         isImporting = false
+        DiagnosticsSupport.record(category: "batch", message: "Audio import completed for \(sessionID) records=\(records.count)")
         Log.batchTranscription.info("Audio import completed for \(sessionID, privacy: .public): \(records.count, privacy: .public) records")
     }
 
@@ -250,12 +257,14 @@ actor BatchAudioTranscriber {
         diarizationVariant: DiarizationVariant
     ) async throws {
         Log.batchTranscription.info("Starting batch transcription for \(sessionID, privacy: .public) with \(model.rawValue, privacy: .public)")
+        DiagnosticsSupport.record(category: "batch", message: "Starting batch transcription for \(sessionID) model=\(model.rawValue)")
         status = .loading(model: model.displayName)
 
         // Load batch metadata
         let urls = await sessionRepository.batchAudioURLs(sessionID: sessionID)
         guard urls.mic != nil || urls.sys != nil else {
             Log.batchTranscription.warning("No batch audio found for \(sessionID, privacy: .public)")
+            DiagnosticsSupport.record(category: "batch", message: "No retained batch audio found for \(sessionID)")
             status = .failed("No audio files found")
             return
         }
@@ -351,8 +360,10 @@ actor BatchAudioTranscriber {
         guard !allRecords.isEmpty else {
             Log.batchTranscription.warning("Batch transcription produced no records for \(sessionID, privacy: .public)")
             if existingRecords.isEmpty {
+                DiagnosticsSupport.record(category: "batch", message: "Batch transcription produced no speech for \(sessionID)")
                 status = .failed("Batch re-transcription produced no speech")
             } else {
+                DiagnosticsSupport.record(category: "batch", message: "Batch transcription produced no speech for \(sessionID); kept existing transcript")
                 status = .failed("Batch re-transcription produced no speech; kept existing transcript")
             }
             return
@@ -365,6 +376,7 @@ actor BatchAudioTranscriber {
             Log.batchTranscription.warning(
                 "Skipping batch transcript overwrite for \(sessionID, privacy: .public): \(rejectionReason, privacy: .public)"
             )
+            DiagnosticsSupport.record(category: "batch", message: "Rejected batch overwrite for \(sessionID): \(rejectionReason)")
             status = .failed(rejectionReason)
             return
         }
@@ -379,6 +391,7 @@ actor BatchAudioTranscriber {
         // SessionRepository purges expired retained assets on startup.
 
         status = .completed(sessionID: sessionID)
+        DiagnosticsSupport.record(category: "batch", message: "Batch transcription completed for \(sessionID) records=\(allRecords.count)")
         Log.batchTranscription.info("Batch transcription completed for \(sessionID, privacy: .public): \(allRecords.count, privacy: .public) records")
     }
 

--- a/OpenOats/Sources/OpenOats/Utils/DiagnosticsSupport.swift
+++ b/OpenOats/Sources/OpenOats/Utils/DiagnosticsSupport.swift
@@ -1,0 +1,253 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+struct DiagnosticsSettingsSnapshot: Sendable, Equatable {
+    let notesGenerationProvider: String
+    let transcriptionModel: String
+    let batchTranscriptionModel: String
+    let knowledgeRetrievalProvider: String
+    let knowledgeBaseConfigured: Bool
+    let meetingDetectionEnabled: Bool
+    let calendarIntegrationEnabled: Bool
+    let saveAudioRecording: Bool
+    let batchRetranscriptionEnabled: Bool
+    let diagnosticLoggingEnabled: Bool
+
+    init(
+        notesGenerationProvider: String,
+        transcriptionModel: String,
+        batchTranscriptionModel: String,
+        knowledgeRetrievalProvider: String,
+        knowledgeBaseConfigured: Bool,
+        meetingDetectionEnabled: Bool,
+        calendarIntegrationEnabled: Bool,
+        saveAudioRecording: Bool,
+        batchRetranscriptionEnabled: Bool,
+        diagnosticLoggingEnabled: Bool
+    ) {
+        self.notesGenerationProvider = notesGenerationProvider
+        self.transcriptionModel = transcriptionModel
+        self.batchTranscriptionModel = batchTranscriptionModel
+        self.knowledgeRetrievalProvider = knowledgeRetrievalProvider
+        self.knowledgeBaseConfigured = knowledgeBaseConfigured
+        self.meetingDetectionEnabled = meetingDetectionEnabled
+        self.calendarIntegrationEnabled = calendarIntegrationEnabled
+        self.saveAudioRecording = saveAudioRecording
+        self.batchRetranscriptionEnabled = batchRetranscriptionEnabled
+        self.diagnosticLoggingEnabled = diagnosticLoggingEnabled
+    }
+
+    @MainActor
+    init(settings: SettingsStore) {
+        notesGenerationProvider = settings.llmProvider.rawValue
+        transcriptionModel = settings.transcriptionModel.rawValue
+        batchTranscriptionModel = settings.batchTranscriptionModel.rawValue
+        knowledgeRetrievalProvider = settings.embeddingProvider.rawValue
+        knowledgeBaseConfigured = settings.kbFolderURL != nil
+        meetingDetectionEnabled = settings.meetingAutoDetectEnabled
+        calendarIntegrationEnabled = settings.calendarIntegrationEnabled
+        saveAudioRecording = settings.saveAudioRecording
+        batchRetranscriptionEnabled = settings.enableBatchRetranscription
+        diagnosticLoggingEnabled = settings.diagnosticLoggingEnabled
+    }
+}
+
+struct DiagnosticsReportBuilder {
+    struct AppInfo: Sendable, Equatable {
+        let generatedAt: Date
+        let bundleIdentifier: String
+        let version: String
+        let build: String
+        let macOSVersion: String
+    }
+
+    static func buildText(
+        appInfo: AppInfo,
+        settings: DiagnosticsSettingsSnapshot,
+        breadcrumbs: String,
+        unifiedLog: String
+    ) -> String {
+        let formatter = ISO8601DateFormatter()
+        var lines: [String] = []
+        lines.append("OpenOats Diagnostics Export")
+        lines.append("Generated at: \(formatter.string(from: appInfo.generatedAt))")
+        lines.append("Bundle ID: \(appInfo.bundleIdentifier)")
+        lines.append("Version: \(appInfo.version) (\(appInfo.build))")
+        lines.append("macOS: \(appInfo.macOSVersion)")
+        lines.append("")
+        lines.append("Settings")
+        lines.append("--------")
+        lines.append("Notes generation: \(settings.notesGenerationProvider)")
+        lines.append("Transcription model: \(settings.transcriptionModel)")
+        lines.append("Batch model: \(settings.batchTranscriptionModel)")
+        lines.append("Knowledge retrieval: \(settings.knowledgeRetrievalProvider)")
+        lines.append("Knowledge base configured: \(settings.knowledgeBaseConfigured ? "yes" : "no")")
+        lines.append("Meeting detection: \(settings.meetingDetectionEnabled ? "on" : "off")")
+        lines.append("Calendar integration: \(settings.calendarIntegrationEnabled ? "on" : "off")")
+        lines.append("Save audio recording: \(settings.saveAudioRecording ? "on" : "off")")
+        lines.append("Batch re-transcription: \(settings.batchRetranscriptionEnabled ? "on" : "off")")
+        lines.append("Diagnostic logging: \(settings.diagnosticLoggingEnabled ? "on" : "off")")
+        lines.append("")
+        lines.append("Breadcrumbs")
+        lines.append("-----------")
+        lines.append(breadcrumbs.isEmpty ? "(none)" : breadcrumbs)
+        lines.append("")
+        lines.append("Unified Log")
+        lines.append("-----------")
+        lines.append(unifiedLog.isEmpty ? "(no recent log entries)" : unifiedLog)
+        lines.append("")
+        return lines.joined(separator: "\n")
+    }
+}
+
+actor DiagnosticsBreadcrumbStore {
+    static let shared = DiagnosticsBreadcrumbStore()
+
+    private let key = "diagnosticLoggingEnabled"
+    private let maxLines = 1000
+
+    func record(category: String, message: String) {
+        guard UserDefaults.standard.bool(forKey: key) else { return }
+        let formatter = ISO8601DateFormatter()
+        let line = "[\(formatter.string(from: Date()))] [\(category)] \(message)\n"
+        let url = breadcrumbsURL()
+        let directory = url.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            var lines = ((try? String(contentsOf: url, encoding: .utf8)) ?? "")
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .map(String.init)
+            lines.append(line.trimmingCharacters(in: .newlines))
+            if lines.count > maxLines {
+                lines = Array(lines.suffix(maxLines))
+            }
+            let payload = lines.filter { !$0.isEmpty }.joined(separator: "\n")
+            try payload.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            Log.diagnostics.error("Failed to append diagnostic breadcrumb: \(error, privacy: .public)")
+        }
+    }
+
+    func loadContents() -> String {
+        let url = breadcrumbsURL()
+        return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+    }
+
+    private func breadcrumbsURL() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport
+            .appendingPathComponent("OpenOats", isDirectory: true)
+            .appendingPathComponent("diagnostics", isDirectory: true)
+            .appendingPathComponent("breadcrumbs.log")
+    }
+}
+
+enum DiagnosticsSupport {
+    enum Error: LocalizedError, Equatable {
+        case cancelled
+        case writeFailed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .cancelled:
+                return "Diagnostics export was cancelled."
+            case .writeFailed(let reason):
+                return reason
+            }
+        }
+    }
+
+    static func record(category: String, message: String) {
+        Task {
+            await DiagnosticsBreadcrumbStore.shared.record(category: category, message: message)
+        }
+    }
+
+    @MainActor
+    static func exportInteractively(settings: SettingsStore) async throws -> URL {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.plainText]
+        panel.canCreateDirectories = true
+        panel.nameFieldStringValue = defaultFilename()
+        panel.title = "Export Diagnostics"
+        panel.message = "Exports recent app logs and a small diagnostics summary for debugging."
+
+        guard panel.runModal() == .OK, let destination = panel.url else {
+            throw Error.cancelled
+        }
+
+        let report = await generateReport(settings: settings)
+        do {
+            try report.write(to: destination, atomically: true, encoding: .utf8)
+            return destination
+        } catch {
+            throw Error.writeFailed("Failed to write diagnostics export: \(error.localizedDescription)")
+        }
+    }
+
+    private static func defaultFilename() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        return "openoats-diagnostics-\(formatter.string(from: Date())).txt"
+    }
+
+    @MainActor
+    private static func generateReport(settings: SettingsStore) async -> String {
+        let bundle = Bundle.main
+        let bundleID = bundle.bundleIdentifier ?? "com.openoats.app"
+        let appInfo = DiagnosticsReportBuilder.AppInfo(
+            generatedAt: Date(),
+            bundleIdentifier: bundleID,
+            version: bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown",
+            build: bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown",
+            macOSVersion: ProcessInfo.processInfo.operatingSystemVersionString
+        )
+        let settingsSnapshot = DiagnosticsSettingsSnapshot(settings: settings)
+        let breadcrumbs = await DiagnosticsBreadcrumbStore.shared.loadContents()
+        let unifiedLog = await unifiedLogReport(bundleIdentifier: bundleID)
+        return DiagnosticsReportBuilder.buildText(
+            appInfo: appInfo,
+            settings: settingsSnapshot,
+            breadcrumbs: breadcrumbs,
+            unifiedLog: unifiedLog
+        )
+    }
+
+    private static func unifiedLogReport(bundleIdentifier: String) async -> String {
+        await Task.detached(priority: .utility) {
+            let subsystems = Set([bundleIdentifier, "com.openoats.app"]).sorted()
+            let predicate = subsystems
+                .map { "subsystem == \"\($0)\"" }
+                .joined(separator: " OR ")
+
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/log")
+            process.arguments = [
+                "show",
+                "--style", "compact",
+                "--last", "2h",
+                "--predicate", predicate,
+            ]
+
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+
+            do {
+                try process.run()
+                process.waitUntilExit()
+                let output = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                let errors = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+                if process.terminationStatus == 0 {
+                    return output.trimmingCharacters(in: .whitespacesAndNewlines)
+                }
+                let detail = errors.isEmpty ? output : errors
+                return "Failed to collect recent unified logs.\n\(detail.trimmingCharacters(in: .whitespacesAndNewlines))"
+            } catch {
+                return "Failed to collect recent unified logs.\n\(error.localizedDescription)"
+            }
+        }.value
+    }
+}

--- a/OpenOats/Sources/OpenOats/Utils/Logging.swift
+++ b/OpenOats/Sources/OpenOats/Utils/Logging.swift
@@ -18,6 +18,11 @@ enum Log {
     static let appleNotes = Logger(subsystem: subsystem, category: "AppleNotes")
     static let webhook = Logger(subsystem: subsystem, category: "Webhook")
     static let whisperkit = Logger(subsystem: subsystem, category: "WhisperKitManager")
+    static let knowledgeBase = Logger(subsystem: subsystem, category: "KnowledgeBase")
+    static let suggestionEngine = Logger(subsystem: subsystem, category: "SuggestionEngine")
+    static let sidecast = Logger(subsystem: subsystem, category: "SidecastEngine")
+    static let templateStore = Logger(subsystem: subsystem, category: "TemplateStore")
+    static let diagnostics = Logger(subsystem: subsystem, category: "Diagnostics")
 
     private static let subsystem = Bundle(for: BundleToken.self).bundleIdentifier ?? "com.openoats.app"
 }

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -63,6 +63,9 @@ private struct GeneralSettingsTab: View {
     @State private var showAutoDetectExplanation = false
     @State private var launchAtLoginEnabled = false
     @State private var showWizard = false
+    @State private var diagnosticsExportMessage: String?
+    @State private var diagnosticsExportHadError = false
+    @State private var diagnosticsExportInFlight = false
 
     var body: some View {
         ScrollView {
@@ -246,6 +249,31 @@ private struct GeneralSettingsTab: View {
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                 }
+
+                Section("Troubleshooting") {
+                    Toggle("Diagnostic logging", isOn: $settings.diagnosticLoggingEnabled)
+                        .font(.system(size: 12))
+
+                    Text("Keeps a small internal breadcrumb trail for session and batch lifecycle debugging. Use Export Diagnostics to share recent technical logs without exposing API keys.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+
+                    Button(diagnosticsExportInFlight ? "Exporting…" : "Export Diagnostics…") {
+                        exportDiagnostics()
+                    }
+                    .font(.system(size: 12))
+                    .disabled(diagnosticsExportInFlight)
+
+                    Text("Exports a plain-text bundle with recent unified logs, non-sensitive app settings, and any diagnostic breadcrumbs collected while the toggle was enabled.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+
+                    if let diagnosticsExportMessage {
+                        Text(diagnosticsExportMessage)
+                            .font(.system(size: 11))
+                            .foregroundStyle(diagnosticsExportHadError ? .red : .secondary)
+                    }
+                }
             }
             .formStyle(.grouped)
         }
@@ -274,6 +302,32 @@ private struct GeneralSettingsTab: View {
         if panel.runModal() == .OK, let url = panel.url {
             settings.notesFolderPath = url.path
             settings.saveNotesFolderBookmark(from: url)
+        }
+    }
+
+    private func exportDiagnostics() {
+        diagnosticsExportInFlight = true
+        diagnosticsExportMessage = nil
+        diagnosticsExportHadError = false
+
+        Task { @MainActor in
+            defer { diagnosticsExportInFlight = false }
+            do {
+                let url = try await DiagnosticsSupport.exportInteractively(settings: settings)
+                diagnosticsExportMessage = "Saved diagnostics to \(url.lastPathComponent)."
+                diagnosticsExportHadError = false
+            } catch let error as DiagnosticsSupport.Error {
+                switch error {
+                case .cancelled:
+                    diagnosticsExportMessage = nil
+                default:
+                    diagnosticsExportMessage = error.localizedDescription
+                    diagnosticsExportHadError = true
+                }
+            } catch {
+                diagnosticsExportMessage = error.localizedDescription
+                diagnosticsExportHadError = true
+            }
         }
     }
 }

--- a/OpenOats/Tests/OpenOatsTests/DiagnosticsSupportTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/DiagnosticsSupportTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class DiagnosticsSupportTests: XCTestCase {
+    func testDiagnosticsReportIncludesSettingsAndLogs() {
+        let appInfo = DiagnosticsReportBuilder.AppInfo(
+            generatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            bundleIdentifier: "com.openoats.app",
+            version: "1.56.0",
+            build: "123",
+            macOSVersion: "macOS 15.0"
+        )
+        let settings = DiagnosticsSettingsSnapshot(
+            notesGenerationProvider: "openRouter",
+            transcriptionModel: "parakeetV3",
+            batchTranscriptionModel: "whisperLargeV3Turbo",
+            knowledgeRetrievalProvider: "voyageAI",
+            knowledgeBaseConfigured: true,
+            meetingDetectionEnabled: true,
+            calendarIntegrationEnabled: false,
+            saveAudioRecording: true,
+            batchRetranscriptionEnabled: true,
+            diagnosticLoggingEnabled: true
+        )
+
+        let report = DiagnosticsReportBuilder.buildText(
+            appInfo: appInfo,
+            settings: settings,
+            breadcrumbs: "[2026-01-01T12:00:00Z] [meeting] Started session",
+            unifiedLog: "2026-01-01 12:00:00.000 OpenOats[1:1] test line"
+        )
+
+        XCTAssertTrue(report.contains("OpenOats Diagnostics Export"))
+        XCTAssertTrue(report.contains("Bundle ID: com.openoats.app"))
+        XCTAssertTrue(report.contains("Notes generation: openRouter"))
+        XCTAssertTrue(report.contains("Knowledge base configured: yes"))
+        XCTAssertTrue(report.contains("[meeting] Started session"))
+        XCTAssertTrue(report.contains("test line"))
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -221,6 +221,14 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(reopened.enableBatchRetranscription)
     }
 
+    func testDiagnosticLoggingRoundTrip() {
+        let store = makeStore()
+        XCTAssertFalse(store.diagnosticLoggingEnabled)
+
+        store.diagnosticLoggingEnabled = true
+        XCTAssertTrue(store.diagnosticLoggingEnabled)
+    }
+
     func testDefaultBatchTranscriptionModel() {
         let store = makeStore()
         XCTAssertEqual(store.batchTranscriptionModel, .whisperLargeV3Turbo)


### PR DESCRIPTION
Fixes #464

## Summary
- add a `Troubleshooting` section in Settings > General with `Diagnostic logging` and `Export Diagnostics…`
- export recent unified logs, a bounded breadcrumb trail, and a non-sensitive settings summary
- add high-level breadcrumbs for app launch, meeting lifecycle, and batch transcription/import flows
- replace remaining stray `print` calls in touched code with `Logger` usage

## Validation
- `swift test --package-path OpenOats --filter 'SettingsStoreTests|DiagnosticsSupportTests|BatchAudioTranscriberTests'`\n- `swift build -c debug --package-path OpenOats`