### PR TITLE
fix: calendar access lost after meeting ends

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppContainer.swift
+++ b/OpenOats/Sources/OpenOats/App/AppContainer.swift
@@ -242,6 +242,9 @@ final class AppContainer {
         if enabled {
             if calendarManager == nil {
                 calendarManager = CalendarManager()
+            } else {
+                // Re-read TCC in case the system state changed since the manager was created.
+                calendarManager?.refreshFromSystem()
             }
             if calendarManager?.accessState == .notDetermined {
                 Task {

--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -25,6 +25,15 @@ final class CalendarManager {
 
     // MARK: - Authorization
 
+    /// Re-reads the current TCC authorization status and updates `accessState` if it has drifted.
+    /// Safe to call at any time — never shows a system dialog.
+    func refreshFromSystem() {
+        let current = Self.currentAccessState()
+        if current != accessState {
+            accessState = current
+        }
+    }
+
     /// Request calendar access. Returns true if authorized.
     func requestAccess() async -> Bool {
         do {

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -38,6 +38,9 @@ struct IdleHomeDashboardView: View {
         .padding(.horizontal, 20)
         .padding(.top, 10)
         .padding(.bottom, 8)
+        .onAppear {
+            container.updateCalendarIntegration(enabled: settings.calendarIntegrationEnabled)
+        }
         .task(id: refreshTaskID(for: accessState)) {
             await refresh()
             try? await Task.sleep(for: refreshInterval(for: accessState))
@@ -199,6 +202,10 @@ struct IdleHomeDashboardView: View {
             earlierTodayEvents = []
             return
         }
+
+        // Re-read from TCC on every refresh so cached state never drifts from reality
+        // (e.g. after a dev rebuild that resets TCC, or on first appear post-meeting).
+        manager.refreshFromSystem()
 
         guard manager.accessState == .authorized else {
             events = []


### PR DESCRIPTION
**Problem**

Every time a meeting session ended, IdleHomeDashboardView showed "Waiting for calendar access / OpenOats will show your upcoming meetings once Calendar access is granted" — even though calendar permission was fully granted in System Settings.

**Root cause**

IdleHomeDashboardView computes its access state as:

container.calendarManager?.accessState ?? .notDetermined

When calendarManager is nil, this always returns .notDetermined regardless of what TCC says. The dashboard only appears while the session is not running (it's not in the view hierarchy during a meeting), so it has no live connection to calendarManager's state. If the manager was nil or stale when the view appeared after a meeting, it would get stuck showing "Waiting" — the 1-second polling loop would call refresh(), which guards on calendarManager being non-nil and exits early, never recovering.

A secondary issue: CalendarManager.accessState was only ever set at init() and after requestAccess(). There was no way to re-sync it with TCC after the fact (e.g. after a dev rebuild resets TCC state).

**Fix**

Three layered changes:
1. CalendarManager — added refreshFromSystem(), which re-reads EKEventStore.authorizationStatus and updates accessState if it has drifted. Never shows a system dialog.
2. AppContainer.updateCalendarIntegration — when called with enabled: true and a manager already exists (previously a no-op), now calls refreshFromSystem() to keep cached state in sync with TCC.
3. IdleHomeDashboardView — added .onAppear that calls container.updateCalendarIntegration(enabled:) each time the dashboard becomes visible (i.e. on every meeting end). This either recreates the manager if it was  nil, or refreshes it if it existed. Also added a manager.refreshFromSystem() call inside refresh() so the ongoing poll loop always works from current TCC state.