### PR TITLE
feat: meeting-apps: Add kMeet support

### DIFF
--- a/OpenOats/Sources/OpenOats/Resources/meeting-apps.json
+++ b/OpenOats/Sources/OpenOats/Resources/meeting-apps.json
@@ -30,5 +30,9 @@
     {
         "bundleID": "com.hnc.Discord",
         "displayName": "Discord"
+    },
+    {
+        "bundleID": "com.infomaniak.meet",
+        "displayName": "kMeet"
     }
 ]


### PR DESCRIPTION
Hello.

I just added a reference to kMeet, a video conferencing software made in Switzerland, based on Jitsi (an open-source technology), and quite popular in Europe.