### PR TITLE
Sync the main window with meeting lifecycle state

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -181,6 +181,10 @@ final class AppCoordinator {
     // MARK: - Side Effects
 
     private func performSideEffects(for event: MeetingEvent, settings: AppSettings?) {
+        if let settings {
+            liveSessionController?.syncProjectedState(settings: settings)
+        }
+
         switch event {
         case .userStarted(let metadata):
             Task { await liveSessionController?.startTranscription(metadata: metadata, settings: settings) }

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -85,8 +85,7 @@ final class LiveSessionController {
     /// Polls at 250ms while recording for responsive UI, and at 2s while idle
     /// to minimize observation churn and SwiftUI re-render cycles.
     func runPollingLoop(settings: AppSettings) async {
-        refreshState(settings: settings)
-        synchronizeDerivedState(settings: settings)
+        syncProjectedState(settings: settings)
 
         while !Task.isCancelled {
             let isActive = coordinator.transcriptionEngine?.isRunning == true
@@ -119,9 +118,13 @@ final class LiveSessionController {
                 }
             }
 
-            refreshState(settings: settings)
-            synchronizeDerivedState(settings: settings)
+            syncProjectedState(settings: settings)
         }
+    }
+
+    func syncProjectedState(settings: AppSettings) {
+        refreshState(settings: settings)
+        synchronizeDerivedState(settings: settings)
     }
 
     // MARK: - Session Actions
@@ -626,20 +629,28 @@ final class LiveSessionController {
             sidebarGenerating = coordinator.sidecastEngine?.isGenerating ?? false
         }
 
-        let isRunning = coordinator.transcriptionEngine?.isRunning ?? false
+        let lifecycleState = coordinator.state
+        let engineIsRunning = coordinator.transcriptionEngine?.isRunning ?? false
+        let isRunning: Bool
         let matchedCalendarEvent: CalendarEvent?
-        switch coordinator.state {
-        case .recording(let metadata), .ending(let metadata):
+        switch lifecycleState {
+        case .recording(let metadata):
+            // Prefer lifecycle state so the primary UI does not lag engine startup.
+            isRunning = true
+            matchedCalendarEvent = metadata.calendarEvent
+        case .ending(let metadata):
+            isRunning = engineIsRunning
             matchedCalendarEvent = metadata.calendarEvent
         case .idle:
+            isRunning = false
             matchedCalendarEvent = nil
         }
 
         // Use set(_:_:) for all Equatable fields: only fires @Observable withMutation
         // when the value actually changed, preventing spurious layout passes on NSHostingView.
         set(\.isRunning, isRunning)
-        set(\.sessionPhase, coordinator.state)
-        set(\.audioLevel, isRunning ? (coordinator.transcriptionEngine?.audioLevel ?? 0) : 0)
+        set(\.sessionPhase, lifecycleState)
+        set(\.audioLevel, engineIsRunning ? (coordinator.transcriptionEngine?.audioLevel ?? 0) : 0)
         set(\.volatileYouText, coordinator.transcriptStore.volatileYouText)
         set(\.volatileThemText, coordinator.transcriptStore.volatileThemText)
         set(\.isGeneratingSuggestions, sidebarGenerating)

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -217,6 +217,25 @@ final class LiveSessionControllerTests: XCTestCase {
         }
     }
 
+    func testCoordinatorStartProjectsRunningStateBeforeEngineStarts() {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        let (controller, coordinator) = makeUninitializedController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings
+        )
+
+        XCTAssertFalse(controller.state.isRunning)
+        XCTAssertNil(coordinator.transcriptionEngine)
+
+        coordinator.handle(.userStarted(.manual()), settings: settings)
+
+        XCTAssertTrue(controller.state.isRunning)
+        XCTAssertEqual(controller.state.sessionPhase, coordinator.state)
+        XCTAssertNil(coordinator.transcriptionEngine)
+    }
+
     func testStopSessionWhileIdleIsNoOp() {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)


### PR DESCRIPTION
## Summary
- project live session state into the main window immediately when the coordinator transitions, so notification-started meetings do not leave the main UI on the idle dashboard
- centralize projected-state syncing in `LiveSessionController` and keep audio-level rendering tied to engine startup rather than the UI-facing running flag
- add a regression test that covers the coordinator-started session state before the transcription engine is initialized

## Test plan
- [x] `swift test --filter LiveSessionControllerTests`
- [x] `swift test --filter AppCoordinatorIntegrationTests`

Made with [Cursor](https://cursor.com)