### PR TITLE
Add folder picker to Coming up meetings

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -275,6 +275,10 @@ struct IdleHomeDashboardView: View {
 
                 folderColorGrid(selectedColor: $newFolderColor)
 
+                Label("Future meetings like this will use this folder by default.", systemImage: "arrow.triangle.branch")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+
                 HStack {
                     Spacer()
 

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -547,9 +547,7 @@ private struct ComingUpEventRow: View {
             }
         } label: {
             HStack(spacing: 4) {
-                Image(systemName: preferredFolderPath == nil ? "folder" : "folder.fill")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(folderColor(for: preferredFolderPath))
+                folderGlyphBadge(for: preferredFolderPath)
 
                 if isFolderHovering {
                     Text(folderDisplayName(for: preferredFolderPath))
@@ -568,7 +566,7 @@ private struct ComingUpEventRow: View {
                     .fill(isFolderHovering ? Color.primary.opacity(0.05) : .clear)
             )
         }
-        .menuStyle(.borderlessButton)
+        .menuStyle(.button)
         .menuIndicator(.hidden)
         .buttonStyle(.plain)
         .contentShape(RoundedRectangle(cornerRadius: 8))
@@ -631,6 +629,21 @@ private struct ComingUpEventRow: View {
 
     private func folderColor(for folderPath: String?) -> Color {
         folderColor(for: folderDefinition(for: folderPath)?.color ?? .gray)
+    }
+
+    @ViewBuilder
+    private func folderGlyphBadge(for folderPath: String?) -> some View {
+        let color = folderColor(for: folderPath)
+
+        ZStack {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(color.opacity(0.14))
+                .frame(width: 24, height: 24)
+
+            Image(systemName: folderPath == nil ? "folder" : "folder.fill")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(color)
+        }
     }
 
     private func folderColor(for color: NotesFolderColor) -> Color {

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -275,10 +275,6 @@ struct IdleHomeDashboardView: View {
 
                 folderColorGrid(selectedColor: $newFolderColor)
 
-                Label("Future meetings like this will use this folder by default.", systemImage: "arrow.triangle.branch")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-
                 HStack {
                     Spacer()
 

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -9,6 +9,10 @@ struct IdleHomeDashboardView: View {
 
     @State private var events: [CalendarEvent] = []
     @State private var refreshTick = 0
+    @State private var creatingFolderEvent: CalendarEvent?
+    @State private var newFolderPath = ""
+    @State private var newFolderColor: NotesFolderColor = .orange
+    @FocusState private var newFolderFieldFocused: Bool
 
     var body: some View {
         let accessState = currentAccessState
@@ -31,6 +35,14 @@ struct IdleHomeDashboardView: View {
         }
         .onChange(of: settings.calendarIntegrationEnabled) {
             refreshTick &+= 1
+        }
+        .sheet(
+            isPresented: Binding(
+                get: { creatingFolderEvent != nil },
+                set: { if !$0 { cancelCreateFolder() } }
+            )
+        ) {
+            comingUpFolderSheet
         }
     }
 
@@ -116,8 +128,11 @@ struct IdleHomeDashboardView: View {
                 ComingUpDayGroupView(
                     group: group,
                     showCalendarTitle: shouldShowCalendarTitle,
+                    settings: settings,
+                    sessionHistory: coordinator.sessionHistory,
                     onJoinEvent: joinMeeting(for:),
-                    onOpenRelatedNotes: openRelatedNotes(for:)
+                    onOpenRelatedNotes: openRelatedNotes(for:),
+                    onCreateFolder: beginCreateFolder(for:)
                 )
                 if index < groups.count - 1 {
                     Divider()
@@ -222,13 +237,164 @@ struct IdleHomeDashboardView: View {
         coordinator.queueMeetingHistory(event)
         openWindow(id: "notes")
     }
+
+    private func beginCreateFolder(for event: CalendarEvent) {
+        let preferredFolderPath = settings.meetingFamilyPreferences(for: event)?.folderPath
+        newFolderPath = preferredFolderPath ?? ""
+        newFolderColor = folderDefinition(for: preferredFolderPath)?.color ?? .orange
+        creatingFolderEvent = event
+    }
+
+    private func cancelCreateFolder() {
+        creatingFolderEvent = nil
+        newFolderPath = ""
+        newFolderColor = .orange
+        newFolderFieldFocused = false
+    }
+
+    @ViewBuilder
+    private var comingUpFolderSheet: some View {
+        if let event = creatingFolderEvent {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("New Default Folder")
+                    .font(.headline)
+
+                Text("Use a top-level folder and at most one subfolder, like `Work` or `Work/1:1s`.")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+
+                TextField("e.g. Work/1:1s", text: $newFolderPath)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($newFolderFieldFocused)
+                    .onAppear {
+                        newFolderFieldFocused = true
+                    }
+                    .onSubmit {
+                        commitCreateFolder(for: event)
+                    }
+
+                folderColorGrid(selectedColor: $newFolderColor)
+
+                HStack {
+                    Spacer()
+
+                    Button("Cancel") {
+                        cancelCreateFolder()
+                    }
+                    .keyboardShortcut(.cancelAction)
+
+                    Button("Create") {
+                        commitCreateFolder(for: event)
+                    }
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(normalizedMeetingFamilyFolderPath(newFolderPath) == nil)
+                }
+            }
+            .padding(20)
+            .frame(width: 360)
+        }
+    }
+
+    @ViewBuilder
+    private func folderColorGrid(selectedColor: Binding<NotesFolderColor>) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Color")
+                .font(.system(size: 12, weight: .medium))
+            LazyVGrid(columns: Array(repeating: GridItem(.fixed(28), spacing: 8), count: 4), spacing: 8) {
+                ForEach(NotesFolderColor.allCases) { color in
+                    Button {
+                        selectedColor.wrappedValue = color
+                    } label: {
+                        ZStack {
+                            Circle()
+                                .fill(folderColor(for: color))
+                                .frame(width: 18, height: 18)
+                            if selectedColor.wrappedValue == color {
+                                Image(systemName: "checkmark")
+                                    .font(.system(size: 8, weight: .bold))
+                                    .foregroundStyle(.white)
+                            }
+                        }
+                        .frame(width: 28, height: 28)
+                        .background(
+                            Circle()
+                                .stroke(
+                                    selectedColor.wrappedValue == color ? Color.primary.opacity(0.35) : Color.secondary.opacity(0.15),
+                                    lineWidth: 1
+                                )
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .help(color.displayName)
+                }
+            }
+        }
+    }
+
+    private func commitCreateFolder(for event: CalendarEvent) {
+        guard let normalizedPath = normalizedMeetingFamilyFolderPath(newFolderPath) else { return }
+
+        var folders = settings.notesFolders
+        if let existingIndex = folders.firstIndex(where: { $0.path.caseInsensitiveCompare(normalizedPath) == .orderedSame }) {
+            folders[existingIndex].color = newFolderColor
+        } else {
+            folders.append(NotesFolderDefinition(path: normalizedPath, color: newFolderColor))
+        }
+        settings.notesFolders = folders
+        settings.setMeetingFamilyFolderPreference(normalizedPath, for: event)
+        cancelCreateFolder()
+    }
+
+    private func normalizedMeetingFamilyFolderPath(_ rawPath: String) -> String? {
+        guard let normalized = NotesFolderDefinition.normalizePath(rawPath) else { return nil }
+        return normalized.split(separator: "/").count <= 2 ? normalized : nil
+    }
+
+    private func folderDefinition(for folderPath: String?) -> NotesFolderDefinition? {
+        guard let folderPath else { return nil }
+        return settings.notesFolders.first {
+            $0.path.localizedCaseInsensitiveCompare(folderPath) == .orderedSame
+        }
+    }
+
+    private func folderDisplayName(for folderPath: String?) -> String {
+        folderDefinition(for: folderPath)?.displayName ?? "My notes"
+    }
+
+    private func folderColor(for folderPath: String?) -> Color {
+        folderColor(for: folderDefinition(for: folderPath)?.color ?? .gray)
+    }
+
+    private func folderColor(for color: NotesFolderColor) -> Color {
+        switch color {
+        case .gray:
+            return Color.secondary
+        case .orange:
+            return .orange
+        case .gold:
+            return Color(red: 0.74, green: 0.61, blue: 0.23)
+        case .purple:
+            return Color(red: 0.58, green: 0.48, blue: 0.86)
+        case .blue:
+            return .blue
+        case .teal:
+            return .teal
+        case .green:
+            return .green
+        case .red:
+            return .red
+        }
+    }
 }
 
 private struct ComingUpDayGroupView: View {
     let group: UpcomingCalendarGrouping.DayGroup
     let showCalendarTitle: Bool
+    let settings: AppSettings
+    let sessionHistory: [SessionIndex]
     let onJoinEvent: (CalendarEvent) -> Void
     let onOpenRelatedNotes: (CalendarEvent) -> Void
+    let onCreateFolder: (CalendarEvent) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
@@ -242,8 +408,11 @@ private struct ComingUpDayGroupView: View {
                     ComingUpEventRow(
                         event: event,
                         showCalendarTitle: showCalendarTitle,
+                        settings: settings,
+                        sessionHistory: sessionHistory,
                         onJoinEvent: onJoinEvent,
-                        onOpenRelatedNotes: onOpenRelatedNotes
+                        onOpenRelatedNotes: onOpenRelatedNotes,
+                        onCreateFolder: onCreateFolder
                     )
                 }
             }
@@ -254,13 +423,16 @@ private struct ComingUpDayGroupView: View {
 private struct ComingUpEventRow: View {
     let event: CalendarEvent
     let showCalendarTitle: Bool
+    let settings: AppSettings
+    let sessionHistory: [SessionIndex]
     let onJoinEvent: (CalendarEvent) -> Void
     let onOpenRelatedNotes: (CalendarEvent) -> Void
+    let onCreateFolder: (CalendarEvent) -> Void
 
     @State private var isHovering = false
-
+    @State private var isFolderHovering = false
     var body: some View {
-        HStack(alignment: .top, spacing: 8) {
+        HStack(alignment: .center, spacing: 8) {
             Button(action: {
                 onOpenRelatedNotes(event)
             }) {
@@ -280,11 +452,6 @@ private struct ComingUpEventRow: View {
                     }
 
                     Spacer(minLength: 0)
-
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(.tertiary)
-                        .padding(.top, 2)
                 }
                 .padding(.horizontal, 8)
                 .padding(.vertical, 6)
@@ -300,6 +467,8 @@ private struct ComingUpEventRow: View {
             }
             .help("Open meeting history")
             .accessibilityIdentifier("idle.comingUp.event.\(event.id)")
+
+            folderMenu
 
             if event.meetingURL != nil {
                 Button(action: {
@@ -321,6 +490,95 @@ private struct ComingUpEventRow: View {
         }
     }
 
+    private var folderMenu: some View {
+        let preferredFolderPath = settings.meetingFamilyPreferences(for: event)?.folderPath
+        let choices = meetingFamilyFolderChoices(including: preferredFolderPath)
+
+        return Menu {
+            Button {
+                settings.setMeetingFamilyFolderPreference(nil, for: event)
+            } label: {
+                HStack {
+                    Image(systemName: "folder")
+                        .foregroundStyle(.secondary)
+                    Text("My notes")
+                    if preferredFolderPath == nil {
+                        Spacer()
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+
+            if !choices.isEmpty {
+                Divider()
+                ForEach(choices) { folder in
+                    Button {
+                        settings.setMeetingFamilyFolderPreference(folder.path, for: event)
+                    } label: {
+                        HStack {
+                            Image(systemName: "folder.fill")
+                                .foregroundStyle(folderColor(for: folder.color))
+                            VStack(alignment: .leading, spacing: 1) {
+                                Text(folder.displayName)
+                                if let breadcrumb = folder.breadcrumb {
+                                    Text(breadcrumb)
+                                        .font(.system(size: 10))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            if preferredFolderPath?.localizedCaseInsensitiveCompare(folder.path) == .orderedSame {
+                                Spacer()
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+
+            Divider()
+
+            Button {
+                onCreateFolder(event)
+            } label: {
+                HStack {
+                    Image(systemName: "folder.badge.plus")
+                    Text("New Folder…")
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: preferredFolderPath == nil ? "folder" : "folder.fill")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(folderColor(for: preferredFolderPath))
+
+                if isFolderHovering {
+                    Text(folderDisplayName(for: preferredFolderPath))
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .frame(minWidth: 28, minHeight: 28)
+            .padding(.horizontal, isFolderHovering ? 8 : 0)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isFolderHovering ? Color.primary.opacity(0.05) : .clear)
+            )
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .buttonStyle(.plain)
+        .contentShape(RoundedRectangle(cornerRadius: 8))
+        .onHover { hovering in
+            isFolderHovering = hovering
+        }
+        .help(folderHelpText(for: preferredFolderPath))
+        .accessibilityIdentifier("idle.comingUp.folder.\(event.id)")
+    }
+
     private func secondaryLine(for event: CalendarEvent) -> String {
         let time = CalendarEventDisplay.timeRange(for: event)
         guard showCalendarTitle,
@@ -337,6 +595,63 @@ private struct ComingUpEventRow: View {
             return .accentColor
         }
         return color
+    }
+
+    private func folderHelpText(for preferredFolderPath: String?) -> String {
+        let matchingHistoryCount = MeetingHistoryResolver.matchingSessions(
+            forHistoryKey: settings.canonicalMeetingHistoryKey(for: event),
+            sessionHistory: sessionHistory,
+            aliases: settings.meetingHistoryAliasesByKey
+        ).count
+        let base = "Default folder: \(folderDisplayName(for: preferredFolderPath))"
+        guard matchingHistoryCount > 0 else { return base }
+        let noun = matchingHistoryCount == 1 ? "saved meeting" : "saved meetings"
+        return "\(base). \(matchingHistoryCount) \(noun) already exist for this meeting family."
+    }
+
+    private func meetingFamilyFolderChoices(including preferredFolderPath: String?) -> [NotesFolderDefinition] {
+        settings.notesFolders
+            .filter {
+                $0.path.split(separator: "/").count <= 2
+                    || $0.path.localizedCaseInsensitiveCompare(preferredFolderPath ?? "") == .orderedSame
+            }
+            .sorted { $0.path.localizedCaseInsensitiveCompare($1.path) == .orderedAscending }
+    }
+
+    private func folderDefinition(for folderPath: String?) -> NotesFolderDefinition? {
+        guard let folderPath else { return nil }
+        return settings.notesFolders.first {
+            $0.path.localizedCaseInsensitiveCompare(folderPath) == .orderedSame
+        }
+    }
+
+    private func folderDisplayName(for folderPath: String?) -> String {
+        folderDefinition(for: folderPath)?.displayName ?? "My notes"
+    }
+
+    private func folderColor(for folderPath: String?) -> Color {
+        folderColor(for: folderDefinition(for: folderPath)?.color ?? .gray)
+    }
+
+    private func folderColor(for color: NotesFolderColor) -> Color {
+        switch color {
+        case .gray:
+            return Color.secondary
+        case .orange:
+            return .orange
+        case .gold:
+            return Color(red: 0.74, green: 0.61, blue: 0.23)
+        case .purple:
+            return Color(red: 0.58, green: 0.48, blue: 0.86)
+        case .blue:
+            return .blue
+        case .teal:
+            return .teal
+        case .green:
+            return .green
+        case .red:
+            return .red
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #473

## What changed
- added a folder picker directly to each `Coming up` row
- the row-level control updates the meeting-family default folder for that meeting
- the picker supports `My notes`, existing folders, and `New Folder…`
- new folders created from this flow respect the existing two-level folder limit
- the folder icon uses the selected folder color, while the label stays hover-only to keep the row quiet
- removed the old row chevron so the right edge stays visually stable

## Why
Meeting-family folder defaults already exist, but the main preparation screen had no direct way to set them. This adds the filing control to the place where users are deciding what to do before a meeting starts.

## Screenshot
![Coming up folder picker](https://raw.githubusercontent.com/kkarimi/OpenOats/pr-assets-coming-up-folder-picker/.github/pr-assets/coming-up-folder-picker.png)

<img width="332" height="130" alt="image" src="https://github.com/user-attachments/assets/cfc519d2-f456-4f11-a906-a259c901e910" />


## Validation
- `swift test --package-path OpenOats --filter SettingsStoreTests`
- `swift test --package-path OpenOats --filter UpcomingCalendarGroupingTests`
- `swift test --package-path OpenOats --filter LiveSessionControllerTests`
- `./scripts/run_ui_smoke.sh`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
