### PR TITLE
Add transcript flow for earlier meetings from today

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -20,6 +20,7 @@ final class AppCoordinator {
         enum Target: Equatable {
             case session(String)
             case meetingHistory(CalendarEvent)
+            case manualTranscript(CalendarEvent)
             case clearSelection
         }
 
@@ -238,6 +239,10 @@ final class AppCoordinator {
 
     func queueMeetingHistory(_ event: CalendarEvent) {
         requestedNotesNavigation = NotesNavigationRequest(target: .meetingHistory(event))
+    }
+
+    func queueManualTranscript(_ event: CalendarEvent) {
+        requestedNotesNavigation = NotesNavigationRequest(target: .manualTranscript(event))
     }
 
     func consumeRequestedSessionSelection() -> NotesNavigationRequest.Target? {

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -188,6 +188,9 @@ final class NotesController {
             case .meetingHistory(let event):
                 showMeetingFamily(for: event)
                 return true
+            case .manualTranscript(let event):
+                _ = await prepareManualTranscriptSession(for: event)
+                return true
             case .clearSelection:
                 selectSession(nil)
                 return true
@@ -214,6 +217,8 @@ final class NotesController {
             case .session(let sessionID):
                 selectSession(sessionID)
             case .meetingHistory(let event):
+                showMeetingFamily(for: event)
+            case .manualTranscript(let event):
                 showMeetingFamily(for: event)
             case .clearSelection:
                 selectSession(nil)
@@ -342,6 +347,29 @@ final class NotesController {
 
     func showMeetingHistory(for event: CalendarEvent) {
         showMeetingFamily(for: event)
+    }
+
+    func createManualTranscriptSession(for event: CalendarEvent) async -> String {
+        let preferredFolderPath = settings?.meetingFamilyPreferences(for: event)?.folderPath
+        let sessionID = await coordinator.sessionRepository.createManualTranscriptSession(
+            config: .init(
+                title: event.title,
+                startedAt: event.startDate,
+                endedAt: event.endDate,
+                calendarEvent: event,
+                folderPath: preferredFolderPath
+            )
+        )
+        await coordinator.loadHistory()
+        await loadHistory()
+        selectSession(sessionID)
+        return sessionID
+    }
+
+    func prepareManualTranscriptSession(for event: CalendarEvent) async -> Bool {
+        let sessionID = await createManualTranscriptSession(for: event)
+        let transcript = await coordinator.sessionRepository.loadTranscript(sessionID: sessionID)
+        return transcript.isEmpty
     }
 
     func linkMeetingHistorySuggestion(_ suggestion: MeetingHistorySuggestion) {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -88,6 +88,14 @@ struct SessionFinalizeMetadata: Sendable {
     }
 }
 
+struct ManualTranscriptSessionConfig: Sendable {
+    let title: String
+    let startedAt: Date
+    let endedAt: Date
+    let calendarEvent: CalendarEvent
+    let folderPath: String?
+}
+
 /// Full session detail for loading.
 struct SessionDetail: Sendable {
     let index: SessionIndex
@@ -471,6 +479,35 @@ actor SessionRepository {
             language: config.language,
             engine: config.engine,
             source: "imported"
+        )
+        writeSessionMetadata(metadata, sessionID: sessionID)
+
+        return sessionID
+    }
+
+    @discardableResult
+    func createManualTranscriptSession(config: ManualTranscriptSessionConfig) -> String {
+        if let existingSessionID = existingSessionID(for: config.calendarEvent, referenceDate: config.startedAt) {
+            return existingSessionID
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        let sessionID = "session_\(formatter.string(from: config.startedAt))"
+
+        let sessionDir = sessionDirectory(for: sessionID)
+        try? FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+
+        let metadata = SessionMetadata(
+            id: sessionID,
+            startedAt: config.startedAt,
+            endedAt: config.endedAt,
+            title: config.title,
+            utteranceCount: 0,
+            hasNotes: false,
+            folderPath: Self.normalizeSessionFolderPath(config.folderPath),
+            source: "manual",
+            calendarEvent: config.calendarEvent
         )
         writeSessionMetadata(metadata, sessionID: sessionID)
 
@@ -1059,6 +1096,44 @@ actor SessionRepository {
                metadata.calendarEvent?.id == referenceEventID {
                 return (candidate.id, true, gap)
             }
+
+            let candidateTitle = metadata.title ?? metadata.calendarEvent?.title
+            guard MeetingHistoryResolver.historyKey(for: candidateTitle ?? "") == historyKey else {
+                return nil
+            }
+
+            return (candidate.id, false, gap)
+        }
+        .sorted { lhs, rhs in
+            if lhs.exactEventMatch != rhs.exactEventMatch {
+                return lhs.exactEventMatch && !rhs.exactEventMatch
+            }
+            return lhs.gap < rhs.gap
+        }
+
+        return candidates.first?.id
+    }
+
+    private func existingSessionID(
+        for event: CalendarEvent,
+        referenceDate: Date,
+        maximumGap: TimeInterval = 6 * 60 * 60
+    ) -> String? {
+        let historyKey = MeetingHistoryResolver.historyKey(for: event)
+        let referenceEventID = event.id
+
+        let candidates = listSessions().compactMap { candidate -> (id: String, exactEventMatch: Bool, gap: TimeInterval)? in
+            guard let metadata = loadSessionMetadataFile(sessionID: candidate.id) else {
+                return nil
+            }
+
+            let gap = abs(metadata.startedAt.timeIntervalSince(referenceDate))
+
+            if metadata.calendarEvent?.id == referenceEventID {
+                return (candidate.id, true, gap)
+            }
+
+            guard gap <= maximumGap else { return nil }
 
             let candidateTitle = metadata.title ?? metadata.calendarEvent?.title
             guard MeetingHistoryResolver.historyKey(for: candidateTitle ?? "") == historyKey else {

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -56,7 +56,7 @@ struct IdleHomeDashboardView: View {
             } else {
                 switch accessState {
                 case .authorized:
-                    if events.isEmpty {
+                    if events.isEmpty && earlierTodayEvents.isEmpty {
                         emptyStateCard(
                             title: "No upcoming meetings",
                             description: "OpenOats will show your next calendar meetings here."
@@ -122,7 +122,10 @@ struct IdleHomeDashboardView: View {
     }
 
     private var upcomingMeetingsCard: some View {
-        let groups = UpcomingCalendarGrouping.groups(for: events)
+        let groups = ComingUpDayGroupSelection.groups(
+            for: events,
+            earlierTodayEvents: earlierTodayEvents
+        )
         let shouldShowCalendarTitle = UpcomingEventSelection.distinctCalendarCount(in: events) > 1
 
         return VStack(alignment: .leading, spacing: 14) {
@@ -251,7 +254,11 @@ struct IdleHomeDashboardView: View {
     }
 
     private func openRelatedNotes(for event: CalendarEvent) {
-        coordinator.queueMeetingHistory(event)
+        if event.endDate <= Date() {
+            coordinator.queueManualTranscript(event)
+        } else {
+            coordinator.queueMeetingHistory(event)
+        }
         openWindow(id: "notes")
     }
 
@@ -844,6 +851,28 @@ enum EarlierTodaySelection {
                 }
                 return lhs.id > rhs.id
             }
+    }
+}
+
+enum ComingUpDayGroupSelection {
+    static func groups(
+        for upcomingEvents: [CalendarEvent],
+        earlierTodayEvents: [CalendarEvent],
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [UpcomingCalendarGrouping.DayGroup] {
+        var groups = UpcomingCalendarGrouping.groups(for: upcomingEvents, calendar: calendar)
+        guard !earlierTodayEvents.isEmpty else { return groups }
+
+        let today = calendar.startOfDay(for: referenceDate)
+        let hasTodayGroup = groups.contains { calendar.isDate($0.date, inSameDayAs: today) }
+        guard !hasTodayGroup else { return groups }
+
+        groups.insert(
+            UpcomingCalendarGrouping.DayGroup(date: today, events: []),
+            at: 0
+        )
+        return groups
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -73,23 +73,8 @@ struct NotesView: View {
             notesController = controller
             await controller.loadHistory()
 
-            // Handle pending navigation — inline rather than via controller
-            // to ensure @State detailViewMode update happens in the same
-            // transaction as session selection (matches pre-Phase 6 behavior).
-            if let requested = coordinator.consumeRequestedSessionSelection() {
-                switch requested {
-                case .session(let sessionID):
-                    controller.selectSession(sessionID)
-                    // Show Transcript tab for imported sessions (no notes generated yet)
-                    let isImported = controller.state.sessionHistory.first(where: { $0.id == sessionID })?.source == "imported"
-                    detailViewMode = isImported ? .transcript : .notes
-                case .meetingHistory(let event):
-                    controller.showMeetingFamily(for: event)
-                    detailViewMode = .notes
-                case .clearSelection:
-                    controller.selectSession(nil)
-                    detailViewMode = .notes
-                }
+            if await handleRequestedNotesNavigation(controller: controller) {
+                return
             } else if let last = coordinator.lastEndedSession {
                 controller.selectSession(last.id)
             }
@@ -184,8 +169,8 @@ struct NotesView: View {
             Task { await controller.loadHistory() }
         }
         .onChange(of: coordinator.requestedNotesNavigation?.id) {
-            if controller.handleRequestedSessionSelection() {
-                detailViewMode = .notes
+            Task {
+                _ = await handleRequestedNotesNavigation(controller: controller)
             }
         }
         .onChange(of: state.selectedMeetingFamily?.key) {
@@ -1249,6 +1234,7 @@ struct NotesView: View {
         let folders = meetingFamilyFolderChoices(including: preferredFolderPath)
 
         if let event = selection.upcomingEvent {
+            let isPastEvent = event.endDate <= Date()
             let prepNotes = Binding(
                 get: { settings.meetingPrepNotes(for: event) },
                 set: { settings.setMeetingPrepNotes($0, for: event) }
@@ -1284,7 +1270,7 @@ struct NotesView: View {
                     Spacer(minLength: 0)
 
                     HStack(spacing: 8) {
-                        if event.meetingURL != nil {
+                        if !isPastEvent, event.meetingURL != nil {
                             Button {
                                 joinMeeting(for: event)
                             } label: {
@@ -1294,14 +1280,24 @@ struct NotesView: View {
                             .buttonStyle(.bordered)
                         }
 
-                        Button {
-                            startRecording(for: event, selectedTemplate: state.selectedTemplate)
-                        } label: {
-                            Label("Start recording", systemImage: "mic.fill")
-                                .font(.system(size: 12, weight: .semibold))
+                        if isPastEvent {
+                            Button {
+                                createManualTranscriptSessionAndMaybePrompt(controller: controller, event: event)
+                            } label: {
+                                Label("Add Transcript", systemImage: "text.badge.plus")
+                                    .font(.system(size: 12, weight: .semibold))
+                            }
+                            .buttonStyle(.bordered)
+                        } else {
+                            Button {
+                                startRecording(for: event, selectedTemplate: state.selectedTemplate)
+                            } label: {
+                                Label("Start recording", systemImage: "mic.fill")
+                                    .font(.system(size: 12, weight: .semibold))
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(coordinator.isRecording)
                         }
-                        .buttonStyle(.bordered)
-                        .disabled(coordinator.isRecording)
                     }
                 }
 
@@ -1706,6 +1702,16 @@ struct NotesView: View {
         )
         NSApp.activate(ignoringOtherApps: true)
         openWindow(id: OpenOatsRootApp.mainWindowID)
+    }
+
+    private func createManualTranscriptSessionAndMaybePrompt(controller: NotesController, event: CalendarEvent) {
+        Task {
+            let shouldPromptForTranscript = await controller.prepareManualTranscriptSession(for: event)
+            detailViewMode = .transcript
+            if shouldPromptForTranscript {
+                beginAddTranscript()
+            }
+        }
     }
 
     private func joinMeeting(for event: CalendarEvent) {
@@ -2883,6 +2889,32 @@ struct NotesView: View {
     private func beginAddTranscript() {
         manualTranscriptDraft = ""
         showingAddTranscriptSheet = true
+    }
+
+    @MainActor
+    private func handleRequestedNotesNavigation(controller: NotesController) async -> Bool {
+        guard let requested = coordinator.consumeRequestedSessionSelection() else { return false }
+
+        switch requested {
+        case .session(let sessionID):
+            controller.selectSession(sessionID)
+            let isImported = controller.state.sessionHistory.first(where: { $0.id == sessionID })?.source == "imported"
+            detailViewMode = isImported ? .transcript : .notes
+        case .meetingHistory(let event):
+            controller.showMeetingFamily(for: event)
+            detailViewMode = .notes
+        case .manualTranscript(let event):
+            detailViewMode = .transcript
+            let shouldPromptForTranscript = await controller.prepareManualTranscriptSession(for: event)
+            if shouldPromptForTranscript {
+                beginAddTranscript()
+            }
+        case .clearSelection:
+            controller.selectSession(nil)
+            detailViewMode = .notes
+        }
+
+        return true
     }
 
     private func cancelAddTranscript() {

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -277,6 +277,71 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(controller.state.loadedTranscript.map(\.speaker), [.you, .remote(2), .them])
     }
 
+    func testPrepareManualTranscriptSessionCreatesAndSelectsPastMeetingSession() async {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+        let calendarEvent = CalendarEvent(
+            id: "evt-manual-past",
+            title: "Past Meeting",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            calendarTitle: "WFF",
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        settings.setMeetingFamilyFolderPreference("Work", for: calendarEvent)
+        controller.showMeetingFamily(for: calendarEvent)
+
+        let shouldPrompt = await controller.prepareManualTranscriptSession(for: calendarEvent)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertTrue(shouldPrompt)
+        XCTAssertNotNil(controller.state.selectedSessionID)
+        XCTAssertEqual(controller.state.loadedCalendarEvent?.id, calendarEvent.id)
+        XCTAssertTrue(controller.state.loadedTranscript.isEmpty)
+
+        if let sessionID = controller.state.selectedSessionID {
+            let session = await coordinator.sessionRepository.loadSession(id: sessionID)
+            XCTAssertEqual(session.index.folderPath, "Work")
+            XCTAssertEqual(session.index.source, "manual")
+        }
+    }
+
+    func testPrepareManualTranscriptSessionDoesNotPromptWhenTranscriptAlreadyExists() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let calendarEvent = CalendarEvent(
+            id: "evt-existing-past",
+            title: "Recorded Past Meeting",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            calendarTitle: "WFF",
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "session_existing_past",
+            title: calendarEvent.title,
+            utterances: [SessionRecord(speaker: .you, text: "Existing transcript", timestamp: calendarEvent.startDate)],
+            calendarEvent: calendarEvent
+        )
+        controller.showMeetingFamily(for: calendarEvent)
+
+        let shouldPrompt = await controller.prepareManualTranscriptSession(for: calendarEvent)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertFalse(shouldPrompt)
+        XCTAssertEqual(controller.state.loadedTranscript.map(\.text), ["Existing transcript"])
+    }
+
     func testGenerateNotesUpdatesStatus() async {
         let (root, notes) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -497,6 +497,58 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    func testCreateManualTranscriptSessionPersistsCalendarFolderAndSource() async {
+        let calendarEvent = makeCalendarEvent()
+        let sessionID = await repo.createManualTranscriptSession(
+            config: .init(
+                title: calendarEvent.title,
+                startedAt: calendarEvent.startDate,
+                endedAt: calendarEvent.endDate,
+                calendarEvent: calendarEvent,
+                folderPath: "Work/1:1s"
+            )
+        )
+
+        let session = await repo.loadSession(id: sessionID)
+        XCTAssertEqual(session.index.title, calendarEvent.title)
+        XCTAssertEqual(session.index.folderPath, "Work/1:1s")
+        XCTAssertEqual(session.index.source, "manual")
+        XCTAssertEqual(session.calendarEvent?.id, calendarEvent.id)
+        XCTAssertEqual(session.calendarEvent?.calendarTitle, calendarEvent.calendarTitle)
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
+    func testCreateManualTranscriptSessionReusesExistingExactCalendarEvent() async {
+        let calendarEvent = makeCalendarEvent()
+
+        let firstSessionID = await repo.createManualTranscriptSession(
+            config: .init(
+                title: calendarEvent.title,
+                startedAt: calendarEvent.startDate,
+                endedAt: calendarEvent.endDate,
+                calendarEvent: calendarEvent,
+                folderPath: nil
+            )
+        )
+
+        let secondSessionID = await repo.createManualTranscriptSession(
+            config: .init(
+                title: calendarEvent.title,
+                startedAt: calendarEvent.startDate.addingTimeInterval(60),
+                endedAt: calendarEvent.endDate.addingTimeInterval(60),
+                calendarEvent: calendarEvent,
+                folderPath: "Work"
+            )
+        )
+
+        XCTAssertEqual(secondSessionID, firstSessionID)
+        let sessions = await repo.listSessions()
+        XCTAssertEqual(sessions.count, 1)
+
+        await repo.deleteSession(sessionID: firstSessionID)
+    }
+
     func testSaveFinalTranscript() async {
         let sessionID = "session_final_test"
         let initialStart = Date(timeIntervalSince1970: 100)

--- a/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
@@ -208,6 +208,39 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
         XCTAssertEqual(selected.map(\.id), ["newer", "older"])
     }
 
+    func testComingUpGroupsIncludeTodayWhenOnlyEarlierTodayEventsExist() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        let referenceDate = makeDate(year: 2026, month: 4, day: 24, hour: 17, minute: 0, calendar: calendar)
+        let earlierToday = [
+            makeEvent(
+                id: "ended",
+                title: "Standup",
+                start: makeDate(year: 2026, month: 4, day: 24, hour: 9, minute: 0, calendar: calendar)
+            )
+        ]
+        let future = [
+            makeEvent(
+                id: "future",
+                title: "Planning",
+                start: makeDate(year: 2026, month: 4, day: 27, hour: 11, minute: 30, calendar: calendar)
+            )
+        ]
+
+        let groups = ComingUpDayGroupSelection.groups(
+            for: future,
+            earlierTodayEvents: earlierToday,
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertEqual(groups[0].date, calendar.startOfDay(for: referenceDate))
+        XCTAssertTrue(groups[0].events.isEmpty)
+        XCTAssertEqual(groups[1].events.map(\.id), ["future"])
+    }
+
     private func makeEvent(
         id: String,
         title: String,


### PR DESCRIPTION
Fixes #483

## What changed

- add a synthetic Today section when there are earlier meetings from today but no remaining meetings later today
- route ended meetings from Earlier today into Notes as a manual transcript flow
- create or reuse a manual session for that calendar event
- open the Transcript tab and prompt for Add Transcript only when the session is still empty
- add repository, controller, and grouping coverage for the new path

## Why

Earlier meetings from today could disappear from Coming up once the rest of the day was empty. That made it impossible to use the dashboard as an entry point for adding a transcript to a meeting that had already ended.

## Validation

- `swift test --package-path OpenOats --filter 'NotesControllerTests|SessionRepositoryTests|UpcomingCalendarGroupingTests'`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
