### PR TITLE
Improve live recovery UX for empty sessions

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -19,6 +19,7 @@ final class AppCoordinator {
     struct NotesNavigationRequest: Equatable {
         enum Target: Equatable {
             case session(String)
+            case retranscribeSession(String)
             case meetingHistory(CalendarEvent)
             case manualTranscript(CalendarEvent)
             case clearSelection
@@ -53,6 +54,12 @@ final class AppCoordinator {
     var lastEndedSession: SessionIndex? {
         get { access(keyPath: \.lastEndedSession); return _lastEndedSession }
         set { withMutation(keyPath: \.lastEndedSession) { _lastEndedSession = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _pendingRecoverySessionID: String?
+    var pendingRecoverySessionID: String? {
+        get { access(keyPath: \.pendingRecoverySessionID); return _pendingRecoverySessionID }
+        set { withMutation(keyPath: \.pendingRecoverySessionID) { _pendingRecoverySessionID = newValue } }
     }
 
     @ObservationIgnored nonisolated(unsafe) private var _pendingExternalCommand: ExternalCommandRequest?
@@ -239,6 +246,10 @@ final class AppCoordinator {
         } else {
             requestedNotesNavigation = NotesNavigationRequest(target: .clearSelection)
         }
+    }
+
+    func queueSessionRetranscription(_ sessionID: String) {
+        requestedNotesNavigation = NotesNavigationRequest(target: .retranscribeSession(sessionID))
     }
 
     func queueMeetingHistory(_ event: CalendarEvent) {

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -29,6 +29,7 @@ final class LiveSessionState {
     var batchStatus: BatchAudioTranscriber.Status = .idle
     var batchIsImporting: Bool = false
     var lastEndedSession: SessionIndex? = nil
+    var lastEndedSessionCanRetranscribe: Bool = false
     var lastSessionHasNotes: Bool = false
     var kbIndexingStatus: KnowledgeBaseIndexingStatus = .idle
     var statusMessage: String? = nil
@@ -160,11 +161,18 @@ final class LiveSessionController {
             if let engine = coordinator.batchAudioTranscriber {
                 let status = await engine.status
                 let importing = await engine.isImporting
+                let activeBatchSessionID = await engine.activeSessionID
                 if status != .idle || coordinator.batchStatus != .idle {
                     coordinator.batchStatus = status
                     coordinator.batchIsImporting = importing
 
                     if let pendingRecoveryDiagnostics {
+                        if let activeBatchSessionID,
+                           activeBatchSessionID != pendingRecoveryDiagnostics.sessionID {
+                            self.pendingRecoveryDiagnostics = nil
+                            coordinator.pendingRecoverySessionID = nil
+                        }
+
                         switch status {
                         case .completed(let sid) where sid == pendingRecoveryDiagnostics.sessionID:
                             let recoveredIndex = await coordinator.sessionRepository.loadSession(id: sid).index
@@ -189,6 +197,7 @@ final class LiveSessionController {
                                 )
                             )
                             self.pendingRecoveryDiagnostics = nil
+                            coordinator.pendingRecoverySessionID = nil
                         case .failed(let message):
                             recordEmptySessionDiagnostics(
                                 EmptySessionDiagnosticsEvent(
@@ -211,6 +220,7 @@ final class LiveSessionController {
                                 )
                             )
                             self.pendingRecoveryDiagnostics = nil
+                            coordinator.pendingRecoverySessionID = nil
                         case .cancelled:
                             recordEmptySessionDiagnostics(
                                 EmptySessionDiagnosticsEvent(
@@ -233,6 +243,7 @@ final class LiveSessionController {
                                 )
                             )
                             self.pendingRecoveryDiagnostics = nil
+                            coordinator.pendingRecoverySessionID = nil
                         default:
                             break
                         }
@@ -246,6 +257,8 @@ final class LiveSessionController {
                         await coordinator.loadHistory()
                         if coordinator.lastEndedSession?.id == sid {
                             coordinator.lastEndedSession = await coordinator.sessionRepository.loadSession(id: sid).index
+                            let canRetranscribe = await coordinator.sessionRepository.hasRetainedBatchAudio(sessionID: sid)
+                            set(\.lastEndedSessionCanRetranscribe, canRetranscribe)
                         }
 
                         Task { @MainActor in
@@ -439,6 +452,7 @@ final class LiveSessionController {
         }
 
         coordinator.lastEndedSession = nil
+        coordinator.pendingRecoverySessionID = nil
         coordinator.lastStorageError = nil
         coordinator.transcriptStore.clear()
 
@@ -771,15 +785,19 @@ final class LiveSessionController {
                     transcriptionModel: recordingHealthInput.transcriptionModel.rawValue,
                     classification: classification
                 )
+                coordinator.pendingRecoverySessionID = sessionID
             } else {
                 pendingRecoveryDiagnostics = nil
+                coordinator.pendingRecoverySessionID = nil
             }
         } else {
             pendingRecoveryDiagnostics = nil
+            coordinator.pendingRecoverySessionID = nil
         }
 
         // 8. Update UI state + refresh history
         coordinator.lastEndedSession = effectiveIndex
+        set(\.lastEndedSessionCanRetranscribe, retainedBatchAudio)
         coordinator.sessionTemplateSnapshot = nil
         _currentSessionID = nil
         DiagnosticsSupport.record(
@@ -930,6 +948,7 @@ final class LiveSessionController {
         coordinator.transcriptionEngine?.stop()
         coordinator.audioRecorder?.discardRecording()
         coordinator.transcriptStore.clear()
+        coordinator.pendingRecoverySessionID = nil
         if let sessionID = _currentSessionID {
             DiagnosticsSupport.record(category: "meeting", message: "Discarded session \(sessionID)")
         }
@@ -946,6 +965,22 @@ final class LiveSessionController {
     @inline(__always)
     private func set<T: Equatable>(_ kp: ReferenceWritableKeyPath<LiveSessionState, T>, _ value: T) {
         if state[keyPath: kp] != value { state[keyPath: kp] = value }
+    }
+
+    private func refreshLastEndedSessionRetranscriptionAvailability(for sessionID: String?) {
+        guard let sessionID else {
+            set(\.lastEndedSessionCanRetranscribe, false)
+            return
+        }
+
+        Task { [weak self] in
+            guard let self else { return }
+            let canRetranscribe = await coordinator.sessionRepository.hasRetainedBatchAudio(sessionID: sessionID)
+            await MainActor.run {
+                guard self.state.lastEndedSession?.id == sessionID else { return }
+                self.set(\.lastEndedSessionCanRetranscribe, canRetranscribe)
+            }
+        }
     }
 
     @MainActor
@@ -1000,7 +1035,15 @@ final class LiveSessionController {
         set(\.isGeneratingSuggestions, sidebarGenerating)
         set(\.batchStatus, coordinator.batchStatus)
         set(\.batchIsImporting, coordinator.batchIsImporting)
-        if state.lastEndedSession != lastEndedSession { state.lastEndedSession = lastEndedSession }
+        let previousLastEndedSessionID = state.lastEndedSession?.id
+        let currentLastEndedSessionID = lastEndedSession?.id
+        if previousLastEndedSessionID != currentLastEndedSessionID {
+            state.lastEndedSession = lastEndedSession
+            set(\.lastEndedSessionCanRetranscribe, false)
+            refreshLastEndedSessionRetranscriptionAvailability(for: currentLastEndedSessionID)
+        } else if state.lastEndedSession != lastEndedSession {
+            state.lastEndedSession = lastEndedSession
+        }
         set(\.lastSessionHasNotes, lastSessionHasNotes)
         set(\.kbIndexingStatus, coordinator.knowledgeBase?.indexingStatus ?? .idle)
         set(\.statusMessage, coordinator.transcriptionEngine?.assetStatus)

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -194,6 +194,9 @@ final class NotesController {
             case .session(let sessionID):
                 selectSession(sessionID)
                 return true
+            case .retranscribeSession(let sessionID):
+                selectSession(sessionID)
+                return true
             case .meetingHistory(let event):
                 showMeetingFamily(for: event)
                 return true
@@ -224,6 +227,8 @@ final class NotesController {
         if let requested = coordinator.consumeRequestedSessionSelection() {
             switch requested {
             case .session(let sessionID):
+                selectSession(sessionID)
+            case .retranscribeSession(let sessionID):
                 selectSession(sessionID)
             case .meetingHistory(let event):
                 showMeetingFamily(for: event)

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -408,6 +408,24 @@ enum SessionTranscriptIssue: String, Codable, Sendable, Equatable {
     }
 }
 
+enum SessionTranscriptRecoveryState: String, Codable, Sendable, Equatable {
+    case recoveredAfterBatch
+
+    var listLabel: String {
+        switch self {
+        case .recoveredAfterBatch:
+            return "Recovered after batch"
+        }
+    }
+
+    var sessionEndedBannerText: String {
+        switch self {
+        case .recoveredAfterBatch:
+            return "Session recovered after batch"
+        }
+    }
+}
+
 struct SessionIndex: Identifiable, Codable, Sendable, Equatable {
     let id: String
     let startedAt: Date
@@ -432,6 +450,8 @@ struct SessionIndex: Identifiable, Codable, Sendable, Equatable {
     var meetingFamilyKey: String? = nil
     /// Non-nil when the session ended without a transcript for a known recording/transcription reason.
     var transcriptIssue: SessionTranscriptIssue? = nil
+    /// Non-nil when a previously failed transcript was later recovered.
+    var transcriptRecovery: SessionTranscriptRecoveryState? = nil
 }
 
 struct SessionSidecar: Codable, Sendable {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -151,6 +151,7 @@ struct SessionMetadata: Codable, Sendable {
     var source: String?
     var calendarEvent: CalendarEvent?
     var transcriptIssue: SessionTranscriptIssue?
+    var transcriptRecovery: SessionTranscriptRecoveryState? = nil
 }
 
 // MARK: - SessionRepository
@@ -261,7 +262,8 @@ actor SessionRepository {
             title: config.title,
             utteranceCount: 0,
             hasNotes: false,
-            calendarEvent: config.calendarEvent
+            calendarEvent: config.calendarEvent,
+            transcriptRecovery: nil
         )
         writeSessionMetadata(metadata, sessionID: sessionID)
 
@@ -438,7 +440,8 @@ actor SessionRepository {
             meetingApp: metadata.meetingApp,
             engine: metadata.engine,
             calendarEvent: metadata.calendarEvent,
-            transcriptIssue: metadata.transcriptIssue
+            transcriptIssue: metadata.transcriptIssue,
+            transcriptRecovery: nil
         )
         writeSessionMetadata(sessionMeta, sessionID: sessionID)
 
@@ -488,7 +491,8 @@ actor SessionRepository {
             hasNotes: false,
             language: config.language,
             engine: config.engine,
-            source: "imported"
+            source: "imported",
+            transcriptRecovery: nil
         )
         writeSessionMetadata(metadata, sessionID: sessionID)
 
@@ -517,7 +521,8 @@ actor SessionRepository {
             hasNotes: false,
             folderPath: Self.normalizeSessionFolderPath(config.folderPath),
             source: "manual",
-            calendarEvent: config.calendarEvent
+            calendarEvent: config.calendarEvent,
+            transcriptRecovery: nil
         )
         writeSessionMetadata(metadata, sessionID: sessionID)
 
@@ -546,7 +551,8 @@ actor SessionRepository {
     func saveFinalTranscript(
         sessionID: String,
         records: [SessionRecord],
-        backupCurrentTranscript: Bool = false
+        backupCurrentTranscript: Bool = false,
+        markAsRecoveredIfIssuePresent: Bool = false
     ) {
         let dir = sessionDirectory(for: sessionID)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -578,6 +584,12 @@ actor SessionRepository {
         }
 
         if let meta = loadSessionMetadataFile(sessionID: sessionID) {
+            let transcriptRecovery: SessionTranscriptRecoveryState?
+            if markAsRecoveredIfIssuePresent, meta.transcriptIssue != nil {
+                transcriptRecovery = .recoveredAfterBatch
+            } else {
+                transcriptRecovery = nil
+            }
             let refreshedMeta = SessionMetadata(
                 id: meta.id,
                 startedAt: records.first?.timestamp ?? meta.startedAt,
@@ -593,7 +605,8 @@ actor SessionRepository {
                 folderPath: meta.folderPath,
                 source: meta.source,
                 calendarEvent: meta.calendarEvent,
-                transcriptIssue: nil
+                transcriptIssue: nil,
+                transcriptRecovery: transcriptRecovery
             )
             writeSessionMetadata(refreshedMeta, sessionID: sessionID)
         }
@@ -761,7 +774,8 @@ actor SessionRepository {
                         folderPath: meta.folderPath,
                         source: meta.source,
                         meetingFamilyKey: meta.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) },
-                        transcriptIssue: meta.transcriptIssue
+                        transcriptIssue: meta.transcriptIssue,
+                        transcriptRecovery: meta.transcriptRecovery
                     ))
                     continue
                 }
@@ -801,7 +815,8 @@ actor SessionRepository {
                 folderPath: meta.folderPath,
                 source: meta.source,
                 meetingFamilyKey: meta.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) },
-                transcriptIssue: meta.transcriptIssue
+                transcriptIssue: meta.transcriptIssue,
+                transcriptRecovery: meta.transcriptRecovery
             )
 
             let transcript = loadTranscript(sessionID: id)
@@ -903,7 +918,8 @@ actor SessionRepository {
             engine: index.engine,
             tags: normalizedVisibleTags.isEmpty ? nil : normalizedVisibleTags,
             folderPath: index.folderPath,
-            source: index.source
+            source: index.source,
+            transcriptRecovery: nil
         )
         let dir = sessionDirectory(for: sessionID)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -933,7 +949,8 @@ actor SessionRepository {
             engine: index.engine,
             tags: index.tags,
             folderPath: normalizedFolderPath,
-            source: index.source
+            source: index.source,
+            transcriptRecovery: nil
         )
         let dir = sessionDirectory(for: sessionID)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -963,7 +980,8 @@ actor SessionRepository {
             tags: index.tags,
             folderPath: index.folderPath,
             source: index.source,
-            calendarEvent: calendarEvent
+            calendarEvent: calendarEvent,
+            transcriptRecovery: nil
         )
         let dir = sessionDirectory(for: sessionID)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -1411,7 +1429,8 @@ actor SessionRepository {
         templateSnapshot: TemplateSnapshot? = nil,
         title: String? = nil,
         notes: GeneratedNotes? = nil,
-        transcriptIssue: SessionTranscriptIssue? = nil
+        transcriptIssue: SessionTranscriptIssue? = nil,
+        transcriptRecovery: SessionTranscriptRecoveryState? = nil
     ) {
         let dir = sessionDirectory(for: id)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -1427,7 +1446,8 @@ actor SessionRepository {
             hasNotes: notes != nil,
             meetingApp: nil,
             engine: nil,
-            transcriptIssue: transcriptIssue
+            transcriptIssue: transcriptIssue,
+            transcriptRecovery: transcriptRecovery
         )
         writeSessionMetadata(meta, sessionID: id)
 
@@ -1796,7 +1816,8 @@ actor SessionRepository {
             folderPath: meta?.folderPath,
             source: meta?.source,
             meetingFamilyKey: meta?.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) },
-            transcriptIssue: meta?.transcriptIssue
+            transcriptIssue: meta?.transcriptIssue,
+            transcriptRecovery: meta?.transcriptRecovery
         )
 
         MarkdownMeetingWriter.write(

--- a/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
@@ -297,6 +297,7 @@ actor BatchAudioTranscriber {
     private(set) var status: Status = .idle
     /// True when the current batch job is an audio file import (affects UI copy).
     private(set) var isImporting: Bool = false
+    private(set) var activeSessionID: String?
     private var currentTask: Task<Void, Never>?
 
     /// Process batch transcription for a completed session.
@@ -311,6 +312,8 @@ actor BatchAudioTranscriber {
     ) async {
         // Cancel any existing task
         currentTask?.cancel()
+        activeSessionID = sessionID
+        isImporting = false
 
         let task = Task { [weak self] in
             guard let self else { return }
@@ -326,10 +329,12 @@ actor BatchAudioTranscriber {
                 )
             } catch is CancellationError {
                 await self.setStatus(.cancelled)
+                await self.setActiveSessionID(nil)
                 DiagnosticsSupport.record(category: "batch", message: "Batch transcription cancelled for \(sessionID)")
                 Log.batchTranscription.info("Batch transcription cancelled for \(sessionID, privacy: .public)")
             } catch {
                 await self.setStatus(.failed(error.localizedDescription))
+                await self.setActiveSessionID(nil)
                 DiagnosticsSupport.record(category: "batch", message: "Batch transcription failed for \(sessionID): \(error.localizedDescription)")
                 Log.batchTranscription.error("Batch transcription failed: \(error, privacy: .public)")
             }
@@ -345,6 +350,7 @@ actor BatchAudioTranscriber {
         await task?.value
         status = .cancelled
         isImporting = false
+        activeSessionID = nil
     }
 
     // MARK: - Audio Import
@@ -359,6 +365,7 @@ actor BatchAudioTranscriber {
     ) async {
         currentTask?.cancel()
         isImporting = true
+        activeSessionID = sessionID
 
         let task = Task { [weak self] in
             guard let self else { return }
@@ -373,11 +380,13 @@ actor BatchAudioTranscriber {
             } catch is CancellationError {
                 await self.setStatus(.cancelled)
                 await self.setIsImporting(false)
+                await self.setActiveSessionID(nil)
                 DiagnosticsSupport.record(category: "batch", message: "Audio import cancelled for \(sessionID)")
                 Log.batchTranscription.info("Audio import cancelled for \(sessionID, privacy: .public)")
             } catch {
                 await self.setStatus(.failed(error.localizedDescription))
                 await self.setIsImporting(false)
+                await self.setActiveSessionID(nil)
                 DiagnosticsSupport.record(category: "batch", message: "Audio import failed for \(sessionID): \(error.localizedDescription)")
                 Log.batchTranscription.error("Audio import failed: \(error, privacy: .public)")
             }
@@ -472,10 +481,20 @@ actor BatchAudioTranscriber {
 
     private func setStatus(_ newStatus: Status) {
         status = newStatus
+        switch newStatus {
+        case .idle, .cancelled, .failed, .completed:
+            activeSessionID = nil
+        case .loading, .transcribing:
+            break
+        }
     }
 
     private func setIsImporting(_ value: Bool) {
         isImporting = value
+    }
+
+    private func setActiveSessionID(_ value: String?) {
+        activeSessionID = value
     }
 
     private func runTranscription(
@@ -616,7 +635,8 @@ actor BatchAudioTranscriber {
         await sessionRepository.saveFinalTranscript(
             sessionID: sessionID,
             records: allRecords,
-            backupCurrentTranscript: true
+            backupCurrentTranscript: true,
+            markAsRecoveredIfIssuePresent: true
         )
         // Retain batch stems/metadata for a bounded rerun/debug window.
         // SessionRepository purges expired retained assets on startup.

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -72,7 +72,7 @@ struct ContentView: View {
             if let lastSession = controllerState.lastEndedSession {
                 if lastSession.utteranceCount > 0 {
                     HStack {
-                        Text("Session ended \u{00B7} \(lastSession.utteranceCount) utterances")
+                        Text(sessionEndedBannerText(for: lastSession))
                             .font(.system(size: 12))
                             .foregroundStyle(.secondary)
                             .accessibilityIdentifier("app.sessionEndedBanner")
@@ -105,6 +105,7 @@ struct ContentView: View {
 
                     Divider()
                 } else if let transcriptIssue = lastSession.transcriptIssue {
+                    let recoveryIsPending = coordinator.pendingRecoverySessionID == lastSession.id
                     HStack(spacing: 10) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 12))
@@ -115,10 +116,28 @@ struct ContentView: View {
                             .foregroundStyle(.secondary)
                             .accessibilityIdentifier("app.sessionEndedBanner")
                         Spacer()
+                        if recoveryIsPending {
+                            Text("Recovery queued")
+                                .font(.system(size: 12, weight: .medium))
+                                .foregroundStyle(.secondary)
+                                .accessibilityIdentifier("app.recoveryQueuedLabel")
+                        } else if controllerState.lastEndedSessionCanRetranscribe {
+                            Button {
+                                coordinator.queueSessionRetranscription(lastSession.id)
+                                openWindow(id: "notes")
+                            } label: {
+                                Label("Re-transcribe", systemImage: "arrow.trianglehead.2.clockwise.rotate.90")
+                                    .font(.system(size: 12))
+                            }
+                            .buttonStyle(OpenOatsProminentButtonStyle())
+                            .controlSize(.small)
+                            .accessibilityIdentifier("app.retranscribeSessionButton")
+                        }
                         Button {
+                            coordinator.queueSessionSelection(lastSession.id)
                             openWindow(id: "notes")
                         } label: {
-                            Label("Review Session", systemImage: "arrow.right.circle")
+                            Label("Open Session", systemImage: "arrow.right.circle")
                                 .font(.system(size: 12))
                         }
                         .buttonStyle(.bordered)
@@ -459,6 +478,13 @@ struct ContentView: View {
         case .confirmDownload:
             liveSessionController?.downloadModelOnly(settings: settings)
         }
+    }
+
+    private func sessionEndedBannerText(for session: SessionIndex) -> String {
+        if let recovery = session.transcriptRecovery {
+            return "\(recovery.sessionEndedBannerText) \u{00B7} \(session.utteranceCount) utterances"
+        }
+        return "Session ended \u{00B7} \(session.utteranceCount) utterances"
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -409,6 +409,12 @@ struct NotesView: View {
             .font(.system(size: 11))
             .foregroundStyle(.tertiary)
 
+            if let recovery = session.transcriptRecovery {
+                Text(recovery.listLabel)
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundStyle(.green)
+            }
+
             if !visibleTags.isEmpty {
                 HStack(spacing: 4) {
                     ForEach(visibleTags, id: \.self) { tag in
@@ -1765,16 +1771,17 @@ struct NotesView: View {
                                 }
 
                                 HStack(spacing: 8) {
-                                    if entry.session.utteranceCount > 0 {
-                                        Text(transcriptStatusText(for: entry.session))
-                                    } else {
-                                        Text(transcriptStatusText(for: entry.session))
-                                    }
+                                    Text(transcriptStatusText(for: entry.session))
 
                                     if let source = entry.session.source?.trimmingCharacters(in: .whitespacesAndNewlines),
                                        !source.isEmpty {
                                         Text("•")
                                         Text(source.capitalized)
+                                    }
+
+                                    if let recovery = entry.session.transcriptRecovery {
+                                        Text("•")
+                                        Text(recovery.listLabel)
                                     }
                                 }
                                 .font(.system(size: 12))
@@ -2398,14 +2405,17 @@ struct NotesView: View {
             state.sessionHistory.first { $0.id == sessionID }
         }
         let sessionIssue = selectedSession?.transcriptIssue
+        let recoveryIsPending = state.selectedSessionID != nil && coordinator.pendingRecoverySessionID == state.selectedSessionID
         let title = sessionIssue?.emptyStateTitle ?? "No transcript"
         let message = emptyTranscriptMessage(
             for: sessionIssue,
-            canRetranscribe: state.canRetranscribeSelectedSession
+            canRetranscribe: state.canRetranscribeSelectedSession,
+            recoveryIsPending: recoveryIsPending
         )
         let editorBanner = manualNotesBannerText(
             for: sessionIssue,
-            canRetranscribe: state.canRetranscribeSelectedSession
+            canRetranscribe: state.canRetranscribeSelectedSession,
+            recoveryIsPending: recoveryIsPending
         )
 
         if state.isEditingManualNotes {
@@ -2469,7 +2479,11 @@ struct NotesView: View {
                         .foregroundStyle(.secondary)
 
                     HStack(spacing: 8) {
-                        if state.canRetranscribeSelectedSession {
+                        if recoveryIsPending {
+                            Label("Recovery queued", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                        } else if state.canRetranscribeSelectedSession {
                             Button {
                                 container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
                                 controller.rerunBatchTranscription(
@@ -2506,7 +2520,11 @@ struct NotesView: View {
                         .foregroundStyle(.secondary)
 
                     HStack(spacing: 8) {
-                        if state.canRetranscribeSelectedSession {
+                        if recoveryIsPending {
+                            Label("Recovery queued", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                        } else if state.canRetranscribeSelectedSession {
                             Button {
                                 container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
                                 controller.rerunBatchTranscription(
@@ -2779,20 +2797,24 @@ struct NotesView: View {
 
     @ViewBuilder
     private func transcriptView(controller: NotesController, state: NotesState) -> some View {
+        let selectedSession = state.selectedSessionID.flatMap { sessionID in
+            state.sessionHistory.first { $0.id == sessionID }
+        }
+        let recoveryIsPending = state.selectedSessionID != nil && coordinator.pendingRecoverySessionID == state.selectedSessionID
         if state.loadedTranscript.isEmpty {
-            let selectedSession = state.selectedSessionID.flatMap { sessionID in
-                state.sessionHistory.first { $0.id == sessionID }
-            }
             let sessionIssue = selectedSession?.transcriptIssue
             ContentUnavailableView {
                 Label(sessionIssue?.emptyStateTitle ?? "No Transcript", systemImage: "waveform")
             } description: {
                 Text(emptyTranscriptMessage(
                     for: sessionIssue,
-                    canRetranscribe: state.canRetranscribeSelectedSession
+                    canRetranscribe: state.canRetranscribeSelectedSession,
+                    recoveryIsPending: recoveryIsPending
                 ))
             } actions: {
-                if state.canRetranscribeSelectedSession {
+                if recoveryIsPending {
+                    Label("Recovery queued", systemImage: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                } else if state.canRetranscribeSelectedSession {
                     Button {
                         container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
                         controller.rerunBatchTranscription(
@@ -2815,6 +2837,19 @@ struct NotesView: View {
             }
         } else {
             ScrollView {
+                if let recovery = selectedSession?.transcriptRecovery {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 12))
+                            .foregroundStyle(.green)
+                        Text(recovery.listLabel)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 12)
+                }
                 if case .inProgress(let completed, let total) = state.cleanupStatus {
                     cleanupProgressBanner(controller: controller, completed: completed, total: total)
                 }
@@ -2849,21 +2884,29 @@ struct NotesView: View {
 
     private func emptyTranscriptMessage(
         for issue: SessionTranscriptIssue?,
-        canRetranscribe: Bool
+        canRetranscribe: Bool,
+        recoveryIsPending: Bool = false
     ) -> String {
-        var message = issue?.emptyStateMessage ?? "There are no recorded utterances to turn into notes for this session."
-        if canRetranscribe {
+        var message = issue?.emptyStateMessage ?? "OpenOats does not have a transcript for this session."
+        if recoveryIsPending {
+            message += " Recovery has already been queued for the retained audio."
+        } else if canRetranscribe {
             message += " You can re-transcribe the retained audio or add a transcript manually."
+        } else if issue == nil {
+            message += " You can add a transcript manually."
         }
         return message
     }
 
     private func manualNotesBannerText(
         for issue: SessionTranscriptIssue?,
-        canRetranscribe: Bool
+        canRetranscribe: Bool,
+        recoveryIsPending: Bool = false
     ) -> String {
-        var message = issue?.emptyStateMessage ?? "No transcript was recorded for this session."
-        if canRetranscribe {
+        var message = issue?.emptyStateMessage ?? "OpenOats does not have a transcript for this session."
+        if recoveryIsPending {
+            message += " Recovery has already been queued for the retained audio. You can still save manual notes."
+        } else if canRetranscribe {
             message += " You can re-transcribe the retained audio or save manual notes."
         } else {
             message += " You can still save manual notes."
@@ -3167,6 +3210,17 @@ struct NotesView: View {
             controller.selectSession(sessionID)
             let isImported = controller.state.sessionHistory.first(where: { $0.id == sessionID })?.source == "imported"
             detailViewMode = isImported ? .transcript : .notes
+        case .retranscribeSession(let sessionID):
+            controller.selectSession(sessionID)
+            detailViewMode = .transcript
+            try? await Task.sleep(for: .milliseconds(200))
+            if controller.state.canRetranscribeSelectedSession {
+                container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
+                controller.rerunBatchTranscription(
+                    model: settings.batchTranscriptionModel,
+                    settings: settings
+                )
+            }
         case .meetingHistory(let event):
             controller.showMeetingFamily(for: event)
             detailViewMode = .notes

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -707,6 +707,36 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertNil(controller.state.lastEndedSession?.transcriptIssue)
     }
 
+    func testSyncProjectedStateRefreshesRetranscriptionAvailabilityForLastEndedSession() async throws {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings
+        )
+
+        let sessionID = "session_retranscribe_available"
+        await coordinator.sessionRepository.seedSession(
+            id: sessionID,
+            records: [],
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            transcriptIssue: .transcriptionProducedNoText
+        )
+
+        let audioDir = coordinator.sessionRepository.sessionsDirectoryURL
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+        try Data("sys".utf8).write(to: audioDir.appendingPathComponent("sys.caf"))
+
+        coordinator.lastEndedSession = await coordinator.sessionRepository.loadSession(id: sessionID).index
+        controller.syncProjectedState(settings: settings)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertTrue(controller.state.lastEndedSessionCanRetranscribe)
+    }
+
     func testEmptySessionDiagnosticClassificationMarksMissingAudio() {
         let input = LiveSessionController.RecordingHealthInput(
             elapsed: 8,

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -268,6 +268,32 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    func testSaveFinalTranscriptMarksRecoveredAfterBatchWhenIssueWasPresent() async {
+        let sessionID = "session_recovered_after_batch"
+        await repo.seedSession(
+            id: sessionID,
+            records: [],
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            transcriptIssue: .transcriptionProducedNoText
+        )
+
+        await repo.saveFinalTranscript(
+            sessionID: sessionID,
+            records: [
+                SessionRecord(
+                    speaker: .you,
+                    text: "Recovered transcript",
+                    timestamp: Date(timeIntervalSince1970: 1_700_000_030)
+                )
+            ],
+            markAsRecoveredIfIssuePresent: true
+        )
+
+        let session = await repo.loadSession(id: sessionID)
+        XCTAssertNil(session.index.transcriptIssue)
+        XCTAssertEqual(session.index.transcriptRecovery, .recoveredAfterBatch)
+    }
+
     // MARK: - saveNotes writes both files
 
     func testSaveNotesWritesBothFiles() async {


### PR DESCRIPTION
## Summary
- improve the user-facing recovery flow after a live session ends empty
- show `Recovery queued` while automatic recovery is already pending
- surface `Recovered after batch` across the home banner, Notes rows, history cards, and transcript detail

## Details
- add direct `Open Session` and conditional `Re-transcribe` actions where they actually make sense
- keep ambiguous `No transcript` copy neutral instead of implying success or failure
- persist and clear transcript recovery state correctly when transcripts are replaced or restored
- harden queued recovery state so it is cleared when the batch engine has moved on to a different session

## Validation
- `swift test --package-path OpenOats --filter LiveSessionControllerTests`
- `swift test --package-path OpenOats --filter SessionRepositoryTests`
- `swift test --package-path OpenOats --filter NotesControllerTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`

Related to #514.