### PR TITLE
Polish prominent button states in settings and setup

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/OpenOatsProminentButtonStyle.swift
+++ b/OpenOats/Sources/OpenOats/Views/OpenOatsProminentButtonStyle.swift
@@ -13,20 +13,63 @@ private struct ProminentButtonBody: View {
     let color: Color
 
     @Environment(\.controlSize) private var controlSize
+    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.isEnabled) private var isEnabled
 
     var body: some View {
         configuration.label
-            .foregroundStyle(.white)
+            .foregroundStyle(foregroundColor)
             .padding(.horizontal, horizontalPadding)
             .padding(.vertical, verticalPadding)
             .background(
                 RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-                    .fill(color)
+                    .fill(backgroundColor)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                            .strokeBorder(borderColor, lineWidth: 1)
+                    )
             )
-            .opacity(isEnabled ? (configuration.isPressed ? 0.88 : 1.0) : 0.5)
-            .scaleEffect(configuration.isPressed ? 0.985 : 1.0)
+            .shadow(color: shadowColor, radius: shadowRadius, y: shadowOffsetY)
+            .scaleEffect(isEnabled && configuration.isPressed ? 0.985 : 1.0)
             .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+            .animation(.easeOut(duration: 0.12), value: isEnabled)
+    }
+
+    private var foregroundColor: Color {
+        if isEnabled {
+            return .white
+        }
+        return Color.white.opacity(colorScheme == .dark ? 0.78 : 0.88)
+    }
+
+    private var backgroundColor: Color {
+        if !isEnabled {
+            return color.opacity(colorScheme == .dark ? 0.38 : 0.26)
+        }
+        if configuration.isPressed {
+            return color.opacity(colorScheme == .dark ? 0.9 : 0.94)
+        }
+        return color
+    }
+
+    private var borderColor: Color {
+        if !isEnabled {
+            return Color.white.opacity(colorScheme == .dark ? 0.05 : 0.16)
+        }
+        return Color.white.opacity(colorScheme == .dark ? 0.14 : 0.18)
+    }
+
+    private var shadowColor: Color {
+        guard isEnabled else { return .clear }
+        return Color.black.opacity(colorScheme == .dark ? 0.18 : 0.08)
+    }
+
+    private var shadowRadius: CGFloat {
+        isEnabled ? 0.75 : 0
+    }
+
+    private var shadowOffsetY: CGFloat {
+        isEnabled ? 0.5 : 0
     }
 
     private var horizontalPadding: CGFloat {

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -144,7 +144,7 @@ private struct GeneralSettingsTab: View {
                                 showAutoDetectExplanation = false
                             }
                             .keyboardShortcut(.defaultAction)
-                            .buttonStyle(.borderedProminent)
+                            .buttonStyle(OpenOatsProminentButtonStyle())
                         }
                     }
                     .padding(24)
@@ -864,7 +864,7 @@ private struct TemplatesSettingsTab: View {
                                     }
                                     resetNewTemplateForm()
                                 }
-                                .buttonStyle(.borderedProminent)
+                                .buttonStyle(OpenOatsProminentButtonStyle())
                                 .disabled(!canSaveNewTemplate)
                             }
                         }

--- a/OpenOats/Sources/OpenOats/Views/SidecastSettingsTab.swift
+++ b/OpenOats/Sources/OpenOats/Views/SidecastSettingsTab.swift
@@ -372,7 +372,7 @@ private struct SidecastPersonaEditor: View {
                     onSave(draft)
                     dismiss()
                 }
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(OpenOatsProminentButtonStyle())
                 .keyboardShortcut(.defaultAction)
                 .disabled(draft.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }

--- a/OpenOats/Sources/OpenOats/Wizard/ConfirmationStepView.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/ConfirmationStepView.swift
@@ -180,7 +180,7 @@ struct ConfirmationStepView: View {
                     Task { await viewModel.requestMicPermission() }
                 }
                 .font(.system(size: 12, weight: .medium))
-                .buttonStyle(.borderedProminent)
+                .buttonStyle(OpenOatsProminentButtonStyle())
                 .controlSize(.small)
             }
 

--- a/OpenOats/Sources/OpenOats/Wizard/ProviderSetupStepView.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/ProviderSetupStepView.swift
@@ -231,7 +231,7 @@ struct ProviderSetupStepView: View {
                         Task { await viewModel.pullMissingModels() }
                     }
                     .font(.system(size: 12, weight: .medium))
-                    .buttonStyle(.borderedProminent)
+                    .buttonStyle(OpenOatsProminentButtonStyle())
                     .controlSize(.small)
                 }
             }


### PR DESCRIPTION
## Summary
- finish moving the remaining settings and setup primary actions onto `OpenOatsProminentButtonStyle`
- refine the shared style so disabled and pressed states have explicit background, foreground, border, and shadow treatment
- keep the existing red and accent variants while making inactive buttons read more deliberately

## Why
Most prominent actions had already moved to the custom style, but a few settings and wizard flows still used `.borderedProminent`. That left inconsistent visuals and weaker disabled-state behavior across the app.

## Validation
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
- `./scripts/run_ui_smoke.sh` built the macOS UI test host successfully, but execution was blocked by a local environment issue: `Timed out while enabling automation mode`
