### PR TITLE
Update Homebrew cask for 1.65.1

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.65.0"
-  sha256 "fbeb980e8a48e1371e11b8ab84fbbfe0be2e30a25ccc5d05a76bd3eb81fad531"
+  version "1.65.1"
+  sha256 "b795b922a4787856668cd2260f0c26075def2c36e860e7c7998a899d239945b7"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Bump Homebrew cask version to 1.65.1 and update sha256

Routine cask maintenance — version and hash match the v1.65.1 release DMG.