### PR TITLE
Prefer recurring calendar series IDs for meeting-family matching

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -302,7 +302,7 @@ final class NotesController {
             let familySelection = session.map { Self.meetingFamilySelection(for: $0, calendarEvent: data.calendarEvent) }
             state.selectedTemplate = selectedTemplate(
                 forSessionTemplateID: session?.templateSnapshot?.id,
-                meetingFamilyKey: familySelection?.key
+                meetingFamilySelection: familySelection
             )
 
             if let familySelection {
@@ -339,7 +339,7 @@ final class NotesController {
         state.showingOriginal = false
         state.selectedTemplate = selectedTemplate(
             forSessionTemplateID: nil,
-            meetingFamilyKey: selection.key
+            meetingFamilySelection: selection
         )
         coordinator.batchTextCleaner.cancel()
         syncCleanupStatus()
@@ -942,36 +942,63 @@ final class NotesController {
 
         if enabled {
             guard let template = state.selectedTemplate else { return }
-            settings.setMeetingFamilyTemplatePreference(template.id, forHistoryKey: selection.key)
+            if let event = selection.upcomingEvent {
+                settings.setMeetingFamilyTemplatePreference(template.id, for: event)
+            } else {
+                settings.setMeetingFamilyTemplatePreference(template.id, forHistoryKey: selection.key)
+            }
         } else {
-            settings.setMeetingFamilyTemplatePreference(nil, forHistoryKey: selection.key)
+            if let event = selection.upcomingEvent {
+                settings.setMeetingFamilyTemplatePreference(nil, for: event)
+            } else {
+                settings.setMeetingFamilyTemplatePreference(nil, forHistoryKey: selection.key)
+            }
         }
     }
 
     func setMeetingFamilyFolderPreference(_ folderPath: String?) {
         guard let settings,
               let selection = state.selectedMeetingFamily else { return }
-        settings.setMeetingFamilyFolderPreference(folderPath, forHistoryKey: selection.key)
+        if let event = selection.upcomingEvent {
+            settings.setMeetingFamilyFolderPreference(folderPath, for: event)
+        } else {
+            settings.setMeetingFamilyFolderPreference(folderPath, forHistoryKey: selection.key)
+        }
     }
 
     func applyMeetingFamilyFolderPreference(
         _ folderPath: String?,
         moveExistingSessions: Bool,
+        selection: MeetingFamilySelection? = nil,
         forHistoryKey historyKey: String? = nil
     ) {
         guard let settings else { return }
-        let key = historyKey ?? state.selectedMeetingFamily?.key
+        let resolvedSelection = selection ?? state.selectedMeetingFamily
+        let key = historyKey ?? resolvedSelection?.key
         guard let key, !key.isEmpty else { return }
 
-        settings.setMeetingFamilyFolderPreference(folderPath, forHistoryKey: key)
+        if let event = resolvedSelection?.upcomingEvent {
+            settings.setMeetingFamilyFolderPreference(folderPath, for: event)
+        } else {
+            settings.setMeetingFamilyFolderPreference(folderPath, forHistoryKey: key)
+        }
 
         guard moveExistingSessions else { return }
 
-        let sessionIDs = MeetingHistoryResolver.matchingSessions(
-            forHistoryKey: key,
-            sessionHistory: state.sessionHistory,
-            aliases: settings.meetingHistoryAliasesByKey
-        ).map(\.id)
+        let sessionIDs: [String]
+        if let event = resolvedSelection?.upcomingEvent {
+            sessionIDs = MeetingHistoryResolver.matchingSessions(
+                for: event,
+                sessionHistory: state.sessionHistory,
+                aliases: settings.meetingHistoryAliasesByKey
+            ).map(\.id)
+        } else {
+            sessionIDs = MeetingHistoryResolver.matchingSessions(
+                forHistoryKey: key,
+                sessionHistory: state.sessionHistory,
+                aliases: settings.meetingHistoryAliasesByKey
+            ).map(\.id)
+        }
 
         Task {
             for sessionID in sessionIDs {
@@ -1023,7 +1050,7 @@ final class NotesController {
 
     private func selectedTemplate(
         forSessionTemplateID sessionTemplateID: UUID?,
-        meetingFamilyKey: String?
+        meetingFamilySelection: MeetingFamilySelection?
     ) -> MeetingTemplate? {
         if let sessionTemplateID,
            sessionTemplateID != TemplateStore.genericID,
@@ -1031,8 +1058,16 @@ final class NotesController {
             return template
         }
 
-        if let meetingFamilyKey,
-           let preferredID = settings?.meetingFamilyPreferences(forHistoryKey: meetingFamilyKey)?.templateID,
+        let preferredID: UUID?
+        if let upcomingEvent = meetingFamilySelection?.upcomingEvent {
+            preferredID = settings?.meetingFamilyPreferences(for: upcomingEvent)?.templateID
+        } else if let meetingFamilyKey = meetingFamilySelection?.key {
+            preferredID = settings?.meetingFamilyPreferences(forHistoryKey: meetingFamilyKey)?.templateID
+        } else {
+            preferredID = nil
+        }
+
+        if let preferredID,
            let template = coordinator.templateStore.template(for: preferredID) {
             return template
         }
@@ -1101,7 +1136,15 @@ final class NotesController {
     }
 
     private func matchingMeetingHistorySessions(for selection: MeetingFamilySelection) -> [SessionIndex] {
-        MeetingHistoryResolver.matchingSessions(
+        if let upcomingEvent = selection.upcomingEvent {
+            return MeetingHistoryResolver.matchingSessions(
+                for: upcomingEvent,
+                sessionHistory: state.sessionHistory,
+                aliases: settings?.meetingHistoryAliasesByKey ?? [:]
+            )
+        }
+
+        return MeetingHistoryResolver.matchingSessions(
             forHistoryKey: selection.key,
             sessionHistory: state.sessionHistory,
             aliases: settings?.meetingHistoryAliasesByKey ?? [:]
@@ -1270,12 +1313,14 @@ final class NotesController {
     ) -> MeetingFamilySelection {
         let trimmedTitle = session.title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let title = trimmedTitle.isEmpty ? "Untitled" : trimmedTitle
-        let key = MeetingHistoryResolver.historyKey(for: title)
+        let key = calendarEvent.map(MeetingHistoryResolver.preferredHistoryKey(for:))
+            ?? session.meetingFamilyKey
+            ?? MeetingHistoryResolver.historyKey(for: title)
         return MeetingFamilySelection(
             key: key,
             title: title,
             calendarTitle: calendarEvent?.calendarTitle,
-            upcomingEvent: nil
+            upcomingEvent: calendarEvent
         )
     }
 

--- a/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
+++ b/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
@@ -48,6 +48,7 @@ struct CalendarEvent: Sendable, Hashable, Codable, Identifiable {
     let title: String
     let startDate: Date
     let endDate: Date
+    let externalIdentifier: String?
     let calendarID: String?
     let calendarTitle: String?
     let calendarColorHex: String?
@@ -61,6 +62,7 @@ struct CalendarEvent: Sendable, Hashable, Codable, Identifiable {
         title: String,
         startDate: Date,
         endDate: Date,
+        externalIdentifier: String? = nil,
         calendarID: String? = nil,
         calendarTitle: String? = nil,
         calendarColorHex: String? = nil,
@@ -73,6 +75,7 @@ struct CalendarEvent: Sendable, Hashable, Codable, Identifiable {
         self.title = title
         self.startDate = startDate
         self.endDate = endDate
+        self.externalIdentifier = externalIdentifier
         self.calendarID = calendarID
         self.calendarTitle = calendarTitle
         self.calendarColorHex = calendarColorHex
@@ -129,12 +132,38 @@ enum MeetingHistoryResolver {
         normalizedTitle(event.title)
     }
 
+    static func preferredHistoryKey(for event: CalendarEvent) -> String {
+        seriesHistoryKey(for: event) ?? historyKey(for: event)
+    }
+
+    static func historyKeys(for event: CalendarEvent) -> [String] {
+        historyKeys(title: event.title, meetingFamilyKey: seriesHistoryKey(for: event))
+    }
+
     static func historyKey(for title: String) -> String {
         normalizedTitle(title)
     }
 
     static func matchingSessions(for event: CalendarEvent, sessionHistory: [SessionIndex]) -> [SessionIndex] {
-        matchingSessions(forHistoryKey: historyKey(for: event), sessionHistory: sessionHistory)
+        matchingSessions(for: event, sessionHistory: sessionHistory, aliases: [:])
+    }
+
+    static func matchingSessions(
+        for event: CalendarEvent,
+        sessionHistory: [SessionIndex],
+        aliases: [String: String]
+    ) -> [SessionIndex] {
+        let eventKeys = Set(historyKeys(for: event).map { canonicalHistoryKey(for: $0, aliases: aliases) })
+            .filter { !$0.isEmpty }
+        guard !eventKeys.isEmpty else { return [] }
+
+        return sessionHistory
+            .filter { session in
+                historyKeys(title: session.title, meetingFamilyKey: session.meetingFamilyKey)
+                    .map { canonicalHistoryKey(for: $0, aliases: aliases) }
+                    .contains { eventKeys.contains($0) }
+            }
+            .sorted { $0.startedAt > $1.startedAt }
     }
 
     static func matchingSessions(forHistoryKey historyKey: String, sessionHistory: [SessionIndex]) -> [SessionIndex] {
@@ -149,10 +178,24 @@ enum MeetingHistoryResolver {
         guard !historyKey.isEmpty else { return [] }
         let canonicalKey = canonicalHistoryKey(for: historyKey, aliases: aliases)
         return sessionHistory
-            .filter {
-                canonicalHistoryKey(for: normalizedTitle($0.title ?? ""), aliases: aliases) == canonicalKey
+            .filter { session in
+                historyKeys(title: session.title, meetingFamilyKey: session.meetingFamilyKey)
+                    .map { canonicalHistoryKey(for: $0, aliases: aliases) }
+                    .contains(canonicalKey)
             }
             .sorted { $0.startedAt > $1.startedAt }
+    }
+
+    static func seriesHistoryKey(for event: CalendarEvent) -> String? {
+        seriesHistoryKey(forExternalIdentifier: event.externalIdentifier)
+    }
+
+    static func seriesHistoryKey(forExternalIdentifier externalIdentifier: String?) -> String? {
+        let trimmed = externalIdentifier?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        guard !trimmed.isEmpty else { return nil }
+        return "series:\(trimmed)"
     }
 
     static func canonicalHistoryKey(for historyKey: String, aliases: [String: String]) -> String {
@@ -208,6 +251,22 @@ enum MeetingHistoryResolver {
 
     private static func tokenSet(forHistoryKey historyKey: String) -> Set<String> {
         Set(historyKey.split(separator: " ").map(String.init))
+    }
+
+    private static func historyKeys(title: String?, meetingFamilyKey: String?) -> [String] {
+        var keys: [String] = []
+
+        if let meetingFamilyKey,
+           !meetingFamilyKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            keys.append(meetingFamilyKey)
+        }
+
+        let titleKey = normalizedTitle(title ?? "")
+        if !titleKey.isEmpty, !keys.contains(titleKey) {
+            keys.append(titleKey)
+        }
+
+        return keys
     }
 
     private static func singleTokenRelationScore(

--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -149,6 +149,7 @@ extension CalendarEvent {
             title: event.title ?? "Untitled Event",
             startDate: event.startDate,
             endDate: event.endDate,
+            externalIdentifier: event.calendarItemExternalIdentifier,
             calendarID: event.calendar.calendarIdentifier,
             calendarTitle: event.calendar.title,
             calendarColorHex: CalendarColorCodec.hexString(from: event.calendar.cgColor),

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -387,6 +387,8 @@ struct SessionIndex: Identifiable, Codable, Sendable {
     var folderPath: String? = nil
     /// How the session was created (nil for live sessions, "imported" for imported audio).
     var source: String?
+    /// Stronger recurring meeting-family key derived from a calendar series identifier when available.
+    var meetingFamilyKey: String? = nil
 }
 
 struct SessionSidecar: Codable, Sendable {

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -935,8 +935,12 @@ final class SettingsStore {
     }
 
     func meetingPrepNotes(for event: CalendarEvent) -> String {
-        let key = canonicalMeetingHistoryKey(for: event)
-        return meetingPrepNotesByKey[key] ?? ""
+        for key in orderedMeetingFamilyKeys(for: event) {
+            if let notes = meetingPrepNotesByKey[key], !notes.isEmpty {
+                return notes
+            }
+        }
+        return ""
     }
 
     func setMeetingPrepNotes(_ text: String, for event: CalendarEvent) {
@@ -951,7 +955,7 @@ final class SettingsStore {
     }
 
     func canonicalMeetingHistoryKey(for event: CalendarEvent) -> String {
-        canonicalMeetingHistoryKey(forHistoryKey: MeetingHistoryResolver.historyKey(for: event))
+        canonicalMeetingHistoryKey(forHistoryKey: MeetingHistoryResolver.preferredHistoryKey(for: event))
     }
 
     func canonicalMeetingHistoryKey(forHistoryKey historyKey: String) -> String {
@@ -962,7 +966,12 @@ final class SettingsStore {
     }
 
     func meetingFamilyPreferences(for event: CalendarEvent) -> MeetingFamilyPreferences? {
-        meetingFamilyPreferences(forHistoryKey: MeetingHistoryResolver.historyKey(for: event))
+        for key in orderedMeetingFamilyKeys(for: event) {
+            if let preferences = meetingFamilyPreferencesByKey[key] {
+                return preferences
+            }
+        }
+        return nil
     }
 
     func meetingFamilyPreferences(forHistoryKey historyKey: String) -> MeetingFamilyPreferences? {
@@ -973,7 +982,7 @@ final class SettingsStore {
     func setMeetingFamilyTemplatePreference(_ templateID: UUID?, for event: CalendarEvent) {
         setMeetingFamilyTemplatePreference(
             templateID,
-            forHistoryKey: MeetingHistoryResolver.historyKey(for: event)
+            forHistoryKey: MeetingHistoryResolver.preferredHistoryKey(for: event)
         )
     }
 
@@ -996,8 +1005,19 @@ final class SettingsStore {
     func setMeetingFamilyFolderPreference(_ folderPath: String?, for event: CalendarEvent) {
         setMeetingFamilyFolderPreference(
             folderPath,
-            forHistoryKey: MeetingHistoryResolver.historyKey(for: event)
+            forHistoryKey: MeetingHistoryResolver.preferredHistoryKey(for: event)
         )
+    }
+
+    private func orderedMeetingFamilyKeys(for event: CalendarEvent) -> [String] {
+        var keys: [String] = []
+        for historyKey in MeetingHistoryResolver.historyKeys(for: event) {
+            let canonicalKey = canonicalMeetingHistoryKey(forHistoryKey: historyKey)
+            if !canonicalKey.isEmpty, !keys.contains(canonicalKey) {
+                keys.append(canonicalKey)
+            }
+        }
+        return keys
     }
 
     func setMeetingFamilyFolderPreference(_ folderPath: String?, forHistoryKey historyKey: String) {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -748,7 +748,8 @@ actor SessionRepository {
                         engine: meta.engine,
                         tags: meta.tags,
                         folderPath: meta.folderPath,
-                        source: meta.source
+                        source: meta.source,
+                        meetingFamilyKey: meta.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) }
                     ))
                     continue
                 }
@@ -786,7 +787,8 @@ actor SessionRepository {
                 engine: meta.engine,
                 tags: meta.tags,
                 folderPath: meta.folderPath,
-                source: meta.source
+                source: meta.source,
+                meetingFamilyKey: meta.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) }
             )
 
             let transcript = loadTranscript(sessionID: id)
@@ -1777,7 +1779,8 @@ actor SessionRepository {
             engine: meta?.engine,
             tags: meta?.tags,
             folderPath: meta?.folderPath,
-            source: meta?.source
+            source: meta?.source,
+            meetingFamilyKey: meta?.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) }
         )
 
         MarkdownMeetingWriter.write(

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -52,8 +52,7 @@ struct NotesView: View {
     @State private var isMeetingFamilyBottomCollapsed = false
 
     private struct PendingMeetingFamilyFolderChange: Equatable {
-        let historyKey: String
-        let familyTitle: String
+        let selection: MeetingFamilySelection
         let folderPath: String?
         let existingMeetingCount: Int
     }
@@ -667,8 +666,15 @@ struct NotesView: View {
         creatingFolderForSessionID = session.id
     }
 
+    private func meetingFamilyPreferences(for selection: MeetingFamilySelection) -> MeetingFamilyPreferences? {
+        if let upcomingEvent = selection.upcomingEvent {
+            return settings.meetingFamilyPreferences(for: upcomingEvent)
+        }
+        return settings.meetingFamilyPreferences(forHistoryKey: selection.key)
+    }
+
     private func beginCreateFolder(for selection: MeetingFamilySelection) {
-        let preferredFolderPath = settings.meetingFamilyPreferences(forHistoryKey: selection.key)?.folderPath
+        let preferredFolderPath = meetingFamilyPreferences(for: selection)?.folderPath
         newFolderPath = preferredFolderPath ?? ""
         newFolderColor = folderDefinition(for: preferredFolderPath)?.color ?? .orange
         creatingFolderForMeetingFamilyKey = selection.key
@@ -863,13 +869,12 @@ struct NotesView: View {
         folderPath: String?,
         historyCount: Int
     ) {
-        let currentFolderPath = settings.meetingFamilyPreferences(forHistoryKey: selection.key)?.folderPath
+        let currentFolderPath = meetingFamilyPreferences(for: selection)?.folderPath
         guard currentFolderPath != folderPath else { return }
 
         if historyCount > 0 {
             pendingMeetingFamilyFolderChange = PendingMeetingFamilyFolderChange(
-                historyKey: selection.key,
-                familyTitle: selection.title,
+                selection: selection,
                 folderPath: folderPath,
                 existingMeetingCount: historyCount
             )
@@ -879,6 +884,7 @@ struct NotesView: View {
         controller.applyMeetingFamilyFolderPreference(
             folderPath,
             moveExistingSessions: false,
+            selection: selection,
             forHistoryKey: selection.key
         )
     }
@@ -891,7 +897,8 @@ struct NotesView: View {
         controller.applyMeetingFamilyFolderPreference(
             pendingChange.folderPath,
             moveExistingSessions: moveExistingSessions,
-            forHistoryKey: pendingChange.historyKey
+            selection: pendingChange.selection,
+            forHistoryKey: pendingChange.selection.key
         )
         pendingMeetingFamilyFolderChange = nil
     }
@@ -905,7 +912,7 @@ struct NotesView: View {
         let destination = folderDisplayName(for: pendingChange.folderPath)
         let count = pendingChange.existingMeetingCount
         let noun = count == 1 ? "saved meeting" : "saved meetings"
-        return "Use \(destination) for future meetings in \"\(pendingChange.familyTitle)\", or move the existing \(count) \(noun) there too."
+        return "Use \(destination) for future meetings in \"\(pendingChange.selection.title)\", or move the existing \(count) \(noun) there too."
     }
 
     private func folderDisplayName(for folderPath: String?) -> String {
@@ -1250,7 +1257,7 @@ struct NotesView: View {
         selection: MeetingFamilySelection,
         historyCount: Int
     ) -> some View {
-        let preferredFolderPath = settings.meetingFamilyPreferences(forHistoryKey: selection.key)?.folderPath
+        let preferredFolderPath = meetingFamilyPreferences(for: selection)?.folderPath
         let preferredFolder = folderDefinition(for: preferredFolderPath)
         let folders = meetingFamilyFolderChoices(including: preferredFolderPath)
 
@@ -1632,7 +1639,7 @@ struct NotesView: View {
     ) -> some View {
         let hasCalendarContext = state.loadedCalendarEvent != nil
         let historyCount = state.meetingHistoryEntries.count
-        let preferredFolderPath = settings.meetingFamilyPreferences(forHistoryKey: selection.key)?.folderPath
+        let preferredFolderPath = meetingFamilyPreferences(for: selection)?.folderPath
         let preferredFolder = folderDefinition(for: preferredFolderPath)
         let folders = meetingFamilyFolderChoices(including: preferredFolderPath)
         let selectedSession = state.selectedSessionID.flatMap { sessionID in
@@ -2663,7 +2670,7 @@ struct NotesView: View {
                             Toggle(isOn: Binding(
                                 get: {
                                     guard let selectedTemplate = state.selectedTemplate else { return false }
-                                    return settings.meetingFamilyPreferences(forHistoryKey: selection.key)?.templateID == selectedTemplate.id
+                                    return meetingFamilyPreferences(for: selection)?.templateID == selectedTemplate.id
                                 },
                                 set: { controller.setSelectedTemplateSavedForMeetingFamily($0) }
                             )) {

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -943,6 +943,50 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(controller.state.selectedTemplate?.id, TemplateStore.standUpID)
     }
 
+    func testSelectSessionUsesRecurringSeriesTemplatePreferenceWhenTitleDrifts() async {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+
+        let preferredEvent = CalendarEvent(
+            id: "evt-platform-feedback-new",
+            title: "Regular Platform feedback",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            externalIdentifier: "series-platform-feedback",
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+        settings.setMeetingFamilyTemplatePreference(TemplateStore.standUpID, for: preferredEvent)
+
+        let historicalEvent = CalendarEvent(
+            id: "evt-platform-feedback-old",
+            title: "Platform feedback",
+            startDate: Date(timeIntervalSince1970: 1_699_000_000),
+            endDate: Date(timeIntervalSince1970: 1_699_000_900),
+            externalIdentifier: "series-platform-feedback",
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "platform-feedback",
+            title: "Platform feedback",
+            calendarEvent: historicalEvent
+        )
+        await controller.loadHistory()
+
+        controller.selectSession("platform-feedback")
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertEqual(controller.state.selectedTemplate?.id, TemplateStore.standUpID)
+    }
+
     func testApplyMeetingFamilyFolderPreferenceCanMoveExistingSessions() async {
         let (root, notes) = makeTempDirs()
         let settings = makeSettings(notesDirectory: notes)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -89,6 +89,36 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: handle.sessionID)
     }
 
+    func testStartSessionPersistsRecurringMeetingFamilyKey() async {
+        let calendarEvent = CalendarEvent(
+            id: "event-series-123",
+            title: "Regular Platform feedback",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            externalIdentifier: "series-platform-feedback",
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+        let handle = await repo.startSession(
+            config: SessionStartConfig(
+                templateSnapshot: nil,
+                title: calendarEvent.title,
+                calendarEvent: calendarEvent
+            )
+        )
+
+        let session = await repo.loadSession(id: handle.sessionID)
+        XCTAssertEqual(
+            session.index.meetingFamilyKey,
+            MeetingHistoryResolver.seriesHistoryKey(forExternalIdentifier: "series-platform-feedback")
+        )
+
+        await repo.endSession()
+        await repo.deleteSession(sessionID: handle.sessionID)
+    }
+
     // MARK: - appendLiveUtterance writes to JSONL
 
     func testAppendLiveUtteranceWritesToJSONL() async {

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -527,6 +527,53 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(store.meetingFamilyPreferencesByKey.isEmpty)
     }
 
+    func testMeetingFamilyPreferencesForRecurringEventFallBackToLegacyTitleKey() {
+        let store = makeStore()
+        let recurringEvent = CalendarEvent(
+            id: "evt-recurring",
+            title: "Weekly Sync",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            externalIdentifier: "series-123",
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        store.setMeetingFamilyFolderPreference(
+            "Work/Weekly",
+            forHistoryKey: MeetingHistoryResolver.historyKey(for: recurringEvent.title)
+        )
+
+        XCTAssertEqual(
+            store.meetingFamilyPreferences(for: recurringEvent)?.folderPath,
+            "Work/Weekly"
+        )
+    }
+
+    func testMeetingFamilyPreferencesForRecurringEventWriteToSeriesKey() {
+        let store = makeStore()
+        let recurringEvent = CalendarEvent(
+            id: "evt-recurring",
+            title: "Weekly Sync",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            externalIdentifier: "series-123",
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        store.setMeetingFamilyTemplatePreference(TemplateStore.weeklyID, for: recurringEvent)
+
+        XCTAssertEqual(
+            store.meetingFamilyPreferencesByKey[MeetingHistoryResolver.seriesHistoryKey(forExternalIdentifier: "series-123")!]?.templateID,
+            TemplateStore.weeklyID
+        )
+    }
+
     func testKbFolderURLWhenEmpty() {
         let store = makeStore()
         XCTAssertNil(store.kbFolderURL)

--- a/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/UpcomingCalendarGroupingTests.swift
@@ -93,6 +93,36 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
         XCTAssertEqual(matched.map(\.id), ["newer", "older"])
     }
 
+    func testMeetingHistoryResolverMatchesRecurringSeriesEvenWhenTitleDrifts() {
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let event = makeEvent(
+            id: "evt",
+            title: "Regular Platform feedback",
+            start: startedAt,
+            externalIdentifier: "series-platform-feedback"
+        )
+        let sessions = [
+            SessionIndex(
+                id: "drifted",
+                startedAt: startedAt.addingTimeInterval(-100),
+                endedAt: nil,
+                templateSnapshot: nil,
+                title: "Platform council review",
+                utteranceCount: 12,
+                hasNotes: true,
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                tags: nil,
+                source: nil,
+                meetingFamilyKey: MeetingHistoryResolver.seriesHistoryKey(forExternalIdentifier: "series-platform-feedback")
+            ),
+        ]
+
+        let matched = MeetingHistoryResolver.matchingSessions(for: event, sessionHistory: sessions)
+        XCTAssertEqual(matched.map(\.id), ["drifted"])
+    }
+
     func testMeetingHistoryResolverReturnsEmptyWithoutTitleMatch() {
         let event = makeEvent(id: "evt", title: "Design Review", start: Date())
         let sessions = [
@@ -245,6 +275,7 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
         id: String,
         title: String,
         start: Date,
+        externalIdentifier: String? = nil,
         calendarID: String? = nil,
         calendarTitle: String? = nil,
         duration: TimeInterval = 30 * 60
@@ -254,6 +285,7 @@ final class UpcomingCalendarGroupingTests: XCTestCase {
             title: title,
             startDate: start,
             endDate: start.addingTimeInterval(duration),
+            externalIdentifier: externalIdentifier,
             calendarID: calendarID,
             calendarTitle: calendarTitle,
             calendarColorHex: nil,


### PR DESCRIPTION
Fixes #503

## Summary
- carry recurring calendar external identifiers through `CalendarEvent` and derive a stronger series key
- prefer recurring-series keys for meeting-family matching and template/folder/prep-note preference lookup when an event is available
- preserve compatibility by falling back to the existing title-based family key

## Tests
- `swift test --package-path OpenOats --filter SettingsStoreTests`
- `swift test --package-path OpenOats --filter UpcomingCalendarGroupingTests`
- `swift test --package-path OpenOats --filter NotesControllerTests`
- `swift test --package-path OpenOats --filter SessionRepositoryTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`