### PR TITLE
Add manual transcript import for no-transcript sessions

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -627,6 +627,25 @@ final class NotesController {
         }
     }
 
+    func addManualTranscript(_ rawText: String) {
+        guard let sessionID = state.selectedSessionID else { return }
+
+        let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+
+        let baseDate = state.sessionHistory.first(where: { $0.id == sessionID })?.startedAt
+            ?? state.loadedCalendarEvent?.startDate
+            ?? Date()
+        let records = ManualTranscriptImporter.records(from: trimmed, baseDate: baseDate)
+        guard !records.isEmpty else { return }
+
+        Task {
+            await coordinator.sessionRepository.saveManualTranscriptSource(sessionID: sessionID, text: trimmed)
+            await coordinator.sessionRepository.saveFinalTranscript(sessionID: sessionID, records: records)
+            await reloadSessionAfterTranscriptMutation(sessionID: sessionID)
+        }
+    }
+
     // MARK: - Transcript Cleanup
 
     func cleanUpTranscript(settings: AppSettings) {
@@ -1350,5 +1369,76 @@ final class NotesController {
         if state.streamingMarkdown != engine.generatedMarkdown {
             state.streamingMarkdown = engine.generatedMarkdown
         }
+    }
+}
+
+private enum ManualTranscriptImporter {
+    private static let timestampPrefixPattern = #"^\s*(?:\[\s*\d{1,2}:\d{2}(?::\d{2})?\s*\]|\d{1,2}:\d{2}(?::\d{2})?)\s*"#
+
+    static func records(from text: String, baseDate: Date) -> [SessionRecord] {
+        let lines = text
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
+        guard !lines.isEmpty else { return [] }
+
+        return lines.enumerated().compactMap { index, line in
+            let strippedTimestamp = line.replacingOccurrences(
+                of: timestampPrefixPattern,
+                with: "",
+                options: .regularExpression
+            )
+            let (speaker, body) = parseSpeakerAndBody(from: strippedTimestamp)
+            let trimmedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedBody.isEmpty else { return nil }
+
+            return SessionRecord(
+                speaker: speaker,
+                text: trimmedBody,
+                timestamp: baseDate.addingTimeInterval(TimeInterval(index * 30))
+            )
+        }
+    }
+
+    private static func parseSpeakerAndBody(from line: String) -> (Speaker, String) {
+        let separators = [":", "-", "–", "—"]
+        for separator in separators {
+            guard let range = line.range(of: separator) else { continue }
+            let rawSpeaker = line[..<range.lowerBound].trimmingCharacters(in: .whitespacesAndNewlines)
+            let body = String(line[range.upperBound...])
+            if let speaker = speaker(from: rawSpeaker) {
+                return (speaker, body)
+            }
+        }
+        return (.them, line)
+    }
+
+    private static func speaker(from raw: String) -> Speaker? {
+        let normalized = raw
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        switch normalized {
+        case "you", "me", "i":
+            return .you
+        case "them", "other", "speaker":
+            return .them
+        default:
+            break
+        }
+
+        if normalized.hasPrefix("speaker "),
+           let number = Int(normalized.dropFirst("speaker ".count)) {
+            return .remote(number)
+        }
+
+        if normalized.hasPrefix("remote "),
+           let number = Int(normalized.dropFirst("remote ".count)) {
+            return .remote(number)
+        }
+
+        return nil
     }
 }

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -554,6 +554,25 @@ actor SessionRepository {
         scheduleMirror(sessionID: sessionID)
     }
 
