### PR TITLE
Sort Notes sidebar groups by recency and make them collapsible

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -74,6 +74,7 @@ struct SessionFolderGroup: Identifiable {
     let id: String
     let title: String
     let sessions: [SessionIndex]
+    let isRoot: Bool
 }
 
 struct MeetingFamilySelection: Equatable {
@@ -795,20 +796,18 @@ final class NotesController {
 
     var sessionSourceGroups: [SessionSourceGroup] {
         let grouped = Dictionary(grouping: filteredSessions, by: Self.sourceGroupKey(for:))
-        let orderedKeys = grouped.keys.sorted { lhs, rhs in
-            let lhsOrder = Self.sourceGroupSortOrder(for: lhs)
-            let rhsOrder = Self.sourceGroupSortOrder(for: rhs)
-            if lhsOrder != rhsOrder { return lhsOrder < rhsOrder }
-            return Self.sourceDisplayName(for: lhs).localizedCaseInsensitiveCompare(
-                Self.sourceDisplayName(for: rhs)
-            ) == .orderedAscending
-        }
-        return orderedKeys.map { key in
+        let groups = grouped.keys.map { key in
             SessionSourceGroup(
                 id: key,
                 title: Self.sourceDisplayName(for: key),
-                sessions: grouped[key] ?? []
+                sessions: (grouped[key] ?? []).sorted { $0.startedAt > $1.startedAt }
             )
+        }
+        return groups.sorted { lhs, rhs in
+            let lhsLatest = lhs.sessions.first?.startedAt ?? .distantPast
+            let rhsLatest = rhs.sessions.first?.startedAt ?? .distantPast
+            if lhsLatest != rhsLatest { return lhsLatest > rhsLatest }
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
         }
     }
 
@@ -820,10 +819,15 @@ final class NotesController {
 
     var rootFolderSessions: [SessionIndex] {
         guard showsFolderSections else { return [] }
-        return filteredSessions.filter { Self.normalizedFolderPath(for: $0)?.isEmpty != false }
+        return filteredSessions
+            .filter { Self.normalizedFolderPath(for: $0)?.isEmpty != false }
+            .sorted { $0.startedAt > $1.startedAt }
     }
 
     var folderGroups: [SessionFolderGroup] {
+        guard showsFolderSections else { return [] }
+
+        let rootSessions = rootFolderSessions
         let grouped = Dictionary(
             grouping: filteredSessions.compactMap { session -> (String, SessionIndex)? in
                 guard let folderPath = Self.normalizedFolderPath(for: session), !folderPath.isEmpty else {
@@ -833,15 +837,30 @@ final class NotesController {
             },
             by: \.0
         )
-        let orderedKeys = grouped.keys.sorted {
-            $0.localizedCaseInsensitiveCompare($1) == .orderedAscending
-        }
-        return orderedKeys.map { key in
+        var groups: [SessionFolderGroup] = grouped.keys.map { key in
             SessionFolderGroup(
                 id: key,
                 title: Self.folderDisplayName(for: key),
-                sessions: (grouped[key] ?? []).map(\.1)
+                sessions: (grouped[key] ?? []).map(\.1).sorted { $0.startedAt > $1.startedAt },
+                isRoot: false
             )
+        }
+        if !rootSessions.isEmpty {
+            groups.append(
+                SessionFolderGroup(
+                    id: "__root__",
+                    title: "My notes",
+                    sessions: rootSessions,
+                    isRoot: true
+                )
+            )
+        }
+
+        return groups.sorted { lhs, rhs in
+            let lhsLatest = lhs.sessions.first?.startedAt ?? .distantPast
+            let rhsLatest = rhs.sessions.first?.startedAt ?? .distantPast
+            if lhsLatest != rhsLatest { return lhsLatest > rhsLatest }
+            return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
         }
     }
 
@@ -910,17 +929,6 @@ final class NotesController {
             "Granola"
         default:
             sourceKey.replacingOccurrences(of: "-", with: " ").capitalized
-        }
-    }
-
-    private static func sourceGroupSortOrder(for sourceKey: String) -> Int {
-        switch sourceKey {
-        case "openoats":
-            0
-        case "granola":
-            1
-        default:
-            2
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -29,6 +29,7 @@ struct NotesView: View {
     @State private var confirmRestoreOriginalTranscript = false
     @State private var showingAddTranscriptSheet = false
     @State private var manualTranscriptDraft = ""
+    @State private var collapsedSidebarGroupIDs = Self.loadCollapsedSidebarGroupIDs()
 
     enum DetailViewMode: String, CaseIterable {
         case transcript = "Transcript"
@@ -226,30 +227,27 @@ struct NotesView: View {
             if bulkDeleteMode {
                 List(selection: $bulkDeleteSelection) {
                     if controller.showsFolderSections {
-                        if !controller.rootFolderSessions.isEmpty {
-                            Section {
-                                ForEach(controller.rootFolderSessions) { session in
-                                    sessionRow(controller: controller, session: session)
-                                }
-                            } header: {
-                                rootFolderSectionHeader()
-                            }
-                        }
                         ForEach(controller.folderGroups) { group in
                             Section {
-                                ForEach(group.sessions) { session in
-                                    sessionRow(controller: controller, session: session)
+                                if isSidebarGroupExpanded(collapseID(for: group)) {
+                                    ForEach(group.sessions) { session in
+                                        sessionRow(controller: controller, session: session)
+                                    }
                                 }
                             } header: {
-                                folderSectionHeader(group)
+                                collapsibleFolderSectionHeader(group)
                             }
                         }
                     } else if controller.showsSourceSections {
                         ForEach(controller.sessionSourceGroups) { group in
-                            Section(group.title) {
-                                ForEach(group.sessions) { session in
-                                    sessionRow(controller: controller, session: session)
+                            Section {
+                                if isSidebarGroupExpanded(collapseID(for: group)) {
+                                    ForEach(group.sessions) { session in
+                                        sessionRow(controller: controller, session: session)
+                                    }
                                 }
+                            } header: {
+                                collapsibleSourceSectionHeader(group)
                             }
                         }
                     } else {
@@ -266,30 +264,27 @@ struct NotesView: View {
                 )
                 List(selection: selectedBinding) {
                     if controller.showsFolderSections {
-                        if !controller.rootFolderSessions.isEmpty {
-                            Section {
-                                ForEach(controller.rootFolderSessions) { session in
-                                    sessionListEntry(controller: controller, session: session)
-                                }
-                            } header: {
-                                rootFolderSectionHeader()
-                            }
-                        }
                         ForEach(controller.folderGroups) { group in
                             Section {
-                                ForEach(group.sessions) { session in
-                                    sessionListEntry(controller: controller, session: session)
+                                if isSidebarGroupExpanded(collapseID(for: group)) {
+                                    ForEach(group.sessions) { session in
+                                        sessionListEntry(controller: controller, session: session)
+                                    }
                                 }
                             } header: {
-                                folderSectionHeader(group)
+                                collapsibleFolderSectionHeader(group)
                             }
                         }
                     } else if controller.showsSourceSections {
                         ForEach(controller.sessionSourceGroups) { group in
-                            Section(group.title) {
-                                ForEach(group.sessions) { session in
-                                    sessionListEntry(controller: controller, session: session)
+                            Section {
+                                if isSidebarGroupExpanded(collapseID(for: group)) {
+                                    ForEach(group.sessions) { session in
+                                        sessionListEntry(controller: controller, session: session)
+                                    }
                                 }
+                            } header: {
+                                collapsibleSourceSectionHeader(group)
                             }
                         }
                     } else {
@@ -728,23 +723,49 @@ struct NotesView: View {
     }
 
     @ViewBuilder
-    private func folderSectionHeader(_ group: SessionFolderGroup) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: "folder.fill")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(folderColor(for: group.id))
-            Text(group.title)
-        }
+    private func collapsibleFolderSectionHeader(_ group: SessionFolderGroup) -> some View {
+        collapsibleSidebarSectionHeader(
+            title: group.title,
+            systemImage: group.isRoot ? "folder" : "folder.fill",
+            iconColor: group.isRoot ? .secondary : folderColor(for: group.id),
+            collapseID: collapseID(for: group)
+        )
     }
 
     @ViewBuilder
-    private func rootFolderSectionHeader() -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: "folder")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(.secondary)
-            Text("My notes")
+    private func collapsibleSourceSectionHeader(_ group: SessionSourceGroup) -> some View {
+        collapsibleSidebarSectionHeader(
+            title: group.title,
+            systemImage: "tray.full",
+            iconColor: .secondary,
+            collapseID: collapseID(for: group)
+        )
+    }
+
+    @ViewBuilder
+    private func collapsibleSidebarSectionHeader(
+        title: String,
+        systemImage: String,
+        iconColor: Color,
+        collapseID: String
+    ) -> some View {
+        Button {
+            toggleSidebarGroup(collapseID)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: isSidebarGroupExpanded(collapseID) ? "chevron.down" : "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(.tertiary)
+                    .frame(width: 10)
+                Image(systemName: systemImage)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(iconColor)
+                Text(title)
+                Spacer()
+            }
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
     }
 
     private func renamePlaceholder(for sessionID: String, controller: NotesController) -> String {
@@ -2942,6 +2963,37 @@ struct NotesView: View {
     private func beginAddTranscript() {
         manualTranscriptDraft = ""
         showingAddTranscriptSheet = true
+    }
+
+    private func collapseID(for group: SessionFolderGroup) -> String {
+        "folder:\(group.id)"
+    }
+
+    private func collapseID(for group: SessionSourceGroup) -> String {
+        "source:\(group.id)"
+    }
+
+    private func isSidebarGroupExpanded(_ collapseID: String) -> Bool {
+        !collapsedSidebarGroupIDs.contains(collapseID)
+    }
+
+    private func toggleSidebarGroup(_ collapseID: String) {
+        if collapsedSidebarGroupIDs.contains(collapseID) {
+            collapsedSidebarGroupIDs.remove(collapseID)
+        } else {
+            collapsedSidebarGroupIDs.insert(collapseID)
+        }
+        persistCollapsedSidebarGroupIDs()
+    }
+
+    private func persistCollapsedSidebarGroupIDs() {
+        UserDefaults.standard.set(Array(collapsedSidebarGroupIDs).sorted(), forKey: Self.collapsedSidebarGroupsDefaultsKey)
+    }
+
+    private static let collapsedSidebarGroupsDefaultsKey = "notesCollapsedSidebarGroups"
+
+    private static func loadCollapsedSidebarGroupIDs() -> Set<String> {
+        Set(UserDefaults.standard.stringArray(forKey: collapsedSidebarGroupsDefaultsKey) ?? [])
     }
 
     @MainActor

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -36,9 +36,9 @@ final class NotesControllerTests: XCTestCase {
         sessionID: String = "session_test_001",
         title: String = "Test Meeting",
         utterances: [SessionRecord]? = nil,
-        calendarEvent: CalendarEvent? = nil
+        calendarEvent: CalendarEvent? = nil,
+        startedAt: Date = Date(timeIntervalSince1970: 1_700_000_000)
     ) async {
-        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
         let records = utterances ?? [
             SessionRecord(speaker: .you, text: "Hello there.", timestamp: startedAt),
             SessionRecord(speaker: .them, text: "Hi, how are you?", timestamp: startedAt.addingTimeInterval(10)),
@@ -515,18 +515,34 @@ final class NotesControllerTests: XCTestCase {
     func testFolderGroupsSessionsByPath() async {
         let (root, _) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
 
-        await seedSession(coordinator: coordinator, sessionID: "session_root", title: "Inbox Meeting")
-        await seedSession(coordinator: coordinator, sessionID: "session_team", title: "Team Sync")
-        await seedSession(coordinator: coordinator, sessionID: "session_ones", title: "Bertie 1:1")
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "session_root",
+            title: "Inbox Meeting",
+            startedAt: base
+        )
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "session_team",
+            title: "Team Sync",
+            startedAt: base.addingTimeInterval(300)
+        )
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "session_ones",
+            title: "Bertie 1:1",
+            startedAt: base.addingTimeInterval(150)
+        )
         await coordinator.sessionRepository.updateSessionFolder(sessionID: "session_team", folderPath: "Work/Team")
         await coordinator.sessionRepository.updateSessionFolder(sessionID: "session_ones", folderPath: "Work/1:1s")
         await controller.loadHistory()
 
         XCTAssertTrue(controller.showsFolderSections)
         XCTAssertEqual(controller.rootFolderSessions.map(\.id), ["session_root"])
-        XCTAssertEqual(controller.folderGroups.map(\.id), ["Work/1:1s", "Work/Team"])
-        XCTAssertEqual(controller.folderGroups.map(\.title), ["Work › 1:1s", "Work › Team"])
+        XCTAssertEqual(controller.folderGroups.map(\.id), ["Work/Team", "Work/1:1s", "__root__"])
+        XCTAssertEqual(controller.folderGroups.map(\.title), ["Work › Team", "Work › 1:1s", "My notes"])
     }
 
     func testDeleteSessionRemovesFromHistory() async {
@@ -1167,10 +1183,21 @@ final class NotesControllerTests: XCTestCase {
     func testSessionSourceGroupsKeepGranolaSeparateFromOpenOats() async {
         let (root, _) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)
+        let base = Date(timeIntervalSince1970: 1_700_000_000)
 
-        await seedSession(coordinator: coordinator, sessionID: "session_local", title: "Local")
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "session_local",
+            title: "Local",
+            startedAt: base
+        )
 
-        await seedSession(coordinator: coordinator, sessionID: "session_granola", title: "Imported")
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "session_granola",
+            title: "Imported",
+            startedAt: base.addingTimeInterval(300)
+        )
         await coordinator.sessionRepository.updateSessionSource(
             sessionID: "session_granola",
             source: "granola",
@@ -1181,9 +1208,9 @@ final class NotesControllerTests: XCTestCase {
 
         let groups = controller.sessionSourceGroups
 
-        XCTAssertEqual(groups.map(\.title), ["OpenOats", "Granola"])
-        XCTAssertEqual(groups.first?.sessions.map(\.id), ["session_local"])
-        XCTAssertEqual(groups.last?.sessions.map(\.id), ["session_granola"])
+        XCTAssertEqual(groups.map(\.title), ["Granola", "OpenOats"])
+        XCTAssertEqual(groups.first?.sessions.map(\.id), ["session_granola"])
+        XCTAssertEqual(groups.last?.sessions.map(\.id), ["session_local"])
         XCTAssertTrue(controller.showsSourceSections)
     }
 }


### PR DESCRIPTION
Fixes #493

## What changed

- sort Notes sidebar folder sections by the newest session they contain
- let `My notes` participate in that same recency ordering instead of pinning it above more active sections
- sort source sections such as `Granola` by latest activity as well
- make folder and source sections collapsible
- persist the collapse state locally

## Why

Recent meetings could look missing even when they had been filed correctly, because the relevant folder or source section was visually buried and could not be collapsed out of the way. This makes the sidebar reflect current activity instead of static group order.

## Validation

- `swift test --filter NotesControllerTests`
- `swift build -c debug`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
