### PR TITLE
Show earlier meetings from today in Coming up

### DIFF
--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -94,6 +94,29 @@ final class CalendarManager {
         return events.map { CalendarEvent(from: $0) }
     }
 
+    /// Calendar events occurring on the same local day as the given date, ordered by start date.
+    /// Returns an empty array if access is not authorized.
+    func events(onSameDayAs date: Date = Date()) -> [CalendarEvent] {
+        guard accessState == .authorized else { return [] }
+        let calendars = eventCalendars()
+        let calendar = Calendar.current
+        let startOfDay = calendar.startOfDay(for: date)
+        guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else {
+            return []
+        }
+
+        let predicate = store.predicateForEvents(
+            withStart: startOfDay,
+            end: endOfDay,
+            calendars: calendars
+        )
+        let events = store.events(matching: predicate)
+            .filter { !$0.isAllDay }
+            .sorted { $0.startDate < $1.startDate }
+
+        return events.map { CalendarEvent(from: $0) }
+    }
+
     // MARK: - Helpers
 
     private func eventCalendars() -> [EKCalendar] {

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -8,6 +8,8 @@ struct IdleHomeDashboardView: View {
     @Environment(\.openWindow) private var openWindow
 
     @State private var events: [CalendarEvent] = []
+    @State private var earlierTodayEvents: [CalendarEvent] = []
+    @State private var showsEarlierToday = false
     @State private var refreshTick = 0
     @State private var creatingFolderEvent: CalendarEvent?
     @State private var newFolderPath = ""
@@ -130,6 +132,9 @@ struct IdleHomeDashboardView: View {
                     showCalendarTitle: shouldShowCalendarTitle,
                     settings: settings,
                     sessionHistory: coordinator.sessionHistory,
+                    earlierTodayEvents: Calendar.current.isDateInToday(group.date) ? earlierTodayEvents : [],
+                    showsEarlierToday: Calendar.current.isDateInToday(group.date) ? showsEarlierToday : false,
+                    onToggleEarlierToday: { showsEarlierToday.toggle() },
                     onJoinEvent: joinMeeting(for:),
                     onOpenRelatedNotes: openRelatedNotes(for:),
                     onCreateFolder: beginCreateFolder(for:)
@@ -156,16 +161,19 @@ struct IdleHomeDashboardView: View {
     private func refresh() async {
         guard settings.calendarIntegrationEnabled, let manager = container.calendarManager else {
             events = []
+            earlierTodayEvents = []
             return
         }
 
         guard manager.accessState == .authorized else {
             events = []
+            earlierTodayEvents = []
             return
         }
 
         let now = Date()
         let currentEvent = manager.currentEvent(at: now)
+        let dayEvents = manager.events(onSameDayAs: now)
         let upcomingEvents = manager.upcomingEvents(
             from: now,
             within: 7 * 24 * 60 * 60,
@@ -184,6 +192,15 @@ struct IdleHomeDashboardView: View {
         )
         combined.append(contentsOf: selectedUpcoming)
         events = combined
+
+        earlierTodayEvents = EarlierTodaySelection.select(
+            from: dayEvents,
+            now: now,
+            currentEventID: currentEvent?.id
+        )
+        if earlierTodayEvents.isEmpty {
+            showsEarlierToday = false
+        }
     }
 
     private var currentAccessState: CalendarManager.AccessState {
@@ -392,6 +409,9 @@ private struct ComingUpDayGroupView: View {
     let showCalendarTitle: Bool
     let settings: AppSettings
     let sessionHistory: [SessionIndex]
+    let earlierTodayEvents: [CalendarEvent]
+    let showsEarlierToday: Bool
+    let onToggleEarlierToday: () -> Void
     let onJoinEvent: (CalendarEvent) -> Void
     let onOpenRelatedNotes: (CalendarEvent) -> Void
     let onCreateFolder: (CalendarEvent) -> Void
@@ -404,9 +424,14 @@ private struct ComingUpDayGroupView: View {
                 .textCase(.uppercase)
 
             VStack(alignment: .leading, spacing: 10) {
+                if !earlierTodayEvents.isEmpty {
+                    earlierTodayDisclosure
+                }
+
                 ForEach(group.events) { event in
                     ComingUpEventRow(
                         event: event,
+                        showJoinButton: true,
                         showCalendarTitle: showCalendarTitle,
                         settings: settings,
                         sessionHistory: sessionHistory,
@@ -418,10 +443,78 @@ private struct ComingUpDayGroupView: View {
             }
         }
     }
+
+    @ViewBuilder
+    private var earlierTodayDisclosure: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Rectangle()
+                    .fill(Color.secondary.opacity(0.18))
+                    .frame(height: 1)
+
+                Button(action: onToggleEarlierToday) {
+                    HStack(spacing: 5) {
+                        Image(systemName: showsEarlierToday ? "chevron.down" : "chevron.right")
+                            .font(.system(size: 10, weight: .semibold))
+                        Text("Earlier today")
+                        Text("\(earlierTodayEvents.count)")
+                            .foregroundStyle(.tertiary)
+                    }
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        Capsule()
+                            .fill(Color.primary.opacity(0.04))
+                    )
+                }
+                .buttonStyle(.plain)
+
+                Rectangle()
+                    .fill(Color.secondary.opacity(0.18))
+                    .frame(height: 1)
+            }
+
+            if showsEarlierToday {
+                VStack(alignment: .leading, spacing: 10) {
+                    ForEach(earlierTodayEvents) { event in
+                        ComingUpEventRow(
+                            event: event,
+                            showJoinButton: false,
+                            showCalendarTitle: showCalendarTitle,
+                            settings: settings,
+                            sessionHistory: sessionHistory,
+                            onJoinEvent: onJoinEvent,
+                            onOpenRelatedNotes: onOpenRelatedNotes,
+                            onCreateFolder: onCreateFolder
+                        )
+                    }
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
+
+                if !group.events.isEmpty {
+                    DashedSeparator()
+                }
+            }
+        }
+        .padding(.top, 2)
+    }
+}
+
+private struct DashedSeparator: View {
+    var body: some View {
+        Rectangle()
+            .stroke(style: StrokeStyle(lineWidth: 1, dash: [4, 4]))
+            .foregroundStyle(Color.secondary.opacity(0.24))
+            .frame(height: 1)
+            .padding(.vertical, 2)
+    }
 }
 
 private struct ComingUpEventRow: View {
     let event: CalendarEvent
+    let showJoinButton: Bool
     let showCalendarTitle: Bool
     let settings: AppSettings
     let sessionHistory: [SessionIndex]
@@ -470,7 +563,7 @@ private struct ComingUpEventRow: View {
 
             folderMenu
 
-            if event.meetingURL != nil {
+            if showJoinButton, event.meetingURL != nil {
                 Button(action: {
                     onJoinEvent(event)
                 }) {
@@ -732,6 +825,25 @@ enum UpcomingEventSelection {
             return "title:\(calendarTitle)"
         }
         return "event:\(event.id)"
+    }
+}
+
+enum EarlierTodaySelection {
+    static func select(
+        from dayEvents: [CalendarEvent],
+        now: Date,
+        currentEventID: String?
+    ) -> [CalendarEvent] {
+        dayEvents
+            .filter { event in
+                event.endDate <= now && event.id != currentEventID
+            }
+            .sorted { lhs, rhs in
+                if lhs.startDate != rhs.startDate {
+                    return lhs.startDate > rhs.startDate
+                }
+                return lhs.id > rhs.id
+            }
     }
 }
 

--- a/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
@@ -172,18 +172,55 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
         XCTAssertEqual(UpcomingEventSelection.distinctCalendarCount(in: events), 2)
     }
 
+    func testEarlierTodaySelectionReturnsEndedMeetingsNewestFirst() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let older = makeEvent(
+            id: "older",
+            title: "Morning Sync",
+            start: now.addingTimeInterval(-4_000),
+            duration: 1_200
+        )
+        let newer = makeEvent(
+            id: "newer",
+            title: "Lunch Review",
+            start: now.addingTimeInterval(-2_000),
+            duration: 1_200
+        )
+        let current = makeEvent(
+            id: "current",
+            title: "Current Meeting",
+            start: now.addingTimeInterval(-300),
+            duration: 1_800
+        )
+        let future = makeEvent(
+            id: "future",
+            title: "Later Today",
+            start: now.addingTimeInterval(1_800),
+            duration: 1_200
+        )
+
+        let selected = EarlierTodaySelection.select(
+            from: [older, future, current, newer],
+            now: now,
+            currentEventID: current.id
+        )
+
+        XCTAssertEqual(selected.map(\.id), ["newer", "older"])
+    }
+
     private func makeEvent(
         id: String,
         title: String,
         start: Date,
         calendarID: String? = nil,
-        calendarTitle: String? = nil
+        calendarTitle: String? = nil,
+        duration: TimeInterval = 30 * 60
     ) -> CalendarEvent {
         CalendarEvent(
             id: id,
             title: title,
             startDate: start,
-            endDate: start.addingTimeInterval(30 * 60),
+            endDate: start.addingTimeInterval(duration),
             calendarID: calendarID,
             calendarTitle: calendarTitle,
             calendarColorHex: nil,


### PR DESCRIPTION
Fixes #477

## Summary

- add an `Earlier today` disclosure inside the `Today` section of `Coming up`
- fetch ended meetings from earlier in the same day separately from the normal upcoming selection
- keep notes/folder affordances on those older rows while hiding join
- use a dashed separator to distinguish earlier-today rows from the current/upcoming list

## Why

This is the first slice toward letting users add their own transcript to a past meeting. Before that workflow exists, the dashboard needs a natural way to reveal meetings that already happened earlier today.

### Screenshot
<img width="557" height="211" alt="Screenshot 2026-04-24 at 14 37 08" src="https://github.com/user-attachments/assets/ccada063-79d1-42a6-8283-b20f15a24719" />

## Validation

- `swift test --package-path OpenOats --filter UpcomingCalendarGroupingTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`