### PR TITLE
Surface structured note fields in previous meeting cards

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -92,10 +92,18 @@ struct MeetingHistorySelection: Equatable {
 
 struct MeetingHistoryEntry: Identifiable {
     let session: SessionIndex
+    let highlights: [MeetingHistoryHighlight]
     let notesPreview: String?
     let hasAudio: Bool
 
     var id: String { session.id }
+}
+
+struct MeetingHistoryHighlight: Identifiable, Equatable {
+    let title: String
+    let value: String
+
+    var id: String { "\(title)|\(value)" }
 }
 
 struct MeetingHistorySuggestion: Identifiable, Equatable {
@@ -1113,7 +1121,7 @@ final class NotesController {
         loadMeetingFamilyKnowledgeBaseCoverage(for: selection)
 
         let sessions = matchingMeetingHistorySessions(for: selection)
-        let entries = sessions.map { MeetingHistoryEntry(session: $0, notesPreview: nil, hasAudio: false) }
+        let entries = sessions.map { MeetingHistoryEntry(session: $0, highlights: [], notesPreview: nil, hasAudio: false) }
         state.meetingHistoryEntries = entries
         state.relatedMeetingSuggestions = loadMeetingHistorySuggestions(
             for: selection,
@@ -1136,6 +1144,7 @@ final class NotesController {
 
                 let notes = await coordinator.sessionRepository.loadNotes(sessionID: session.id)
                 let hasAudio = !(await coordinator.sessionRepository.audioSources(for: session.id)).isEmpty
+                let highlights = notes.map { Self.meetingHistoryHighlights(from: $0.markdown) } ?? []
                 let preview = notes.flatMap { Self.notesPreview(from: $0.markdown) }
 
                 guard state.selectedMeetingFamily?.key == selection.key else { return }
@@ -1143,10 +1152,12 @@ final class NotesController {
                     continue
                 }
 
-                if state.meetingHistoryEntries[index].notesPreview != preview
+                if state.meetingHistoryEntries[index].highlights != highlights
+                    || state.meetingHistoryEntries[index].notesPreview != preview
                     || state.meetingHistoryEntries[index].hasAudio != hasAudio {
                     state.meetingHistoryEntries[index] = MeetingHistoryEntry(
                         session: state.meetingHistoryEntries[index].session,
+                        highlights: highlights,
                         notesPreview: preview,
                         hasAudio: hasAudio
                     )
@@ -1342,27 +1353,118 @@ final class NotesController {
         return "Untitled document"
     }
 
+    static func meetingHistoryHighlights(from markdown: String, limit: Int = 2) -> [MeetingHistoryHighlight] {
+        var highlights: [MeetingHistoryHighlight] = []
+        var currentTitle: String?
+        var currentLines: [String] = []
+
+        func flushSection() {
+            guard let sectionTitle = currentTitle else { return }
+            defer {
+                currentTitle = nil
+                currentLines.removeAll(keepingCapacity: true)
+            }
+
+            guard let value = bestMeetingHistoryHighlightValue(from: currentLines) else { return }
+            highlights.append(MeetingHistoryHighlight(title: sectionTitle, value: value))
+        }
+
+        for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if line.hasPrefix("## ") || line.hasPrefix("### ") {
+                let prefixLength = line.hasPrefix("### ") ? 4 : 3
+                let heading = String(line.dropFirst(prefixLength)).trimmingCharacters(in: .whitespacesAndNewlines)
+                if heading.caseInsensitiveCompare("Transcript") == .orderedSame {
+                    flushSection()
+                    break
+                }
+
+                flushSection()
+                currentTitle = heading.isEmpty ? nil : heading
+                continue
+            }
+
+            guard currentTitle != nil else { continue }
+            let sanitized = sanitizedMeetingHistoryLine(line)
+            if !sanitized.isEmpty {
+                currentLines.append(sanitized)
+            }
+        }
+
+        flushSection()
+        return Array(highlights.prefix(limit))
+    }
+
     static func notesPreview(from markdown: String) -> String? {
         for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
             let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !line.isEmpty else { continue }
-            guard !line.hasPrefix("#") else { continue }
-            guard !line.hasPrefix("!") else { continue }
-            let sanitized = line
-                .replacingOccurrences(
-                    of: #"^([-*+]|[0-9]+\.)\s+"#,
-                    with: "",
-                    options: .regularExpression
-                )
-                .replacingOccurrences(of: "**", with: "")
-                .replacingOccurrences(of: "__", with: "")
-                .replacingOccurrences(of: "`", with: "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let sanitized = sanitizedMeetingHistoryLine(line)
             if !sanitized.isEmpty {
                 return sanitized
             }
         }
         return nil
+    }
+
+    private static func bestMeetingHistoryHighlightValue(from lines: [String]) -> String? {
+        let filtered = lines.filter { !$0.isEmpty }
+        guard !filtered.isEmpty else { return nil }
+
+        if let firstDetailedLine = filtered.first(where: { !isLikelyMeetingHistoryNameLine($0) }) {
+            return firstDetailedLine
+        }
+
+        return filtered.first
+    }
+
+    private static func sanitizedMeetingHistoryLine(_ line: String) -> String {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "" }
+        guard !trimmed.hasPrefix("#") else { return "" }
+        guard !trimmed.hasPrefix("!") else { return "" }
+
+        return trimmed
+            .replacingOccurrences(
+                of: #"^[-*+]\s+\[[ xX]\]\s+"#,
+                with: "",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: #"^([-*+]|[0-9]+\.)\s+"#,
+                with: "",
+                options: .regularExpression
+            )
+            .replacingOccurrences(of: "**", with: "")
+            .replacingOccurrences(of: "__", with: "")
+            .replacingOccurrences(of: "`", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func isLikelyMeetingHistoryNameLine(_ line: String) -> Bool {
+        guard !line.isEmpty,
+              !line.contains(":"),
+              !line.contains("."),
+              !line.contains(","),
+              !line.contains("•"),
+              !line.contains("("),
+              !line.contains(")"),
+              !line.contains("["),
+              !line.contains("]") else {
+            return false
+        }
+
+        let words = line.split(whereSeparator: \.isWhitespace)
+        guard !words.isEmpty, words.count <= 3 else { return false }
+
+        for word in words {
+            let stripped = word.trimmingCharacters(in: CharacterSet(charactersIn: "-/'"))
+            guard let first = stripped.first, first.isLetter, first.isUppercase else {
+                return false
+            }
+        }
+
+        return true
     }
 
     /// Maps engine observable state to our flat status enums.

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -1773,7 +1773,22 @@ struct NotesView: View {
                                 .font(.system(size: 12))
                                 .foregroundStyle(.secondary)
 
-                                if let preview = entry.notesPreview {
+                                if !entry.highlights.isEmpty {
+                                    VStack(alignment: .leading, spacing: 6) {
+                                        ForEach(entry.highlights) { highlight in
+                                            VStack(alignment: .leading, spacing: 2) {
+                                                Text(highlight.title)
+                                                    .font(.system(size: 11, weight: .semibold))
+                                                    .foregroundStyle(.secondary)
+                                                Text(highlight.value)
+                                                    .font(.system(size: 13))
+                                                    .foregroundStyle(.primary)
+                                                    .lineLimit(2)
+                                                    .multilineTextAlignment(.leading)
+                                            }
+                                        }
+                                    }
+                                } else if let preview = entry.notesPreview {
                                     Text(preview)
                                         .font(.system(size: 13))
                                         .foregroundStyle(.secondary)

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -714,6 +714,57 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(controller.state.meetingHistoryEntries.first?.notesPreview, "Reviewed payout issues and next steps.")
     }
 
+    func testShowMeetingHistoryHydratesStructuredHighlights() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+
+        await seedSession(coordinator: coordinator, sessionID: "standup", title: "Payment Ops / Merchant stand up")
+
+        let template = coordinator.templateStore.snapshot(
+            of: coordinator.templateStore.template(for: TemplateStore.standUpID) ?? TemplateStore.builtInTemplates.first!
+        )
+        let notes = GeneratedNotes(
+            template: template,
+            generatedAt: Date(),
+            markdown: """
+            # Notes
+
+            ## Yesterday
+            - Sam
+              - Was working on PCI-related work and webhooks.
+
+            ## Today
+            - Dan
+              - Will share the existing design link with the team.
+            """
+        )
+        await coordinator.sessionRepository.saveNotes(sessionID: "standup", notes: notes)
+        await controller.loadHistory()
+
+        let event = CalendarEvent(
+            id: "evt_payment_ops_structured",
+            title: "Payment Ops / Merchant stand-up",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        controller.showMeetingHistory(for: event)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertEqual(controller.state.meetingHistoryEntries.first?.highlights.map(\.title), ["Yesterday", "Today"])
+        XCTAssertEqual(
+            controller.state.meetingHistoryEntries.first?.highlights.map(\.value),
+            [
+                "Was working on PCI-related work and webhooks.",
+                "Will share the existing design link with the team.",
+            ]
+        )
+    }
+
     func testShowMeetingHistorySuggestsRenamedMeetingSeriesWhenExactHistoryIsEmpty() async {
         let (root, notes) = makeTempDirs()
         let settings = makeSettings(notesDirectory: notes)
@@ -876,6 +927,47 @@ final class NotesControllerTests: XCTestCase {
     func testMeetingHistoryPreviewStripsBulletsAndMarkdownMarkers() {
         let preview = NotesController.notesPreview(from: "# Notes\n\n- **Booking invoices page** - New interface for PMs")
         XCTAssertEqual(preview, "Booking invoices page - New interface for PMs")
+    }
+
+    func testMeetingHistoryHighlightsLiftStructuredSections() {
+        let markdown = """
+        # Meeting Notes: Payment Ops / Merchant stand up
+
+        ## Yesterday
+        - Sam
+          - Was working on PCI-related work and webhooks.
+        - Dan
+          - Reviewed the current webhook designs.
+
+        ## Today
+        - Dan
+          - Will share the existing design link with the team.
+
+        ## Transcript
+        [00:00:01] You: Hello
+        """
+
+        let highlights = NotesController.meetingHistoryHighlights(from: markdown)
+
+        XCTAssertEqual(highlights.map(\.title), ["Yesterday", "Today"])
+        XCTAssertEqual(
+            highlights.map(\.value),
+            [
+                "Was working on PCI-related work and webhooks.",
+                "Will share the existing design link with the team.",
+            ]
+        )
+    }
+
+    func testMeetingHistoryHighlightsIgnoreTranscriptSection() {
+        let markdown = """
+        # Notes
+
+        ## Transcript
+        [00:00:01] You: Reviewed payout issues and next steps.
+        """
+
+        XCTAssertTrue(NotesController.meetingHistoryHighlights(from: markdown).isEmpty)
     }
 
     func testSelectSessionAlsoLoadsMeetingFamilyHistory() async {


### PR DESCRIPTION
Fixes #501

## Summary
- lift structured note sections like `Yesterday` and `Today` near the top of `Previous meetings` cards
- keep the old generic preview as a fallback when notes are not structured
- ignore transcript content when extracting those highlights

## Validation
- swift test --package-path OpenOats --filter NotesControllerTests
- swift build -c debug --package-path OpenOats
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh