### PR TITLE
Recover empty cloud live sessions and surface health warnings

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -3,6 +3,16 @@ import Observation
 import CoreAudio
 import AppKit
 
+struct RecordingHealthNotice: Equatable {
+    enum Severity: Equatable {
+        case warning
+        case error
+    }
+
+    let severity: Severity
+    let message: String
+}
+
 /// Published state for the live session, projected by ContentView.
 /// Declared as @Observable class so SwiftUI tracks each property individually,
 /// preventing a full view-tree re-render whenever any single field changes.
@@ -31,6 +41,7 @@ final class LiveSessionState {
     var modelDisplayName: String = ""
     var showLiveTranscript: Bool = true
     var isMicMuted: Bool = false
+    var recordingHealthNotice: RecordingHealthNotice? = nil
     /// The user's live scratchpad text for the active session.
     var scratchpadText: String = ""
 }
@@ -41,6 +52,25 @@ final class LiveSessionState {
 @Observable
 @MainActor
 final class LiveSessionController {
+    struct AudioRetentionPlan: Equatable {
+        let shouldStartRecorder: Bool
+        let shouldRetainBatchAudio: Bool
+        let shouldExportRecording: Bool
+        let shouldRunRecoveryBatch: Bool
+    }
+
+    struct RecordingHealthInput: Equatable {
+        let elapsed: TimeInterval
+        let transcriptionModel: TranscriptionModel
+        let utteranceCount: Int
+        let peakAudioLevel: Float
+        let micHasCapturedFrames: Bool
+        let systemHasCapturedFrames: Bool
+        let micCaptureError: String?
+        let isMicMuted: Bool
+        let hasBlockingError: Bool
+    }
+
     private(set) var state = LiveSessionState()
 
     private let coordinator: AppCoordinator
@@ -66,6 +96,7 @@ final class LiveSessionController {
     /// Tracks the session ID we last handled a batch completion for,
     /// preventing the auto-dismiss → re-poll cycle from re-triggering the notification.
     private var lastNotifiedBatchSessionID: String?
+    private var observedPeakAudioLevelSinceStart: Float = 0
 
     init(coordinator: AppCoordinator, container: AppContainer) {
         self.coordinator = coordinator
@@ -358,7 +389,8 @@ final class LiveSessionController {
         }
 
         if let settings {
-            if settings.saveAudioRecording || settings.enableBatchRetranscription {
+            let audioRetentionPlan = Self.audioRetentionPlan(settings: settings, utteranceCount: nil)
+            if audioRetentionPlan.shouldStartRecorder {
                 coordinator.audioRecorder?.startSession()
                 coordinator.transcriptionEngine?.audioRecorder = coordinator.audioRecorder
             } else {
@@ -474,9 +506,13 @@ final class LiveSessionController {
         }
 
         // 6. Handle audio recording
+        var retainedBatchAudio = false
+        var forcedRecoveryBatch = false
         if let settings, let recorder = coordinator.audioRecorder {
-            let wantsBatch = settings.enableBatchRetranscription
-            let wantsExport = settings.saveAudioRecording
+            let audioRetentionPlan = Self.audioRetentionPlan(settings: settings, utteranceCount: utteranceCount)
+            let wantsBatch = audioRetentionPlan.shouldRetainBatchAudio
+            let wantsExport = audioRetentionPlan.shouldExportRecording
+            forcedRecoveryBatch = audioRetentionPlan.shouldRunRecoveryBatch
 
             if wantsBatch && wantsExport {
                 let tempURLs = recorder.tempFileURLs()
@@ -503,6 +539,7 @@ final class LiveSessionController {
                     copiedSys = nil
                 }
 
+                retainedBatchAudio = copiedMic != nil || copiedSys != nil
                 await coordinator.sessionRepository.stashAudioForBatch(
                     sessionID: sessionID,
                     micURL: copiedMic,
@@ -519,6 +556,7 @@ final class LiveSessionController {
                 await recorder.finalizeRecording()
             } else if wantsBatch {
                 let sealed = recorder.sealForBatch()
+                retainedBatchAudio = sealed.mic != nil || sealed.sys != nil
                 await coordinator.sessionRepository.stashAudioForBatch(
                     sessionID: sessionID,
                     micURL: sealed.mic,
@@ -533,12 +571,28 @@ final class LiveSessionController {
                 )
             } else if wantsExport {
                 await recorder.finalizeRecording()
+            } else {
+                recorder.discardRecording()
             }
         }
 
         // 7. Collapse obviously empty duplicate sessions back into the real meeting session.
         var effectiveIndex = index
         var shouldRunBatchRetranscription = settings?.enableBatchRetranscription == true
+        if forcedRecoveryBatch {
+            if retainedBatchAudio {
+                shouldRunBatchRetranscription = true
+                DiagnosticsSupport.record(
+                    category: "meeting",
+                    message: "Escalating empty cloud session \(sessionID) to batch recovery"
+                )
+            } else {
+                DiagnosticsSupport.record(
+                    category: "meeting",
+                    message: "Cloud session \(sessionID) ended empty with no recovery audio"
+                )
+            }
+        }
         if utteranceCount == 0,
            let mergedSessionID = await coordinator.sessionRepository.reconcileGhostSession(sessionID: sessionID) {
             effectiveIndex = await coordinator.sessionRepository.loadSession(id: mergedSessionID).index
@@ -580,6 +634,63 @@ final class LiveSessionController {
                 )
             }
         }
+    }
+
+    static func audioRetentionPlan(settings: AppSettings, utteranceCount: Int?) -> AudioRetentionPlan {
+        let shouldRunRecoveryBatch = settings.transcriptionModel.isCloud && utteranceCount == 0
+        let shouldRetainBatchAudio = settings.enableBatchRetranscription || shouldRunRecoveryBatch
+        let shouldExportRecording = settings.saveAudioRecording
+        let shouldStartRecorder = shouldExportRecording || shouldRetainBatchAudio || settings.transcriptionModel.isCloud
+        return AudioRetentionPlan(
+            shouldStartRecorder: shouldStartRecorder,
+            shouldRetainBatchAudio: shouldRetainBatchAudio,
+            shouldExportRecording: shouldExportRecording,
+            shouldRunRecoveryBatch: shouldRunRecoveryBatch
+        )
+    }
+
+    static func recordingHealthNotice(for input: RecordingHealthInput) -> RecordingHealthNotice? {
+        guard !input.hasBlockingError else { return nil }
+
+        if let micCaptureError = input.micCaptureError, !micCaptureError.isEmpty {
+            return RecordingHealthNotice(severity: .error, message: micCaptureError)
+        }
+
+        if input.elapsed >= 5 {
+            if !input.systemHasCapturedFrames && (!input.isMicMuted && !input.micHasCapturedFrames) {
+                return RecordingHealthNotice(
+                    severity: .warning,
+                    message: "No microphone or system audio detected. Check your input and output device settings."
+                )
+            }
+            if !input.systemHasCapturedFrames {
+                return RecordingHealthNotice(
+                    severity: .warning,
+                    message: "No system audio detected. Check the selected speaker/output device."
+                )
+            }
+            if !input.isMicMuted && !input.micHasCapturedFrames {
+                return RecordingHealthNotice(
+                    severity: .warning,
+                    message: "No microphone audio detected. Check the selected microphone."
+                )
+            }
+        }
+
+        if input.elapsed >= 20,
+           input.utteranceCount == 0,
+           input.peakAudioLevel >= 0.04,
+           input.micHasCapturedFrames || input.systemHasCapturedFrames {
+            let message: String
+            if input.transcriptionModel.isCloud {
+                message = "Capturing audio, but live transcription is not producing text. Recovery batch transcription will run after you stop."
+            } else {
+                message = "Capturing audio, but live transcription is not producing text."
+            }
+            return RecordingHealthNotice(severity: .warning, message: message)
+        }
+
+        return nil
     }
 
     func discardSession() {
@@ -782,6 +893,30 @@ final class LiveSessionController {
             handleNewUtterances(startingAt: observedUtteranceCount, settings: settings)
         }
         observedUtteranceCount = utteranceCount
+
+        if currentState.isRunning {
+            observedPeakAudioLevelSinceStart = max(observedPeakAudioLevelSinceStart, currentState.audioLevel)
+            if case .recording(let metadata) = currentState.sessionPhase {
+                let captureHealth = coordinator.transcriptionEngine?.captureHealthSnapshot
+                let input = RecordingHealthInput(
+                    elapsed: max(0, Date().timeIntervalSince(metadata.startedAt)),
+                    transcriptionModel: settings.transcriptionModel,
+                    utteranceCount: utteranceCount,
+                    peakAudioLevel: observedPeakAudioLevelSinceStart,
+                    micHasCapturedFrames: captureHealth?.micHasCapturedFrames ?? false,
+                    systemHasCapturedFrames: captureHealth?.systemHasCapturedFrames ?? false,
+                    micCaptureError: captureHealth?.micCaptureError,
+                    isMicMuted: currentState.isMicMuted,
+                    hasBlockingError: currentState.errorMessage != nil
+                )
+                set(\.recordingHealthNotice, Self.recordingHealthNotice(for: input))
+            } else {
+                set(\.recordingHealthNotice, nil)
+            }
+        } else {
+            observedPeakAudioLevelSinceStart = 0
+            set(\.recordingHealthNotice, nil)
+        }
 
         if currentState.isRunning != observedIsRunning {
             observedIsRunning = currentState.isRunning

--- a/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
@@ -9,9 +9,11 @@ import os
 /// Captures system output audio via a Core Audio process tap.
 final class SystemAudioCapture: @unchecked Sendable {
     private let _audioLevel = AudioLevel()
+    private let _hasCapturedFrames = SyncBool()
 
     /// Thread-safe audio level (0…1) from the system audio stream.
     var audioLevel: Float { _audioLevel.value }
+    var hasCapturedFrames: Bool { _hasCapturedFrames.value }
 
     private let _aggregateDeviceID = OSAllocatedUnfairLock<AudioObjectID>(
         uncheckedState: AudioObjectID(kAudioObjectUnknown)
@@ -38,6 +40,7 @@ final class SystemAudioCapture: @unchecked Sendable {
         let sysStream = AsyncStream<AVAudioPCMBuffer> { continuation in
             self._sysContinuation.withLock { $0 = continuation }
         }
+        _hasCapturedFrames.value = false
 
         let resolvedDeviceID: AudioDeviceID
         if let requested = outputDeviceID {
@@ -158,6 +161,7 @@ final class SystemAudioCapture: @unchecked Sendable {
     func stop() async {
         finishStream()
         _audioLevel.value = 0
+        _hasCapturedFrames.value = false
 
         let aggregateDeviceID = _aggregateDeviceID.withLock { state -> AudioObjectID in
             let current = state
@@ -236,6 +240,7 @@ final class SystemAudioCapture: @unchecked Sendable {
             vDSP_rmsqv(channelData[0], 1, &rms, vDSP_Length(pcmBuffer.frameLength))
             _audioLevel.value = min(rms * 25, 1.0)
         }
+        _hasCapturedFrames.value = true
 
         _ = _sysContinuation.withLock { $0?.yield(pcmBuffer) }
     }

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -50,6 +50,12 @@ struct DiarizationFeedRelay: Sendable {
     }
 }
 
+struct CaptureHealthSnapshot: Sendable, Equatable {
+    let micHasCapturedFrames: Bool
+    let systemHasCapturedFrames: Bool
+    let micCaptureError: String?
+}
+
 /// Orchestrates dual StreamingTranscriber instances for mic (you) and system audio (them).
 @Observable
 @MainActor
@@ -137,6 +143,14 @@ final class TranscriptionEngine {
     nonisolated var isMicMuted: Bool {
         get { micCapture.isMuted }
         set { micCapture.isMuted = newValue }
+    }
+
+    nonisolated var captureHealthSnapshot: CaptureHealthSnapshot {
+        CaptureHealthSnapshot(
+            micHasCapturedFrames: micCapture.hasCapturedFrames,
+            systemHasCapturedFrames: systemCapture.hasCapturedFrames,
+            micCaptureError: micCapture.captureError
+        )
     }
 
     private var micTask: Task<Void, Never>?

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -498,6 +498,7 @@ private struct IsolatedControlBarWrapper: View {
             kbIndexingStatus: state.kbIndexingStatus,
             statusMessage: state.statusMessage,
             errorMessage: state.errorMessage,
+            recordingHealthNotice: state.recordingHealthNotice,
             needsDownload: state.needsDownload,
             downloadProgress: state.downloadProgress,
             downloadDetail: state.downloadDetail,

--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -11,6 +11,7 @@ struct ControlBar: View {
     let kbIndexingStatus: KnowledgeBaseIndexingStatus
     let statusMessage: String?
     let errorMessage: String?
+    let recordingHealthNotice: RecordingHealthNotice?
     let needsDownload: Bool
     let downloadProgress: Double?
     let downloadDetail: DownloadProgressDetail?
@@ -57,6 +58,10 @@ struct ControlBar: View {
 
                     if let status = statusMessage, status != "Ready" {
                         modelStatusSection(status: status)
+                    }
+
+                    if let notice = recordingHealthNotice {
+                        recordingHealthSection(notice: notice)
                     }
 
                     if kbIndexingStatus.isVisible {
@@ -152,6 +157,7 @@ struct ControlBar: View {
     private var shouldShowStatusArea: Bool {
         batchStatus.isFooterVisible
             || (statusMessage != nil && statusMessage != "Ready")
+            || recordingHealthNotice != nil
             || kbIndexingStatus.isVisible
     }
 
@@ -191,6 +197,31 @@ struct ControlBar: View {
                 }
             }
         }
+    }
+
+    @ViewBuilder
+    private func recordingHealthSection(notice: RecordingHealthNotice) -> some View {
+        let symbolName = switch notice.severity {
+        case .warning: "exclamationmark.triangle.fill"
+        case .error: "xmark.octagon.fill"
+        }
+        let color = switch notice.severity {
+        case .warning: Color.orange
+        case .error: Color.red
+        }
+
+        HStack(alignment: .top, spacing: 6) {
+            Image(systemName: symbolName)
+                .font(.system(size: 11))
+                .foregroundStyle(color)
+                .padding(.top, 1)
+
+            Text(notice.message)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityIdentifier("app.controlBar.recordingHealth")
     }
 }
 

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -496,6 +496,134 @@ final class LiveSessionControllerTests: XCTestCase {
         let mergedDetail = await coordinator.sessionRepository.loadSession(id: "session_real")
         XCTAssertEqual(mergedDetail.calendarEvent?.id, event.id)
     }
+
+    func testAudioRetentionPlanKeepsRecoveryAudioForCloudLiveTranscription() {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        settings.transcriptionModel = .elevenLabsScribe
+        settings.saveAudioRecording = false
+        settings.enableBatchRetranscription = false
+
+        let startupPlan = LiveSessionController.audioRetentionPlan(settings: settings, utteranceCount: nil)
+        XCTAssertTrue(startupPlan.shouldStartRecorder)
+        XCTAssertFalse(startupPlan.shouldRetainBatchAudio)
+        XCTAssertFalse(startupPlan.shouldExportRecording)
+        XCTAssertFalse(startupPlan.shouldRunRecoveryBatch)
+
+        let recoveryPlan = LiveSessionController.audioRetentionPlan(settings: settings, utteranceCount: 0)
+        XCTAssertTrue(recoveryPlan.shouldStartRecorder)
+        XCTAssertTrue(recoveryPlan.shouldRetainBatchAudio)
+        XCTAssertFalse(recoveryPlan.shouldExportRecording)
+        XCTAssertTrue(recoveryPlan.shouldRunRecoveryBatch)
+    }
+
+    func testAudioRetentionPlanDoesNotForceRecoveryForCloudSessionWithUtterances() {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        settings.transcriptionModel = .assemblyAI
+        settings.saveAudioRecording = false
+        settings.enableBatchRetranscription = false
+
+        let plan = LiveSessionController.audioRetentionPlan(settings: settings, utteranceCount: 4)
+        XCTAssertTrue(plan.shouldStartRecorder)
+        XCTAssertFalse(plan.shouldRetainBatchAudio)
+        XCTAssertFalse(plan.shouldExportRecording)
+        XCTAssertFalse(plan.shouldRunRecoveryBatch)
+    }
+
+    func testAudioRetentionPlanLeavesLocalModelsUntouchedWhenRecordingOptionsAreOff() {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        settings.transcriptionModel = .parakeetV3
+        settings.saveAudioRecording = false
+        settings.enableBatchRetranscription = false
+
+        let plan = LiveSessionController.audioRetentionPlan(settings: settings, utteranceCount: 0)
+        XCTAssertFalse(plan.shouldStartRecorder)
+        XCTAssertFalse(plan.shouldRetainBatchAudio)
+        XCTAssertFalse(plan.shouldExportRecording)
+        XCTAssertFalse(plan.shouldRunRecoveryBatch)
+    }
+
+    func testRecordingHealthNoticeWarnsWhenNoAudioDetected() {
+        let input = LiveSessionController.RecordingHealthInput(
+            elapsed: 6,
+            transcriptionModel: .elevenLabsScribe,
+            utteranceCount: 0,
+            peakAudioLevel: 0,
+            micHasCapturedFrames: false,
+            systemHasCapturedFrames: false,
+            micCaptureError: nil,
+            isMicMuted: false,
+            hasBlockingError: false
+        )
+
+        let notice = LiveSessionController.recordingHealthNotice(for: input)
+        XCTAssertEqual(notice?.severity, .warning)
+        XCTAssertEqual(
+            notice?.message,
+            "No microphone or system audio detected. Check your input and output device settings."
+        )
+    }
+
+    func testRecordingHealthNoticeWarnsWhenCloudTranscriptStallsButAudioIsFlowing() {
+        let input = LiveSessionController.RecordingHealthInput(
+            elapsed: 21,
+            transcriptionModel: .elevenLabsScribe,
+            utteranceCount: 0,
+            peakAudioLevel: 0.08,
+            micHasCapturedFrames: true,
+            systemHasCapturedFrames: true,
+            micCaptureError: nil,
+            isMicMuted: false,
+            hasBlockingError: false
+        )
+
+        let notice = LiveSessionController.recordingHealthNotice(for: input)
+        XCTAssertEqual(notice?.severity, .warning)
+        XCTAssertEqual(
+            notice?.message,
+            "Capturing audio, but live transcription is not producing text. Recovery batch transcription will run after you stop."
+        )
+    }
+
+    func testRecordingHealthNoticeWarnsWhenLocalTranscriptStallsButAudioIsFlowing() {
+        let input = LiveSessionController.RecordingHealthInput(
+            elapsed: 21,
+            transcriptionModel: .parakeetV3,
+            utteranceCount: 0,
+            peakAudioLevel: 0.08,
+            micHasCapturedFrames: true,
+            systemHasCapturedFrames: true,
+            micCaptureError: nil,
+            isMicMuted: false,
+            hasBlockingError: false
+        )
+
+        let notice = LiveSessionController.recordingHealthNotice(for: input)
+        XCTAssertEqual(notice?.severity, .warning)
+        XCTAssertEqual(
+            notice?.message,
+            "Capturing audio, but live transcription is not producing text."
+        )
+    }
+
+    func testRecordingHealthNoticeSuppressesWarningWhenBlockingErrorExists() {
+        let input = LiveSessionController.RecordingHealthInput(
+            elapsed: 30,
+            transcriptionModel: .elevenLabsScribe,
+            utteranceCount: 0,
+            peakAudioLevel: 0.08,
+            micHasCapturedFrames: true,
+            systemHasCapturedFrames: true,
+            micCaptureError: nil,
+            isMicMuted: false,
+            hasBlockingError: true
+        )
+
+        XCTAssertNil(LiveSessionController.recordingHealthNotice(for: input))
+    }
+
     func testRunningStateChangeCallbackFires() async {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)


### PR DESCRIPTION
Fixes #491

## What changed

- keep temporary recovery audio for cloud live transcription sessions even when the user has not enabled audio export or batch retranscription
- auto-run batch recovery when a cloud live session ends with `0` utterances
- surface recording health warnings in the control bar for:
  - no captured audio after startup
  - audio flowing but no live transcript arriving
- mention that cloud recovery batch will run after stop when the stalled live session is using a cloud model

## Why

Cloud live sessions could fail quietly and leave the user with an empty session stub. If the user also had audio export and batch disabled, there was no recovery path and no useful warning during the meeting.

## Validation

- `swift test --filter LiveSessionControllerTests`
- `swift build -c debug`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
