### PR TITLE
Add pause/resume recording button

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.68.5"
-  sha256 "563815a479191f68cf03e0a4806e1945db1f9ff1ee5bc329917868bb9283d009"
+  version "1.68.6"
+  sha256 "e435ef3a0298bd180c3907ef81ef3e14762d79cffa994d0792690490c8e54a7b"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -42,6 +42,7 @@ final class LiveSessionState {
     var modelDisplayName: String = ""
     var showLiveTranscript: Bool = true
     var isMicMuted: Bool = false
+    var isRecordingPaused: Bool = false
     var recordingHealthNotice: RecordingHealthNotice? = nil
     /// The user's live scratchpad text for the active session.
     var scratchpadText: String = ""
@@ -100,6 +101,7 @@ final class LiveSessionController {
         let systemHasCapturedFrames: Bool
         let micCaptureError: String?
         let isMicMuted: Bool
+        let isRecordingPaused: Bool
         let hasBlockingError: Bool
     }
 
@@ -328,6 +330,11 @@ final class LiveSessionController {
     func toggleMicMute() {
         guard let engine = coordinator.transcriptionEngine, engine.isRunning else { return }
         engine.isMicMuted.toggle()
+    }
+
+    func toggleRecordingPause() {
+        guard let engine = coordinator.transcriptionEngine, engine.isRunning else { return }
+        engine.isRecordingPaused.toggle()
     }
 
     /// Update the scratchpad text and schedule a debounced save.
@@ -587,6 +594,7 @@ final class LiveSessionController {
             systemHasCapturedFrames: captureHealthAtStop?.systemHasCapturedFrames ?? false,
             micCaptureError: captureHealthAtStop?.micCaptureError,
             isMicMuted: wasMicMutedAtStop,
+            isRecordingPaused: false,
             hasBlockingError: false
         )
         let transcriptIssue = Self.transcriptIssue(for: recordingHealthInput)
@@ -866,6 +874,7 @@ final class LiveSessionController {
 
     static func recordingHealthNotice(for input: RecordingHealthInput) -> RecordingHealthNotice? {
         guard !input.hasBlockingError else { return nil }
+        guard !input.isRecordingPaused else { return nil }
 
         if let micCaptureError = input.micCaptureError, !micCaptureError.isEmpty {
             return RecordingHealthNotice(severity: .error, message: micCaptureError)
@@ -1056,6 +1065,7 @@ final class LiveSessionController {
         set(\.modelDisplayName, activeModelRaw.split(separator: "/").last.map(String.init) ?? activeModelRaw)
         set(\.showLiveTranscript, settings.showLiveTranscript)
         set(\.isMicMuted, coordinator.transcriptionEngine?.isMicMuted ?? false)
+        set(\.isRecordingPaused, coordinator.transcriptionEngine?.isRecordingPaused ?? false)
         // scratchpadText is managed by updateScratchpad(), not refreshed from coordinator
         // downloadDetail is not Equatable; only update when nil-ness changes or download active
         let nextDetail = coordinator.transcriptionEngine?.downloadDetail
@@ -1184,6 +1194,7 @@ final class LiveSessionController {
                     systemHasCapturedFrames: captureHealth?.systemHasCapturedFrames ?? false,
                     micCaptureError: captureHealth?.micCaptureError,
                     isMicMuted: currentState.isMicMuted,
+                    isRecordingPaused: currentState.isRecordingPaused,
                     hasBlockingError: currentState.errorMessage != nil
                 )
                 set(\.recordingHealthNotice, Self.recordingHealthNotice(for: input))

--- a/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
@@ -14,8 +14,9 @@ final class MicCapture: @unchecked Sendable {
     private let _error = SyncString()
     private let _streamContinuation = OSAllocatedUnfairLock<AsyncStream<AVAudioPCMBuffer>.Continuation?>(uncheckedState: nil)
     private let _muted = SyncBool()
+    private let _paused = SyncBool()
 
-    var audioLevel: Float { _muted.value ? 0 : _audioLevel.value }
+    var audioLevel: Float { (_muted.value || _paused.value) ? 0 : _audioLevel.value }
     var hasCapturedFrames: Bool { _hasCapturedFrames.value }
     var captureError: String? { _error.value }
 
@@ -23,6 +24,12 @@ final class MicCapture: @unchecked Sendable {
     var isMuted: Bool {
         get { _muted.value }
         set { _muted.value = newValue }
+    }
+
+    /// When paused, buffers are not forwarded (independent of mute).
+    var isPaused: Bool {
+        get { _paused.value }
+        set { _paused.value = newValue }
     }
 
     /// Set a specific input device by its AudioDeviceID. Pass nil to use system default.
@@ -139,6 +146,7 @@ final class MicCapture: @unchecked Sendable {
             Log.mic.info("tapFormat: sr=\(tapFormat.sampleRate, privacy: .public) ch=\(tapFormat.channelCount, privacy: .public)")
 
             let muted = self._muted
+            let paused = self._paused
             var tapCallCount = 0
             inputNode.installTap(onBus: 0, bufferSize: 4096, format: tapFormat) { buffer, _ in
                 tapCallCount += 1
@@ -150,7 +158,7 @@ final class MicCapture: @unchecked Sendable {
                     Log.mic.debug("tap #\(tapCallCount, privacy: .public): frames=\(buffer.frameLength, privacy: .public) rms=\(rms, privacy: .public) level=\(level.value, privacy: .public)")
                 }
 
-                guard !muted.value else { return }
+                guard !muted.value && !paused.value else { return }
                 continuation.yield(buffer)
             }
             self.hasTapInstalled = true

--- a/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
@@ -10,10 +10,17 @@ import os
 final class SystemAudioCapture: @unchecked Sendable {
     private let _audioLevel = AudioLevel()
     private let _hasCapturedFrames = SyncBool()
+    private let _paused = SyncBool()
 
     /// Thread-safe audio level (0…1) from the system audio stream.
-    var audioLevel: Float { _audioLevel.value }
+    var audioLevel: Float { _paused.value ? 0 : _audioLevel.value }
     var hasCapturedFrames: Bool { _hasCapturedFrames.value }
+
+    /// When paused, buffers are not forwarded to the stream and audio level reads as 0.
+    var isPaused: Bool {
+        get { _paused.value }
+        set { _paused.value = newValue }
+    }
 
     private let _aggregateDeviceID = OSAllocatedUnfairLock<AudioObjectID>(
         uncheckedState: AudioObjectID(kAudioObjectUnknown)
@@ -242,6 +249,7 @@ final class SystemAudioCapture: @unchecked Sendable {
         }
         _hasCapturedFrames.value = true
 
+        guard !_paused.value else { return }
         _ = _sysContinuation.withLock { $0?.yield(pcmBuffer) }
     }
 

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -151,6 +151,16 @@ final class TranscriptionEngine {
         set { micCapture.isMuted = newValue }
     }
 
+    /// Pause/resume all recording. When paused, neither mic nor system audio
+    /// is transcribed and audio levels read as 0.
+    nonisolated var isRecordingPaused: Bool {
+        get { micCapture.isPaused }
+        set {
+            micCapture.isPaused = newValue
+            systemCapture.isPaused = newValue
+        }
+    }
+
     nonisolated var captureHealthSnapshot: CaptureHealthSnapshot {
         CaptureHealthSnapshot(
             micHasCapturedFrames: micCapture.hasCapturedFrames,

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -255,6 +255,9 @@ struct ContentView: View {
                 onMuteToggle: {
                     liveSessionController?.toggleMicMute()
                 },
+                onPauseToggle: {
+                    liveSessionController?.toggleRecordingPause()
+                },
                 onConfirmDownload: {
                     pendingControlBarAction = .confirmDownload
                 }
@@ -538,13 +541,15 @@ private struct IsolatedControlBarWrapper: View {
     let state: LiveSessionState
     let onToggle: () -> Void
     let onMuteToggle: () -> Void
+    let onPauseToggle: () -> Void
     let onConfirmDownload: () -> Void
-    
+
     var body: some View {
         ControlBar(
             isRunning: state.isRunning,
             audioLevel: state.audioLevel,
             isMicMuted: state.isMicMuted,
+            isRecordingPaused: state.isRecordingPaused,
             modelDisplayName: state.modelDisplayName,
             transcriptionPrompt: state.transcriptionPrompt,
             batchStatus: state.batchStatus,
@@ -558,6 +563,7 @@ private struct IsolatedControlBarWrapper: View {
             downloadDetail: state.downloadDetail,
             onToggle: onToggle,
             onMuteToggle: onMuteToggle,
+            onPauseToggle: onPauseToggle,
             onConfirmDownload: onConfirmDownload
         )
     }

--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -4,6 +4,7 @@ struct ControlBar: View {
     let isRunning: Bool
     let audioLevel: Float
     let isMicMuted: Bool
+    let isRecordingPaused: Bool
     let modelDisplayName: String
     let transcriptionPrompt: String
     let batchStatus: BatchAudioTranscriber.Status
@@ -17,6 +18,7 @@ struct ControlBar: View {
     let downloadDetail: DownloadProgressDetail?
     let onToggle: () -> Void
     let onMuteToggle: () -> Void
+    let onPauseToggle: () -> Void
     let onConfirmDownload: () -> Void
 
     var body: some View {
@@ -77,20 +79,19 @@ struct ControlBar: View {
             HStack(spacing: 10) {
                 if isRunning {
                     HStack(spacing: 6) {
-                        // Pulsing dot when live, static when muted
                         Circle()
-                            .fill(isMicMuted ? Color.red : Color.green)
+                            .fill(isRecordingPaused ? Color.orange : (isMicMuted ? Color.red : Color.green))
                             .frame(width: 8, height: 8)
-                            .scaleEffect(isMicMuted ? 1.0 : 1.0 + CGFloat(audioLevel) * 0.5)
+                            .scaleEffect(isRecordingPaused || isMicMuted ? 1.0 : 1.0 + CGFloat(audioLevel) * 0.5)
                             .animation(.easeOut(duration: 0.1), value: audioLevel)
 
-                        Text(isMicMuted ? "Muted" : "Live")
+                        Text(isRecordingPaused ? "Paused" : (isMicMuted ? "Muted" : "Live"))
                             .font(.system(size: 12, weight: .medium))
-                            .foregroundStyle(isMicMuted ? .red : .primary)
+                            .foregroundStyle(isRecordingPaused ? .orange : (isMicMuted ? .red : .primary))
                     }
                     .padding(.horizontal, 12)
                     .padding(.vertical, 7)
-                    .background(isMicMuted ? Color.red.opacity(0.1) : Color.green.opacity(0.1))
+                    .background(isRecordingPaused ? Color.orange.opacity(0.1) : (isMicMuted ? Color.red.opacity(0.1) : Color.green.opacity(0.1)))
                     .clipShape(Capsule())
                     .accessibilityIdentifier("app.controlBar.status")
 
@@ -121,8 +122,17 @@ struct ControlBar: View {
                     .accessibilityIdentifier("app.controlBar.toggle")
                 }
 
-                // Mute button + audio level bars when running
                 if isRunning {
+                    Button(action: onPauseToggle) {
+                        Image(systemName: isRecordingPaused ? "play.fill" : "pause.fill")
+                            .font(.system(size: 11))
+                            .foregroundStyle(isRecordingPaused ? .orange : .secondary)
+                            .frame(width: 20, height: 20)
+                    }
+                    .buttonStyle(.plain)
+                    .help(isRecordingPaused ? "Resume recording" : "Pause recording")
+                    .accessibilityIdentifier("app.controlBar.pauseToggle")
+
                     Button(action: onMuteToggle) {
                         Image(systemName: isMicMuted ? "mic.slash.fill" : "mic.fill")
                             .font(.system(size: 11))
@@ -132,10 +142,12 @@ struct ControlBar: View {
                     .buttonStyle(.plain)
                     .help(isMicMuted ? "Unmute microphone" : "Mute microphone")
                     .accessibilityIdentifier("app.controlBar.muteToggle")
+                    .opacity(isRecordingPaused ? 0.3 : 1.0)
+                    .disabled(isRecordingPaused)
 
                     AudioLevelView(level: audioLevel)
                         .frame(width: 40, height: 14)
-                        .opacity(isMicMuted ? 0.3 : 1.0)
+                        .opacity(isRecordingPaused || isMicMuted ? 0.3 : 1.0)
                 }
 
                 Spacer()

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -555,6 +555,7 @@ final class LiveSessionControllerTests: XCTestCase {
             systemHasCapturedFrames: false,
             micCaptureError: nil,
             isMicMuted: false,
+            isRecordingPaused: false,
             hasBlockingError: false
         )
 
@@ -576,6 +577,7 @@ final class LiveSessionControllerTests: XCTestCase {
             systemHasCapturedFrames: true,
             micCaptureError: nil,
             isMicMuted: false,
+            isRecordingPaused: false,
             hasBlockingError: false
         )
 
@@ -597,6 +599,7 @@ final class LiveSessionControllerTests: XCTestCase {
             systemHasCapturedFrames: true,
             micCaptureError: nil,
             isMicMuted: false,
+            isRecordingPaused: false,
             hasBlockingError: false
         )
 
@@ -618,6 +621,7 @@ final class LiveSessionControllerTests: XCTestCase {
             systemHasCapturedFrames: true,
             micCaptureError: nil,
             isMicMuted: false,
+            isRecordingPaused: false,
             hasBlockingError: true
         )
 
@@ -634,6 +638,7 @@ final class LiveSessionControllerTests: XCTestCase {
             systemHasCapturedFrames: false,
             micCaptureError: nil,
             isMicMuted: false,
+            isRecordingPaused: false,
             hasBlockingError: false
         )
 
@@ -650,6 +655,7 @@ final class LiveSessionControllerTests: XCTestCase {
             systemHasCapturedFrames: true,
             micCaptureError: nil,
             isMicMuted: false,
+            isRecordingPaused: false,
             hasBlockingError: false
         )
 
@@ -669,6 +675,7 @@ final class LiveSessionControllerTests: XCTestCase {
             systemHasCapturedFrames: false,
             micCaptureError: nil,
             isMicMuted: false,
+            isRecordingPaused: false,
             hasBlockingError: false
         )
 
@@ -747,6 +754,7 @@ final class LiveSessionControllerTests: XCTestCase {
             systemHasCapturedFrames: false,
             micCaptureError: nil,
             isMicMuted: false,
+            isRecordingPaused: false,
             hasBlockingError: false
         )
 


### PR DESCRIPTION
## Summary
- Adds a pause button to the control bar that temporarily halts both mic and system audio capture
- Independent of mic mute: pausing stops all streams while preserving mic mute state for resume
- Orange "Paused" status indicator, mic mute dimmed and disabled while paused
- Health warnings suppressed during paused state
- Bumps Homebrew cask to 1.68.6

Closes #529

## Changes
- `SystemAudioCapture`: new `isPaused` flag (mirrors `MicCapture.isMuted` pattern)
- `MicCapture`: new `isPaused` flag checked alongside `isMuted` in tap callback
- `TranscriptionEngine`: `isRecordingPaused` property toggling both captures
- `ControlBar`: pause/play button with three-state indicator (Live/Muted/Paused)
- `RecordingHealthInput`: suppress health warnings while paused
- `Casks/openoats.rb`: version + sha256 bump to 1.68.6