### PR TITLE
Mark empty failed live sessions explicitly

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -138,6 +138,9 @@ final class LiveSessionController {
                             await notifService.postBatchCompleted(sessionID: sid)
                         }
                         await coordinator.loadHistory()
+                        if coordinator.lastEndedSession?.id == sid {
+                            coordinator.lastEndedSession = await coordinator.sessionRepository.loadSession(id: sid).index
+                        }
 
                         Task { @MainActor in
                             try? await Task.sleep(for: .seconds(3))
@@ -412,6 +415,10 @@ final class LiveSessionController {
             await coordinator.sessionRepository.saveScratchpad(sessionID: sessionID, text: state.scratchpadText)
         }
 
+        let captureHealthAtStop = coordinator.transcriptionEngine?.captureHealthSnapshot
+        let wasMicMutedAtStop = state.isMicMuted
+        let peakAudioLevelAtStop = observedPeakAudioLevelSinceStart
+
         // 1. Drain audio buffers
         await coordinator.transcriptionEngine?.finalize()
 
@@ -450,6 +457,33 @@ final class LiveSessionController {
             guard let locale = settings?.transcriptionLocale, !locale.isEmpty else { return nil }
             return locale
         }()
+        let transcriptIssueInput: RecordingHealthInput
+        if let meetingStartedAt = endingMetadata?.startedAt, let transcriptionModel = settings?.transcriptionModel {
+            transcriptIssueInput = RecordingHealthInput(
+                elapsed: max(0, Date().timeIntervalSince(meetingStartedAt)),
+                transcriptionModel: transcriptionModel,
+                utteranceCount: utteranceCount,
+                peakAudioLevel: peakAudioLevelAtStop,
+                micHasCapturedFrames: captureHealthAtStop?.micHasCapturedFrames ?? false,
+                systemHasCapturedFrames: captureHealthAtStop?.systemHasCapturedFrames ?? false,
+                micCaptureError: captureHealthAtStop?.micCaptureError,
+                isMicMuted: wasMicMutedAtStop,
+                hasBlockingError: false
+            )
+        } else {
+            transcriptIssueInput = RecordingHealthInput(
+                elapsed: 0,
+                transcriptionModel: settings?.transcriptionModel ?? .parakeetV3,
+                utteranceCount: utteranceCount,
+                peakAudioLevel: peakAudioLevelAtStop,
+                micHasCapturedFrames: captureHealthAtStop?.micHasCapturedFrames ?? false,
+                systemHasCapturedFrames: captureHealthAtStop?.systemHasCapturedFrames ?? false,
+                micCaptureError: captureHealthAtStop?.micCaptureError,
+                isMicMuted: wasMicMutedAtStop,
+                hasBlockingError: false
+            )
+        }
+        let transcriptIssue = Self.transcriptIssue(for: transcriptIssueInput)
 
         // 4. Finalize: closes file handle, backfills cleaned text, writes session.json
         await coordinator.sessionRepository.finalizeSession(
@@ -463,7 +497,8 @@ final class LiveSessionController {
                 engine: engineName,
                 templateSnapshot: coordinator.sessionTemplateSnapshot,
                 utterances: utterancesSnapshot,
-                calendarEvent: endingMetadata?.calendarEvent
+                calendarEvent: endingMetadata?.calendarEvent,
+                transcriptIssue: transcriptIssue
             )
         )
 
@@ -476,7 +511,7 @@ final class LiveSessionController {
         // 5. Build index for UI state
         let index = SessionIndex(
             id: sessionID,
-            startedAt: utterancesSnapshot.first?.timestamp ?? Date(),
+            startedAt: utterancesSnapshot.first?.timestamp ?? endingMetadata?.startedAt ?? Date(),
             endedAt: Date(),
             templateSnapshot: coordinator.sessionTemplateSnapshot,
             title: title,
@@ -484,7 +519,8 @@ final class LiveSessionController {
             hasNotes: false,
             language: transcriptionLanguage,
             meetingApp: meetingAppName,
-            engine: engineName
+            engine: engineName,
+            transcriptIssue: transcriptIssue
         )
 
         // 5b. Fire webhook if configured
@@ -649,6 +685,27 @@ final class LiveSessionController {
         )
     }
 
+    static func transcriptIssue(for input: RecordingHealthInput) -> SessionTranscriptIssue? {
+        guard input.utteranceCount == 0 else { return nil }
+
+        if let micCaptureError = input.micCaptureError, !micCaptureError.isEmpty {
+            return .noAudioDetected
+        }
+
+        if input.elapsed >= 5,
+           !input.systemHasCapturedFrames,
+           (!input.isMicMuted && !input.micHasCapturedFrames) {
+            return .noAudioDetected
+        }
+
+        if input.peakAudioLevel >= 0.04,
+           input.micHasCapturedFrames || input.systemHasCapturedFrames {
+            return .transcriptionProducedNoText
+        }
+
+        return nil
+    }
+
     static func recordingHealthNotice(for input: RecordingHealthInput) -> RecordingHealthNotice? {
         guard !input.hasBlockingError else { return nil }
 
@@ -767,7 +824,7 @@ final class LiveSessionController {
         set(\.isGeneratingSuggestions, sidebarGenerating)
         set(\.batchStatus, coordinator.batchStatus)
         set(\.batchIsImporting, coordinator.batchIsImporting)
-        if state.lastEndedSession?.id != lastEndedSession?.id { state.lastEndedSession = lastEndedSession }
+        if state.lastEndedSession != lastEndedSession { state.lastEndedSession = lastEndedSession }
         set(\.lastSessionHasNotes, lastSessionHasNotes)
         set(\.kbIndexingStatus, coordinator.knowledgeBase?.indexingStatus ?? .idle)
         set(\.statusMessage, coordinator.transcriptionEngine?.assetStatus)

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -329,7 +329,7 @@ struct MeetingTemplate: Identifiable, Codable, Sendable, Hashable {
     var isBuiltIn: Bool
 }
 
-struct TemplateSnapshot: Codable, Sendable {
+struct TemplateSnapshot: Codable, Sendable, Equatable {
     let id: UUID
     let name: String
     let icon: String
@@ -367,7 +367,48 @@ struct SessionAudioSource: Identifiable, Sendable, Hashable {
     var displayName: String { kind.displayName }
 }
 
-struct SessionIndex: Identifiable, Codable, Sendable {
+enum SessionTranscriptIssue: String, Codable, Sendable, Equatable {
+    case noAudioDetected
+    case transcriptionProducedNoText
+
+    var listLabel: String {
+        switch self {
+        case .noAudioDetected:
+            return "No audio captured"
+        case .transcriptionProducedNoText:
+            return "Transcription failed"
+        }
+    }
+
+    var emptyStateTitle: String {
+        switch self {
+        case .noAudioDetected:
+            return "No audio captured"
+        case .transcriptionProducedNoText:
+            return "Transcription failed"
+        }
+    }
+
+    var emptyStateMessage: String {
+        switch self {
+        case .noAudioDetected:
+            return "OpenOats did not capture usable microphone or system audio for this session."
+        case .transcriptionProducedNoText:
+            return "OpenOats captured audio for this session, but live transcription did not produce text."
+        }
+    }
+
+    var sessionEndedBannerText: String {
+        switch self {
+        case .noAudioDetected:
+            return "Session ended · No audio captured"
+        case .transcriptionProducedNoText:
+            return "Session ended · Live transcription failed"
+        }
+    }
+}
+
+struct SessionIndex: Identifiable, Codable, Sendable, Equatable {
     let id: String
     let startedAt: Date
     var endedAt: Date?
@@ -389,6 +430,8 @@ struct SessionIndex: Identifiable, Codable, Sendable {
     var source: String?
     /// Stronger recurring meeting-family key derived from a calendar series identifier when available.
     var meetingFamilyKey: String? = nil
+    /// Non-nil when the session ended without a transcript for a known recording/transcription reason.
+    var transcriptIssue: SessionTranscriptIssue? = nil
 }
 
 struct SessionSidecar: Codable, Sendable {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -64,6 +64,7 @@ struct SessionFinalizeMetadata: Sendable {
     let templateSnapshot: TemplateSnapshot?
     let utterances: [Utterance]
     let calendarEvent: CalendarEvent?
+    let transcriptIssue: SessionTranscriptIssue?
 
     init(
         endedAt: Date,
@@ -74,7 +75,8 @@ struct SessionFinalizeMetadata: Sendable {
         engine: String?,
         templateSnapshot: TemplateSnapshot?,
         utterances: [Utterance],
-        calendarEvent: CalendarEvent? = nil
+        calendarEvent: CalendarEvent? = nil,
+        transcriptIssue: SessionTranscriptIssue? = nil
     ) {
         self.endedAt = endedAt
         self.utteranceCount = utteranceCount
@@ -85,6 +87,7 @@ struct SessionFinalizeMetadata: Sendable {
         self.templateSnapshot = templateSnapshot
         self.utterances = utterances
         self.calendarEvent = calendarEvent
+        self.transcriptIssue = transcriptIssue
     }
 }
 
@@ -147,6 +150,7 @@ struct SessionMetadata: Codable, Sendable {
     /// How the session was created (nil for live sessions, "imported" for imported audio).
     var source: String?
     var calendarEvent: CalendarEvent?
+    var transcriptIssue: SessionTranscriptIssue?
 }
 
 // MARK: - SessionRepository
@@ -416,10 +420,15 @@ actor SessionRepository {
         // Backfill cleaned text into live transcript
         backfillCleanedText(sessionID: sessionID, from: metadata.utterances)
 
+        let existingMetadata = loadSessionMetadataFile(sessionID: sessionID)
+        let startedAt = metadata.utterances.first?.timestamp
+            ?? existingMetadata?.startedAt
+            ?? Date()
+
         // Write session.json with final metadata
         let sessionMeta = SessionMetadata(
             id: sessionID,
-            startedAt: metadata.utterances.first?.timestamp ?? Date(),
+            startedAt: startedAt,
             endedAt: metadata.endedAt,
             templateSnapshot: metadata.templateSnapshot,
             title: metadata.title,
@@ -428,7 +437,8 @@ actor SessionRepository {
             language: metadata.language,
             meetingApp: metadata.meetingApp,
             engine: metadata.engine,
-            calendarEvent: metadata.calendarEvent
+            calendarEvent: metadata.calendarEvent,
+            transcriptIssue: metadata.transcriptIssue
         )
         writeSessionMetadata(sessionMeta, sessionID: sessionID)
 
@@ -582,7 +592,8 @@ actor SessionRepository {
                 tags: meta.tags,
                 folderPath: meta.folderPath,
                 source: meta.source,
-                calendarEvent: meta.calendarEvent
+                calendarEvent: meta.calendarEvent,
+                transcriptIssue: nil
             )
             writeSessionMetadata(refreshedMeta, sessionID: sessionID)
         }
@@ -749,7 +760,8 @@ actor SessionRepository {
                         tags: meta.tags,
                         folderPath: meta.folderPath,
                         source: meta.source,
-                        meetingFamilyKey: meta.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) }
+                        meetingFamilyKey: meta.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) },
+                        transcriptIssue: meta.transcriptIssue
                     ))
                     continue
                 }
@@ -788,7 +800,8 @@ actor SessionRepository {
                 tags: meta.tags,
                 folderPath: meta.folderPath,
                 source: meta.source,
-                meetingFamilyKey: meta.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) }
+                meetingFamilyKey: meta.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) },
+                transcriptIssue: meta.transcriptIssue
             )
 
             let transcript = loadTranscript(sessionID: id)
@@ -1397,7 +1410,8 @@ actor SessionRepository {
         endedAt: Date? = nil,
         templateSnapshot: TemplateSnapshot? = nil,
         title: String? = nil,
-        notes: GeneratedNotes? = nil
+        notes: GeneratedNotes? = nil,
+        transcriptIssue: SessionTranscriptIssue? = nil
     ) {
         let dir = sessionDirectory(for: id)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -1412,7 +1426,8 @@ actor SessionRepository {
             utteranceCount: records.count,
             hasNotes: notes != nil,
             meetingApp: nil,
-            engine: nil
+            engine: nil,
+            transcriptIssue: transcriptIssue
         )
         writeSessionMetadata(meta, sessionID: id)
 
@@ -1780,7 +1795,8 @@ actor SessionRepository {
             tags: meta?.tags,
             folderPath: meta?.folderPath,
             source: meta?.source,
-            meetingFamilyKey: meta?.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) }
+            meetingFamilyKey: meta?.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) },
+            transcriptIssue: meta?.transcriptIssue
         )
 
         MarkdownMeetingWriter.write(

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -69,40 +69,68 @@ struct ContentView: View {
             Divider()
 
             // Post-session banner
-            if let lastSession = controllerState.lastEndedSession, lastSession.utteranceCount > 0 {
-                HStack {
-                    Text("Session ended \u{00B7} \(lastSession.utteranceCount) utterances")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                        .accessibilityIdentifier("app.sessionEndedBanner")
-                    Spacer()
-                    if controllerState.lastSessionHasNotes {
+            if let lastSession = controllerState.lastEndedSession {
+                if lastSession.utteranceCount > 0 {
+                    HStack {
+                        Text("Session ended \u{00B7} \(lastSession.utteranceCount) utterances")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .accessibilityIdentifier("app.sessionEndedBanner")
+                        Spacer()
+                        if controllerState.lastSessionHasNotes {
+                            Button {
+                                openWindow(id: "notes")
+                            } label: {
+                                Label("View Notes", systemImage: "doc.text")
+                                    .font(.system(size: 12))
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                            .accessibilityIdentifier("app.viewNotesButton")
+                        } else {
+                            Button {
+                                openWindow(id: "notes")
+                            } label: {
+                                Label("Generate Notes", systemImage: "sparkles")
+                                    .font(.system(size: 12))
+                            }
+                            .buttonStyle(OpenOatsProminentButtonStyle())
+                            .controlSize(.small)
+                            .accessibilityIdentifier("app.generateNotesButton")
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(.ultraThinMaterial)
+
+                    Divider()
+                } else if let transcriptIssue = lastSession.transcriptIssue {
+                    HStack(spacing: 10) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.orange)
+
+                        Text(transcriptIssue.sessionEndedBannerText)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .accessibilityIdentifier("app.sessionEndedBanner")
+                        Spacer()
                         Button {
                             openWindow(id: "notes")
                         } label: {
-                            Label("View Notes", systemImage: "doc.text")
+                            Label("Review Session", systemImage: "arrow.right.circle")
                                 .font(.system(size: 12))
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)
-                        .accessibilityIdentifier("app.viewNotesButton")
-                    } else {
-                        Button {
-                            openWindow(id: "notes")
-                        } label: {
-                            Label("Generate Notes", systemImage: "sparkles")
-                                .font(.system(size: 12))
-                        }
-                        .buttonStyle(OpenOatsProminentButtonStyle())
-                        .controlSize(.small)
-                        .accessibilityIdentifier("app.generateNotesButton")
+                        .accessibilityIdentifier("app.reviewSessionButton")
                     }
-                }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 8)
-                .background(.ultraThinMaterial)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .background(.ultraThinMaterial)
 
-                Divider()
+                    Divider()
+                }
             }
 
             if controllerState.isRunning, let event = controllerState.matchedCalendarEvent {

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -404,7 +404,7 @@ struct NotesView: View {
                 Text(session.startedAt, style: .date)
                 Text(session.startedAt, style: .time)
                 Spacer()
-                Text("\(session.utteranceCount) utterances")
+                Text(transcriptStatusText(for: session))
             }
             .font(.system(size: 11))
             .foregroundStyle(.tertiary)
@@ -1766,9 +1766,9 @@ struct NotesView: View {
 
                                 HStack(spacing: 8) {
                                     if entry.session.utteranceCount > 0 {
-                                        Text("\(entry.session.utteranceCount) utterances")
+                                        Text(transcriptStatusText(for: entry.session))
                                     } else {
-                                        Text("No transcript")
+                                        Text(transcriptStatusText(for: entry.session))
                                     }
 
                                     if let source = entry.session.source?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -2394,6 +2394,19 @@ struct NotesView: View {
     @ViewBuilder
     private func notesNoTranscriptState(controller: NotesController, state: NotesState) -> some View {
         let isEmbeddedMeetingFamilyDetail = state.selectedMeetingFamily != nil
+        let selectedSession = state.selectedSessionID.flatMap { sessionID in
+            state.sessionHistory.first { $0.id == sessionID }
+        }
+        let sessionIssue = selectedSession?.transcriptIssue
+        let title = sessionIssue?.emptyStateTitle ?? "No transcript"
+        let message = emptyTranscriptMessage(
+            for: sessionIssue,
+            canRetranscribe: state.canRetranscribeSelectedSession
+        )
+        let editorBanner = manualNotesBannerText(
+            for: sessionIssue,
+            canRetranscribe: state.canRetranscribeSelectedSession
+        )
 
         if state.isEditingManualNotes {
             ScrollView {
@@ -2402,7 +2415,7 @@ struct NotesView: View {
                         Image(systemName: "waveform")
                             .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(.secondary)
-                        Text("No transcript was recorded for this session. You can still save manual notes.")
+                        Text(editorBanner)
                             .font(.system(size: 12))
                             .foregroundStyle(.secondary)
                     }
@@ -2449,18 +2462,34 @@ struct NotesView: View {
         } else if isEmbeddedMeetingFamilyDetail {
             ScrollView {
                 VStack(alignment: .leading, spacing: 12) {
-                    Text("No transcript")
+                    Text(title)
                         .font(.system(size: 18, weight: .semibold))
-                    Text("There are no recorded utterances to turn into notes for this session.")
+                    Text(message)
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
 
-                    Button {
-                        controller.startManualNotesEditing()
-                    } label: {
-                        Label("Start writing notes", systemImage: "square.and.pencil")
+                    HStack(spacing: 8) {
+                        if state.canRetranscribeSelectedSession {
+                            Button {
+                                container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
+                                controller.rerunBatchTranscription(
+                                    model: settings.batchTranscriptionModel,
+                                    settings: settings
+                                )
+                            } label: {
+                                Label("Re-transcribe", systemImage: "arrow.trianglehead.2.clockwise.rotate.90")
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(coordinator.batchStatus != .idle)
+                        }
+
+                        Button {
+                            controller.startManualNotesEditing()
+                        } label: {
+                            Label("Start writing notes", systemImage: "square.and.pencil")
+                        }
+                        .buttonStyle(OpenOatsProminentButtonStyle())
                     }
-                    .buttonStyle(OpenOatsProminentButtonStyle())
                     .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .frame(maxWidth: .infinity, alignment: .topLeading)
@@ -2470,18 +2499,34 @@ struct NotesView: View {
         } else {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    Text("No transcript")
+                    Text(title)
                         .font(.system(size: 28, weight: .semibold))
-                    Text("There are no recorded utterances to turn into notes for this session.")
+                    Text(message)
                         .font(.system(size: 14))
                         .foregroundStyle(.secondary)
 
-                    Button {
-                        controller.startManualNotesEditing()
-                    } label: {
-                        Label("Start writing notes", systemImage: "square.and.pencil")
+                    HStack(spacing: 8) {
+                        if state.canRetranscribeSelectedSession {
+                            Button {
+                                container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
+                                controller.rerunBatchTranscription(
+                                    model: settings.batchTranscriptionModel,
+                                    settings: settings
+                                )
+                            } label: {
+                                Label("Re-transcribe", systemImage: "arrow.trianglehead.2.clockwise.rotate.90")
+                            }
+                            .buttonStyle(.bordered)
+                            .disabled(coordinator.batchStatus != .idle)
+                        }
+
+                        Button {
+                            controller.startManualNotesEditing()
+                        } label: {
+                            Label("Start writing notes", systemImage: "square.and.pencil")
+                        }
+                        .buttonStyle(OpenOatsProminentButtonStyle())
                     }
-                    .buttonStyle(OpenOatsProminentButtonStyle())
                 }
                 .frame(maxWidth: .infinity, alignment: .topLeading)
                 .padding(32)
@@ -2735,11 +2780,32 @@ struct NotesView: View {
     @ViewBuilder
     private func transcriptView(controller: NotesController, state: NotesState) -> some View {
         if state.loadedTranscript.isEmpty {
+            let selectedSession = state.selectedSessionID.flatMap { sessionID in
+                state.sessionHistory.first { $0.id == sessionID }
+            }
+            let sessionIssue = selectedSession?.transcriptIssue
             ContentUnavailableView {
-                Label("No Transcript", systemImage: "waveform")
+                Label(sessionIssue?.emptyStateTitle ?? "No Transcript", systemImage: "waveform")
             } description: {
-                Text("This session has no recorded utterances.")
+                Text(emptyTranscriptMessage(
+                    for: sessionIssue,
+                    canRetranscribe: state.canRetranscribeSelectedSession
+                ))
             } actions: {
+                if state.canRetranscribeSelectedSession {
+                    Button {
+                        container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
+                        controller.rerunBatchTranscription(
+                            model: settings.batchTranscriptionModel,
+                            settings: settings
+                        )
+                    } label: {
+                        Label("Re-transcribe", systemImage: "arrow.trianglehead.2.clockwise.rotate.90")
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(coordinator.batchStatus != .idle)
+                }
+
                 Button {
                     beginAddTranscript()
                 } label: {
@@ -2772,6 +2838,37 @@ struct NotesView: View {
                 .padding(16)
             }
         }
+    }
+
+    private func transcriptStatusText(for session: SessionIndex) -> String {
+        if session.utteranceCount > 0 {
+            return "\(session.utteranceCount) utterances"
+        }
+        return session.transcriptIssue?.listLabel ?? "No transcript"
+    }
+
+    private func emptyTranscriptMessage(
+        for issue: SessionTranscriptIssue?,
+        canRetranscribe: Bool
+    ) -> String {
+        var message = issue?.emptyStateMessage ?? "There are no recorded utterances to turn into notes for this session."
+        if canRetranscribe {
+            message += " You can re-transcribe the retained audio or add a transcript manually."
+        }
+        return message
+    }
+
+    private func manualNotesBannerText(
+        for issue: SessionTranscriptIssue?,
+        canRetranscribe: Bool
+    ) -> String {
+        var message = issue?.emptyStateMessage ?? "No transcript was recorded for this session."
+        if canRetranscribe {
+            message += " You can re-transcribe the retained audio or save manual notes."
+        } else {
+            message += " You can still save manual notes."
+        }
+        return message
     }
 
     private func cleanupProgressBanner(controller: NotesController, completed: Int, total: Int) -> some View {

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -624,6 +624,89 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertNil(LiveSessionController.recordingHealthNotice(for: input))
     }
 
+    func testTranscriptIssueMarksMissingAudioForExtendedEmptySession() {
+        let input = LiveSessionController.RecordingHealthInput(
+            elapsed: 8,
+            transcriptionModel: .parakeetV3,
+            utteranceCount: 0,
+            peakAudioLevel: 0,
+            micHasCapturedFrames: false,
+            systemHasCapturedFrames: false,
+            micCaptureError: nil,
+            isMicMuted: false,
+            hasBlockingError: false
+        )
+
+        XCTAssertEqual(LiveSessionController.transcriptIssue(for: input), .noAudioDetected)
+    }
+
+    func testTranscriptIssueMarksStalledTranscriptionWhenAudioWasCaptured() {
+        let input = LiveSessionController.RecordingHealthInput(
+            elapsed: 12,
+            transcriptionModel: .elevenLabsScribe,
+            utteranceCount: 0,
+            peakAudioLevel: 0.08,
+            micHasCapturedFrames: true,
+            systemHasCapturedFrames: true,
+            micCaptureError: nil,
+            isMicMuted: false,
+            hasBlockingError: false
+        )
+
+        XCTAssertEqual(
+            LiveSessionController.transcriptIssue(for: input),
+            .transcriptionProducedNoText
+        )
+    }
+
+    func testTranscriptIssueLeavesIntentionallyEmptySessionUnmarked() {
+        let input = LiveSessionController.RecordingHealthInput(
+            elapsed: 3,
+            transcriptionModel: .parakeetV3,
+            utteranceCount: 0,
+            peakAudioLevel: 0,
+            micHasCapturedFrames: false,
+            systemHasCapturedFrames: false,
+            micCaptureError: nil,
+            isMicMuted: false,
+            hasBlockingError: false
+        )
+
+        XCTAssertNil(LiveSessionController.transcriptIssue(for: input))
+    }
+
+    func testSyncProjectedStateRefreshesLastEndedSessionWhenSameSessionChanges() {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings
+        )
+
+        let failedIndex = SessionIndex(
+            id: "session-1",
+            startedAt: Date(timeIntervalSince1970: 100),
+            endedAt: Date(timeIntervalSince1970: 200),
+            title: "Standup",
+            utteranceCount: 0,
+            hasNotes: false,
+            transcriptIssue: .transcriptionProducedNoText
+        )
+        coordinator.lastEndedSession = failedIndex
+        controller.syncProjectedState(settings: settings)
+        XCTAssertEqual(controller.state.lastEndedSession?.transcriptIssue, .transcriptionProducedNoText)
+
+        var recoveredIndex = failedIndex
+        recoveredIndex.utteranceCount = 3
+        recoveredIndex.transcriptIssue = nil
+        coordinator.lastEndedSession = recoveredIndex
+        controller.syncProjectedState(settings: settings)
+
+        XCTAssertEqual(controller.state.lastEndedSession?.utteranceCount, 3)
+        XCTAssertNil(controller.state.lastEndedSession?.transcriptIssue)
+    }
+
     func testRunningStateChangeCallbackFires() async {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -205,6 +205,69 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    func testFinalizeSessionPersistsTranscriptIssue() async {
+        let handle = await repo.startSession()
+        let sessionID = handle.sessionID
+
+        await repo.finalizeSession(
+            sessionID: sessionID,
+            metadata: SessionFinalizeMetadata(
+                endedAt: Date(),
+                utteranceCount: 0,
+                title: "Failed Meeting",
+                language: nil,
+                meetingApp: nil,
+                engine: "elevenLabsScribe",
+                templateSnapshot: nil,
+                utterances: [],
+                transcriptIssue: .transcriptionProducedNoText
+            )
+        )
+
+        let sessions = await repo.listSessions()
+        XCTAssertEqual(
+            sessions.first(where: { $0.id == sessionID })?.transcriptIssue,
+            .transcriptionProducedNoText
+        )
+
+        let session = await repo.loadSession(id: sessionID)
+        XCTAssertEqual(session.index.transcriptIssue, .transcriptionProducedNoText)
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
+    func testFinalizeSessionPreservesExistingStartTimeWhenNoUtterancesExist() async {
+        let handle = await repo.startSession()
+        let sessionID = handle.sessionID
+        let originalStartedAt = Date(timeIntervalSince1970: 1_700_123_456)
+
+        await repo.seedSession(
+            id: sessionID,
+            records: [],
+            startedAt: originalStartedAt
+        )
+
+        await repo.finalizeSession(
+            sessionID: sessionID,
+            metadata: SessionFinalizeMetadata(
+                endedAt: originalStartedAt.addingTimeInterval(600),
+                utteranceCount: 0,
+                title: "Empty Meeting",
+                language: nil,
+                meetingApp: nil,
+                engine: "elevenLabsScribe",
+                templateSnapshot: nil,
+                utterances: [],
+                transcriptIssue: .transcriptionProducedNoText
+            )
+        )
+
+        let session = await repo.loadSession(id: sessionID)
+        XCTAssertEqual(session.index.startedAt, originalStartedAt)
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
     // MARK: - saveNotes writes both files
 
     func testSaveNotesWritesBothFiles() async {


### PR DESCRIPTION
Fixes #508

## What changed

- persist a `transcriptIssue` marker for live sessions that end empty for a known reason
- distinguish `No audio captured` from `Transcription failed` instead of collapsing both into generic `No transcript`
- show a warning-style post-session banner for failed-empty sessions in the main window
- surface issue-specific copy in Notes/history views and show `Re-transcribe` directly when retained audio exists
- clear the failure marker automatically once a later transcript is saved
- preserve the original meeting start time for zero-utterance sessions
- refresh the last-ended session state when recovery updates the same session after batch completion

## Why

The app could previously finalize an empty live session in a misleading way:
- capture and transcription failures looked the same as intentionally empty meetings
- successful later recovery could leave the main window showing a stale failure outcome
- zero-utterance failures could be re-dated incorrectly in history

This change makes those failed-empty outcomes explicit without auto-deleting ambiguous empty sessions.

## Validation

- `swift test --package-path OpenOats --filter LiveSessionControllerTests`
- `swift test --package-path OpenOats --filter SessionRepositoryTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
