### PR TITLE
Add cloud live segment diagnostics

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -523,7 +523,8 @@ final class LiveSessionController {
             await coordinator.transcriptionEngine?.start(
                 locale: settings.locale,
                 inputDeviceID: settings.inputDeviceID,
-                transcriptionModel: settings.transcriptionModel
+                transcriptionModel: settings.transcriptionModel,
+                sessionID: handle.sessionID
             )
         }
     }

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
@@ -5,10 +5,27 @@ import os
 /// Consumes an audio buffer stream, detects speech via Silero VAD,
 /// and transcribes completed speech segments via the TranscriptionBackend protocol.
 final class StreamingTranscriber: @unchecked Sendable {
+    struct CloudSegmentDiagnosticsEvent: Codable, Equatable {
+        let event: String
+        let sessionID: String?
+        let transcriptionModel: String
+        let backend: String
+        let speaker: String
+        let sampleCount: Int
+        let durationSeconds: Double
+        let elapsedMilliseconds: Int
+        let result: String
+        let textLength: Int?
+        let errorKind: String?
+        let errorMessage: String?
+    }
+
     private let backend: any TranscriptionBackend
     private let locale: Locale
     private let vadManager: VadManager
     private let speaker: Speaker
+    private let sessionID: String?
+    private let transcriptionModel: String
     private let onPartial: @Sendable (String) -> Void
     private let onFinal: @Sendable (String) -> Void
 
@@ -51,6 +68,8 @@ final class StreamingTranscriber: @unchecked Sendable {
         locale: Locale,
         vadManager: VadManager,
         speaker: Speaker,
+        sessionID: String?,
+        transcriptionModel: String,
         flushInterval: Int,
         skipPartials: Bool = false,
         onPartial: @escaping @Sendable (String) -> Void,
@@ -60,6 +79,8 @@ final class StreamingTranscriber: @unchecked Sendable {
         self.locale = locale
         self.vadManager = vadManager
         self.speaker = speaker
+        self.sessionID = sessionID
+        self.transcriptionModel = transcriptionModel
         self.flushInterval = flushInterval
         self.skipPartials = skipPartials
         self.onPartial = onPartial
@@ -74,6 +95,7 @@ final class StreamingTranscriber: @unchecked Sendable {
     // flushInterval is now an instance property, set per-model via TranscriptionModel.flushIntervalSamples
     /// Number of trailing words to carry across segment boundaries for decoder priming.
     private static let contextWordCount = 5
+    private static let cloudSegmentDiagnosticsEventName = "live_cloud_segment_transcription"
 
     /// Main loop: reads audio buffers, runs VAD, transcribes speech segments.
     func run(stream: AsyncStream<AVAudioPCMBuffer>) async {
@@ -215,18 +237,126 @@ final class StreamingTranscriber: @unchecked Sendable {
     private var previousContext: String?
 
     private func transcribeSegment(_ samples: [Float]) async {
+        let startedAt = Date()
         do {
             try Task.checkCancellation()
             let text = try await backend.transcribe(samples, locale: locale, previousContext: previousContext)
-            guard !text.isEmpty else { return }
+            if text.isEmpty {
+                recordCloudSegmentDiagnostics(
+                    samples: samples,
+                    startedAt: startedAt,
+                    result: "empty",
+                    textLength: 0,
+                    errorKind: nil,
+                    errorMessage: nil
+                )
+                Log.streaming.warning(
+                    "[\(self.speaker.storageKey, privacy: .public)] cloud segment returned empty text: backend=\(self.backend.displayName, privacy: .public) duration=\(String(format: "%.2f", Double(samples.count) / 16_000), privacy: .public)s"
+                )
+                return
+            }
             Log.streaming.debug("[\(self.speaker.storageKey, privacy: .public)] transcribed: \(text.prefix(80), privacy: .private)")
+            recordCloudSegmentDiagnostics(
+                samples: samples,
+                startedAt: startedAt,
+                result: "success",
+                textLength: text.count,
+                errorKind: nil,
+                errorMessage: nil
+            )
             // Store trailing words for cross-segment context
             let words = text.split(separator: " ")
             previousContext = words.suffix(Self.contextWordCount).joined(separator: " ")
             onFinal(text)
         } catch {
+            recordCloudSegmentDiagnostics(
+                samples: samples,
+                startedAt: startedAt,
+                result: "error",
+                textLength: nil,
+                errorKind: Self.cloudDiagnosticsErrorKind(for: error),
+                errorMessage: Self.cloudDiagnosticsErrorMessage(for: error)
+            )
             Log.streaming.error("ASR error: \(error, privacy: .public)")
         }
+    }
+
+    private func recordCloudSegmentDiagnostics(
+        samples: [Float],
+        startedAt: Date,
+        result: String,
+        textLength: Int?,
+        errorKind: String?,
+        errorMessage: String?
+    ) {
+        guard skipPartials else { return }
+
+        let elapsedMilliseconds = max(0, Int(Date().timeIntervalSince(startedAt) * 1000))
+        let event = CloudSegmentDiagnosticsEvent(
+            event: Self.cloudSegmentDiagnosticsEventName,
+            sessionID: sessionID,
+            transcriptionModel: transcriptionModel,
+            backend: backend.displayName,
+            speaker: speaker.storageKey,
+            sampleCount: samples.count,
+            durationSeconds: Double(samples.count) / 16_000,
+            elapsedMilliseconds: elapsedMilliseconds,
+            result: result,
+            textLength: textLength,
+            errorKind: errorKind,
+            errorMessage: errorMessage
+        )
+        DiagnosticsSupport.record(
+            category: "transcription",
+            message: Self.cloudSegmentDiagnosticsMessage(for: event)
+        )
+    }
+
+    static func cloudSegmentDiagnosticsMessage(for event: CloudSegmentDiagnosticsEvent) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        if let data = try? encoder.encode(event),
+           let json = String(data: data, encoding: .utf8) {
+            return json
+        }
+        return "{\"event\":\"\(Self.cloudSegmentDiagnosticsEventName)\",\"result\":\"encoding_failed\"}"
+    }
+
+    static func cloudDiagnosticsErrorKind(for error: Error) -> String {
+        if error is CancellationError {
+            return "cancelled"
+        }
+        if let cloudError = error as? CloudASRError {
+            switch cloudError {
+            case .invalidAPIKey:
+                return "invalid_api_key"
+            case .invalidUploadURL:
+                return "invalid_upload_url"
+            case .httpError(let statusCode):
+                return "http_\(statusCode)"
+            case .transcriptionFailed:
+                return "transcription_failed"
+            case .timeout:
+                return "timeout"
+            }
+        }
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut:
+                return "transport_timeout"
+            case .networkConnectionLost:
+                return "transport_connection_lost"
+            default:
+                return "url_\(urlError.code.rawValue)"
+            }
+        }
+        return "other"
+    }
+
+    static func cloudDiagnosticsErrorMessage(for error: Error) -> String {
+        let message = error.localizedDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !message.isEmpty else { return String(describing: error) }
+        return String(message.prefix(200))
     }
 
     /// Track wall-clock time vs frames received to detect process-tap rate mismatch.

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -17,7 +17,13 @@ struct DownloadProgressDetail: Sendable {
 
 /// Session-scoped transcription settings captured at start time.
 struct ActiveTranscriptionSession: Sendable, Equatable {
+    let sessionID: String?
     let transcriptionModel: TranscriptionModel
+
+    init(sessionID: String? = nil, transcriptionModel: TranscriptionModel) {
+        self.sessionID = sessionID
+        self.transcriptionModel = transcriptionModel
+    }
 
     var flushIntervalSamples: Int {
         transcriptionModel.flushIntervalSamples
@@ -245,7 +251,8 @@ final class TranscriptionEngine {
     func start(
         locale: Locale,
         inputDeviceID: AudioDeviceID = 0,
-        transcriptionModel: TranscriptionModel
+        transcriptionModel: TranscriptionModel,
+        sessionID: String? = nil
     ) async {
         Log.transcription.info("start() called, isRunning=\(self.isRunning, privacy: .public)")
         guard !isRunning, downloadProgress == nil else { return }
@@ -277,6 +284,7 @@ final class TranscriptionEngine {
         }
 
         activeTranscriptionSession = ActiveTranscriptionSession(
+            sessionID: sessionID,
             transcriptionModel: transcriptionModel
         )
 
@@ -910,6 +918,8 @@ final class TranscriptionEngine {
             locale: locale,
             vadManager: vadManager,
             speaker: speaker,
+            sessionID: activeTranscriptionSession?.sessionID,
+            transcriptionModel: model.rawValue,
             flushInterval: model.flushIntervalSamples,
             skipPartials: model.isCloud,
             onPartial: onPartial,

--- a/OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift
@@ -86,6 +86,50 @@ final class TranscriptionEngineTests: XCTestCase {
         XCTAssertTrue(relay.hasFailed)
         XCTAssertEqual(failureCount, 1)
     }
+
+    // MARK: - Cloud Segment Diagnostics
+
+    func testCloudSegmentDiagnosticsMessageIsStructuredJSON() throws {
+        let event = StreamingTranscriber.CloudSegmentDiagnosticsEvent(
+            event: "live_cloud_segment_transcription",
+            sessionID: "session-123",
+            transcriptionModel: "elevenLabsScribe",
+            backend: "ElevenLabs Scribe",
+            speaker: "them",
+            sampleCount: 160_000,
+            durationSeconds: 10,
+            elapsedMilliseconds: 3_250,
+            result: "error",
+            textLength: nil,
+            errorKind: "timeout",
+            errorMessage: "Cloud ASR request timed out."
+        )
+
+        let message = StreamingTranscriber.cloudSegmentDiagnosticsMessage(for: event)
+        let data = try XCTUnwrap(message.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(StreamingTranscriber.CloudSegmentDiagnosticsEvent.self, from: data)
+
+        XCTAssertEqual(decoded, event)
+    }
+
+    func testCloudDiagnosticsErrorKindClassifiesCommonCloudFailures() {
+        XCTAssertEqual(
+            StreamingTranscriber.cloudDiagnosticsErrorKind(for: CloudASRError.timeout),
+            "timeout"
+        )
+        XCTAssertEqual(
+            StreamingTranscriber.cloudDiagnosticsErrorKind(for: CloudASRError.httpError(statusCode: 429)),
+            "http_429"
+        )
+        XCTAssertEqual(
+            StreamingTranscriber.cloudDiagnosticsErrorKind(for: URLError(.timedOut)),
+            "transport_timeout"
+        )
+        XCTAssertEqual(
+            StreamingTranscriber.cloudDiagnosticsErrorKind(for: URLError(.networkConnectionLost)),
+            "transport_connection_lost"
+        )
+    }
 }
 
 // MARK: - Test Helpers


### PR DESCRIPTION
## Summary
- add structured segment-level diagnostics for the cloud live transcription path
- thread the live session ID and active model through the transcription engine into the streaming transcriber
- capture per-segment outcomes (`success`, `empty`, `error`) with normalized cloud/transport error kinds
- add focused tests for structured JSON encoding and cloud error classification

## Why
The recent live cloud failures were no longer pure capture failures. We needed to know whether live segments were succeeding, returning empty text, timing out, hitting transport problems, or being throttled.

## Impact
This does not change core meeting behavior. It improves observability so the live cloud path can be debugged with evidence instead of guesswork.

## Validation
- `swift test --package-path OpenOats --filter TranscriptionEngineTests`
- `swift test --package-path OpenOats --filter LiveSessionControllerTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
