### PR TITLE
Block OpenRouter requests without configured API key

### DIFF
--- a/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
@@ -52,6 +52,18 @@ actor OpenRouterClient {
         return host.contains("openrouter.ai") || host.contains("openai.com")
     }
 
+    static func preflightError(for url: URL, apiKey: String?) -> OpenRouterError? {
+        guard let host = url.host?.lowercased(), host.contains("openrouter.ai") else {
+            return nil
+        }
+
+        guard let apiKey, !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .missingAPIKey(host: host)
+        }
+
+        return nil
+    }
+
     /// Streams the completion response, yielding text chunks.
     func streamCompletion(
         apiKey: String? = nil,
@@ -64,6 +76,10 @@ actor OpenRouterClient {
             let task = Task {
                 do {
                     let targetURL = baseURL ?? Self.defaultBaseURL
+                    if let preflightError = Self.preflightError(for: targetURL, apiKey: apiKey) {
+                        continuation.finish(throwing: preflightError)
+                        return
+                    }
                     let useNewParam = Self.usesMaxCompletionTokens(targetURL)
                     let request = ChatRequest(
                         model: model,
@@ -134,6 +150,9 @@ actor OpenRouterClient {
         webSearch: Bool = false
     ) async throws -> String {
         let targetURL = baseURL ?? Self.defaultBaseURL
+        if let preflightError = Self.preflightError(for: targetURL, apiKey: apiKey) {
+            throw preflightError
+        }
         let useNewParam = Self.usesMaxCompletionTokens(targetURL)
         let request = ChatRequest(
             model: model,
@@ -172,6 +191,7 @@ actor OpenRouterClient {
 
     enum OpenRouterError: Error, LocalizedError {
         case httpError(Int, host: String?)
+        case missingAPIKey(host: String?)
 
         var errorDescription: String? {
             switch self {
@@ -183,6 +203,13 @@ actor OpenRouterClient {
                 case nil: "LLM"
                 }
                 return "\(provider) API error (HTTP \(code))"
+            case .missingAPIKey(let host):
+                let provider = switch host {
+                case let h? where h.contains("openrouter.ai"): "OpenRouter"
+                case let h?: h
+                case nil: "LLM"
+                }
+                return "\(provider) API key required"
             }
         }
     }

--- a/OpenOats/Tests/OpenOatsTests/OpenRouterClientTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/OpenRouterClientTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class OpenRouterClientTests: XCTestCase {
+    func testPreflightErrorRequiresAPIKeyForOpenRouterHost() throws {
+        let url = try XCTUnwrap(URL(string: "https://openrouter.ai/api/v1/chat/completions"))
+
+        let error = OpenRouterClient.preflightError(for: url, apiKey: nil)
+
+        guard case .missingAPIKey(let host)? = error else {
+            return XCTFail("Expected missing API key error for OpenRouter host")
+        }
+        XCTAssertEqual(host, "openrouter.ai")
+        XCTAssertEqual(error?.errorDescription, "OpenRouter API key required")
+    }
+
+    func testPreflightErrorAllowsOpenRouterHostWhenAPIKeyExists() throws {
+        let url = try XCTUnwrap(URL(string: "https://openrouter.ai/api/v1/chat/completions"))
+
+        let error = OpenRouterClient.preflightError(for: url, apiKey: "sk-or-v1-test")
+
+        XCTAssertNil(error)
+    }
+
+    func testPreflightErrorDoesNotRequireAPIKeyForLocalOpenAICompatibleHost() throws {
+        let url = try XCTUnwrap(URL(string: "http://localhost:11434/v1/chat/completions"))
+
+        let error = OpenRouterClient.preflightError(for: url, apiKey: nil)
+
+        XCTAssertNil(error)
+    }
+
+    func testPreflightErrorDoesNotRequireAPIKeyForRemoteCustomHost() throws {
+        let url = try XCTUnwrap(URL(string: "https://api.example.com/v1/chat/completions"))
+
+        let error = OpenRouterClient.preflightError(for: url, apiKey: nil)
+
+        XCTAssertNil(error)
+    }
+}


### PR DESCRIPTION
Fixes #462

## Summary
- add an OpenRouter client preflight that refuses to call openrouter.ai without an API key
- apply that guard before both streaming and non-streaming OpenRouter requests
- add focused tests covering OpenRouter vs local/custom-host behavior

## Validation
- swift test --package-path OpenOats --filter OpenRouterClientTests
- swift test --package-path OpenOats --filter 'NotesEngineTests|BatchTextCleanerTests'\n- swift build -c debug --package-path OpenOats