### PR TITLE
Fix manual transcript reuse across recurring occurrences

### DIFF
--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -1161,12 +1161,11 @@ actor SessionRepository {
             }
 
             let gap = abs(metadata.startedAt.timeIntervalSince(referenceDate))
+            guard gap <= maximumGap else { return nil }
 
             if metadata.calendarEvent?.id == referenceEventID {
                 return (candidate.id, true, gap)
             }
-
-            guard gap <= maximumGap else { return nil }
 
             let candidateTitle = metadata.title ?? metadata.calendarEvent?.title
             guard MeetingHistoryResolver.historyKey(for: candidateTitle ?? "") == historyKey else {

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -342,6 +342,50 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertEqual(controller.state.loadedTranscript.map(\.text), ["Existing transcript"])
     }
 
+    func testPrepareManualTranscriptSessionCreatesNewOccurrenceWhenRecurringSeriesSharesCalendarID() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let priorEvent = CalendarEvent(
+            id: "evt-recurring-shared-id",
+            title: "Daily Standup",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+        let nextDayEvent = CalendarEvent(
+            id: priorEvent.id,
+            title: priorEvent.title,
+            startDate: priorEvent.startDate.addingTimeInterval(24 * 60 * 60),
+            endDate: priorEvent.endDate.addingTimeInterval(24 * 60 * 60),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        await seedSession(
+            coordinator: coordinator,
+            sessionID: "session_previous_occurrence",
+            title: priorEvent.title,
+            utterances: [SessionRecord(speaker: .you, text: "Yesterday", timestamp: priorEvent.startDate)],
+            calendarEvent: priorEvent,
+            startedAt: priorEvent.startDate
+        )
+
+        controller.showMeetingFamily(for: nextDayEvent)
+
+        let shouldPrompt = await controller.prepareManualTranscriptSession(for: nextDayEvent)
+        try? await Task.sleep(for: .milliseconds(250))
+
+        XCTAssertTrue(shouldPrompt)
+        XCTAssertNotEqual(controller.state.selectedSessionID, "session_previous_occurrence")
+        XCTAssertEqual(controller.state.loadedCalendarEvent?.startDate, nextDayEvent.startDate)
+        XCTAssertTrue(controller.state.loadedTranscript.isEmpty)
+    }
+
     func testGenerateNotesUpdatesStatus() async {
         let (root, notes) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -668,6 +668,52 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: firstSessionID)
     }
 
+    func testCreateManualTranscriptSessionDoesNotReuseRecurringOccurrenceFromDifferentDay() async {
+        let priorOccurrence = makeCalendarEvent()
+        let nextDayStart = priorOccurrence.startDate.addingTimeInterval(24 * 60 * 60)
+        let nextDayEvent = CalendarEvent(
+            id: priorOccurrence.id,
+            title: priorOccurrence.title,
+            startDate: nextDayStart,
+            endDate: nextDayStart.addingTimeInterval(priorOccurrence.endDate.timeIntervalSince(priorOccurrence.startDate)),
+            calendarID: priorOccurrence.calendarID,
+            calendarTitle: priorOccurrence.calendarTitle,
+            calendarColorHex: priorOccurrence.calendarColorHex,
+            organizer: priorOccurrence.organizer,
+            participants: priorOccurrence.participants,
+            isOnlineMeeting: priorOccurrence.isOnlineMeeting,
+            meetingURL: priorOccurrence.meetingURL
+        )
+
+        let firstSessionID = await repo.createManualTranscriptSession(
+            config: .init(
+                title: priorOccurrence.title,
+                startedAt: priorOccurrence.startDate,
+                endedAt: priorOccurrence.endDate,
+                calendarEvent: priorOccurrence,
+                folderPath: nil
+            )
+        )
+
+        let secondSessionID = await repo.createManualTranscriptSession(
+            config: .init(
+                title: nextDayEvent.title,
+                startedAt: nextDayEvent.startDate,
+                endedAt: nextDayEvent.endDate,
+                calendarEvent: nextDayEvent,
+                folderPath: nil
+            )
+        )
+
+        XCTAssertNotEqual(secondSessionID, firstSessionID)
+
+        let sessions = await repo.listSessions()
+        XCTAssertEqual(sessions.count, 2)
+
+        await repo.deleteSession(sessionID: firstSessionID)
+        await repo.deleteSession(sessionID: secondSessionID)
+    }
+
     func testSaveFinalTranscript() async {
         let sessionID = "session_final_test"
         let initialStart = Date(timeIntervalSince1970: 100)


### PR DESCRIPTION
## Summary
- stop manual transcript session reuse from treating a recurring calendar ID as a cross-day exact occurrence match
- create a new manual transcript session when a recurring meeting occurrence is on a different day
- add repository and controller regressions for the `Coming up` -> `Add Transcript` path

## Root Cause
Manual transcript session reuse treated `calendarEvent.id` as an exact occurrence key before checking time proximity. In recurring EventKit data, different occurrences in the same series can share that identifier, so clicking today's meeting from `Coming up` could reopen an older session from the same family.

## Validation
- `swift test --package-path OpenOats --filter SessionRepositoryTests`
- `swift test --package-path OpenOats --filter NotesControllerTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
