### PR TITLE
Add kMeet to meeting-apps allowlist and bump cask to 1.68.5

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.68.4"
-  sha256 "baa185546b726de96eff76733aa3c3d47001f300056fd4f6a63c81f314a2714e"
+  version "1.68.5"
+  sha256 "563815a479191f68cf03e0a4806e1945db1f9ff1ee5bc329917868bb9283d009"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/Resources/meeting-apps.json
+++ b/OpenOats/Sources/OpenOats/Resources/meeting-apps.json
@@ -30,5 +30,9 @@
     {
         "bundleID": "com.hnc.Discord",
         "displayName": "Discord"
+    },
+    {
+        "bundleID": "com.infomaniak.meet",
+        "displayName": "kMeet"
     }
 ]


### PR DESCRIPTION
## Summary
- Add kMeet (`com.infomaniak.meet`) to the default meeting-apps allowlist — a Jitsi-based video conferencing app by Infomaniak, popular in Europe
- Bump Homebrew cask from 1.68.4 → 1.68.5

Reimplements #527 (from @achilleb) with the cask bump included.

Closes #527