### PR TITLE
Update Homebrew cask for 1.68.2

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.68.1"
-  sha256 "2bf1230020f0745820de65749b61f584da90cf232740e7b9c424fbbddb70b223"
+  version "1.68.2"
+  sha256 "60aba76ff68272986e4a86f65166a09ea7703e5c12d98d211879c7ced8bb6f44"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Bump Homebrew cask version to 1.68.2 and update SHA256 to match the release DMG.