+    func saveManualTranscriptSource(sessionID: String, text: String) {
+        let dir = sessionDirectory(for: sessionID)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let url = dir.appendingPathComponent("transcript.manual.txt")
+
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            try? FileManager.default.removeItem(at: url)
+            return
+        }
+
+        try? trimmed.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    func loadManualTranscriptSource(sessionID: String) -> String? {
+        let url = sessionDirectory(for: sessionID).appendingPathComponent("transcript.manual.txt")
+        return try? String(contentsOf: url, encoding: .utf8)
+    }
+
     private func backupTranscriptForBatchOverwrite(sessionID: String) {
         let dir = sessionDirectory(for: sessionID)
         let fm = FileManager.default

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -27,6 +27,8 @@ struct NotesView: View {
     @State private var newTagText: String = ""
     @State private var availableTags: [String] = []
     @State private var confirmRestoreOriginalTranscript = false
+    @State private var showingAddTranscriptSheet = false
+    @State private var manualTranscriptDraft = ""
 
     enum DetailViewMode: String, CaseIterable {
         case transcript = "Transcript"
@@ -137,6 +139,9 @@ struct NotesView: View {
             )
         ) {
             meetingFamilyFolderSheetContent(controller: controller)
+        }
+        .sheet(isPresented: $showingAddTranscriptSheet) {
+            addTranscriptSheet(controller: controller)
         }
         .confirmationDialog(
             "Update default folder?",
@@ -2585,7 +2590,18 @@ struct NotesView: View {
     @ViewBuilder
     private func transcriptView(controller: NotesController, state: NotesState) -> some View {
         if state.loadedTranscript.isEmpty {
-            ContentUnavailableView("No Transcript", systemImage: "waveform", description: Text("This session has no recorded utterances."))
+            ContentUnavailableView {
+                Label("No Transcript", systemImage: "waveform")
+            } description: {
+                Text("This session has no recorded utterances.")
+            } actions: {
+                Button {
+                    beginAddTranscript()
+                } label: {
+                    Label("Add Transcript", systemImage: "text.badge.plus")
+                }
+                .buttonStyle(.bordered)
+            }
         } else {
             ScrollView {
                 if case .inProgress(let completed, let total) = state.cleanupStatus {
@@ -2822,6 +2838,64 @@ struct NotesView: View {
         f.dateFormat = "HH:mm:ss"
         return f
     }()
+
+    @ViewBuilder
+    private func addTranscriptSheet(controller: NotesController) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Add Transcript")
+                .font(.headline)
+
+            Text("Paste transcript text for this meeting. One line per utterance works best. Prefix lines with `You:`, `Them:`, or `Speaker 2:` for basic speaker parsing.")
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+
+            TextEditor(text: $manualTranscriptDraft)
+                .font(.system(size: 13))
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: 240)
+                .padding(10)
+                .background(Color(nsColor: .textBackgroundColor).opacity(0.85))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(.quaternary, lineWidth: 1)
+                )
+
+            HStack {
+                Spacer()
+
+                Button("Cancel") {
+                    cancelAddTranscript()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Add Transcript") {
+                    commitAddTranscript(controller: controller)
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(manualTranscriptDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(20)
+        .frame(width: 540)
+    }
+
+    private func beginAddTranscript() {
+        manualTranscriptDraft = ""
+        showingAddTranscriptSheet = true
+    }
+
+    private func cancelAddTranscript() {
+        showingAddTranscriptSheet = false
+        manualTranscriptDraft = ""
+    }
+
+    private func commitAddTranscript(controller: NotesController) {
+        let trimmed = manualTranscriptDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        controller.addManualTranscript(trimmed)
+        cancelAddTranscript()
+    }
 }
 
 // MARK: - FlowLayout

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -235,6 +235,48 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(controller.state.loadedTranscript.map(\.text), ["Original live"])
     }
 
+    func testAddManualTranscriptPersistsSourceAndReloadsTranscript() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_add_manual_transcript"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID, utterances: [])
+
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+        XCTAssertTrue(controller.state.loadedTranscript.isEmpty)
+
+        controller.addManualTranscript("You: Hello there.\nThem: Hi, how are you?")
+        try? await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertEqual(controller.state.loadedTranscript.map(\.text), ["Hello there.", "Hi, how are you?"])
+        XCTAssertEqual(controller.state.loadedTranscript.map(\.speaker), [.you, .them])
+
+        let rawSource = await coordinator.sessionRepository.loadManualTranscriptSource(sessionID: sessionID)
+        XCTAssertEqual(rawSource, "You: Hello there.\nThem: Hi, how are you?")
+    }
+
+    func testAddManualTranscriptStripsTimestampsAndParsesRemoteSpeakers() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_manual_transcript_parsing"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID, utterances: [])
+
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        controller.addManualTranscript("""
+        [00:10] You: Kickoff
+        00:20 Speaker 2: Response
+        Loose closing line
+        """)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertEqual(controller.state.loadedTranscript.map(\.text), ["Kickoff", "Response", "Loose closing line"])
+        XCTAssertEqual(controller.state.loadedTranscript.map(\.speaker), [.you, .remote(2), .them])
+    }
+
     func testGenerateNotesUpdatesStatus() async {
         let (root, notes) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -478,6 +478,25 @@ final class SessionRepositoryTests: XCTestCase {
 
     // MARK: - saveFinalTranscript
 
+    func testSaveAndLoadManualTranscriptSource() async {
+        let sessionID = "session_manual_source"
+        await repo.seedSession(
+            id: sessionID,
+            records: [],
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        await repo.saveManualTranscriptSource(sessionID: sessionID, text: "You: Hello\nThem: Hi")
+        let saved = await repo.loadManualTranscriptSource(sessionID: sessionID)
+        XCTAssertEqual(saved, "You: Hello\nThem: Hi")
+
+        await repo.saveManualTranscriptSource(sessionID: sessionID, text: "   ")
+        let cleared = await repo.loadManualTranscriptSource(sessionID: sessionID)
+        XCTAssertNil(cleared)
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
     func testSaveFinalTranscript() async {
         let sessionID = "session_final_test"
         let initialStart = Date(timeIntervalSince1970: 100)


### PR DESCRIPTION
Fixes #480

## Summary
- add an `Add Transcript` action in the Transcript tab empty state for existing no-transcript sessions
- persist the pasted raw text as `transcript.manual.txt`
- convert the pasted text into a basic `transcript.final.jsonl` and reload the selected session
- keep the empty-state action quieter with a bordered control instead of a bright primary CTA

## Notes
- speaker parsing supports simple prefixes like `You:`, `Them:`, and `Speaker 2:`
- leading timestamps are stripped during import
- this first slice is for existing session rows only, not direct import from an `Earlier today` calendar row

## Validation
- `swift test --package-path OpenOats --filter NotesControllerTests`
- `swift test --package-path OpenOats --filter SessionRepositoryTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
- `./scripts/run_ui_smoke.sh`
