### PR TITLE
Clarify cloud live transcript UX during recording

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -21,7 +21,10 @@ final class LiveSessionState {
     var isRunning: Bool = false
     var sessionPhase: MeetingState = .idle
     var audioLevel: Float = 0
+    var recordingElapsedSeconds: Int = 0
     var liveTranscript: [Utterance] = []
+    var liveTranscriptNotice: String? = nil
+    var liveTranscriptEmptyStateMessage: String? = nil
     var volatileYouText: String = ""
     var volatileThemText: String = ""
     var suggestions: [Suggestion] = []
@@ -219,29 +222,6 @@ final class LiveSessionController {
                                     finalUtteranceCount: nil,
                                     mergedIntoSessionID: nil,
                                     failureMessage: message
-                                )
-                            )
-                            self.pendingRecoveryDiagnostics = nil
-                            coordinator.pendingRecoverySessionID = nil
-                        case .cancelled:
-                            recordEmptySessionDiagnostics(
-                                EmptySessionDiagnosticsEvent(
-                                    event: "live_empty_session_recovery",
-                                    sessionID: pendingRecoveryDiagnostics.sessionID,
-                                    transcriptionModel: pendingRecoveryDiagnostics.transcriptionModel,
-                                    elapsedSeconds: 0,
-                                    utteranceCount: 0,
-                                    peakAudioLevel: 0,
-                                    micCapturedFrames: false,
-                                    systemCapturedFrames: false,
-                                    micCaptureError: nil,
-                                    classification: pendingRecoveryDiagnostics.classification.rawValue,
-                                    retainedRecoveryAudio: true,
-                                    recoveryBatchAttempted: true,
-                                    recoveryResult: "cancelled",
-                                    finalUtteranceCount: nil,
-                                    mergedIntoSessionID: nil,
-                                    failureMessage: nil
                                 )
                             )
                             self.pendingRecoveryDiagnostics = nil
@@ -594,7 +574,7 @@ final class LiveSessionController {
             systemHasCapturedFrames: captureHealthAtStop?.systemHasCapturedFrames ?? false,
             micCaptureError: captureHealthAtStop?.micCaptureError,
             isMicMuted: wasMicMutedAtStop,
-            isRecordingPaused: false,
+            isRecordingPaused: coordinator.transcriptionEngine?.isRecordingPaused ?? false,
             hasBlockingError: false
         )
         let transcriptIssue = Self.transcriptIssue(for: recordingHealthInput)
@@ -948,6 +928,39 @@ final class LiveSessionController {
         return "event=\(event.event) session_id=\(event.sessionID) classification=\(event.classification)"
     }
 
+    static func liveTranscriptNotice(
+        for model: TranscriptionModel,
+        issue: CloudTranscriptCopy.Presentation? = nil
+    ) -> String? {
+        if let issue {
+            return issue.title
+        }
+        return CloudTranscriptCopy.steadyStateNotice(for: model)
+    }
+
+    static func liveTranscriptEmptyStateMessage(
+        for model: TranscriptionModel,
+        issue: CloudTranscriptCopy.Presentation? = nil
+    ) -> String? {
+        if let issue {
+            return issue.detail
+        }
+        return CloudTranscriptCopy.waitingMessage(for: model)
+    }
+
+    static func recordingElapsedSeconds(for state: MeetingState) -> Int {
+        let startedAt: Date?
+        switch state {
+        case .recording(let metadata), .ending(let metadata):
+            startedAt = metadata.startedAt
+        case .idle:
+            startedAt = nil
+        }
+
+        guard let startedAt else { return 0 }
+        return max(0, Int(Date().timeIntervalSince(startedAt)))
+    }
+
     private func recordEmptySessionDiagnostics(_ event: EmptySessionDiagnosticsEvent) {
         let message = Self.emptySessionDiagnosticsMessage(for: event)
         DiagnosticsSupport.record(category: "meeting", message: message)
@@ -1020,6 +1033,8 @@ final class LiveSessionController {
 
         let lifecycleState = coordinator.state
         let engineIsRunning = coordinator.transcriptionEngine?.isRunning ?? false
+        let activeTranscriptionModel = coordinator.transcriptionEngine?.currentTranscriptionModel() ?? settings.transcriptionModel
+        let liveCloudIssue = coordinator.transcriptionEngine?.liveCloudTranscriptIssue
         let isRunning: Bool
         let matchedCalendarEvent: CalendarEvent?
         switch lifecycleState {
@@ -1040,6 +1055,7 @@ final class LiveSessionController {
         set(\.isRunning, isRunning)
         set(\.sessionPhase, lifecycleState)
         set(\.audioLevel, engineIsRunning ? (coordinator.transcriptionEngine?.audioLevel ?? 0) : 0)
+        set(\.recordingElapsedSeconds, isRunning ? Self.recordingElapsedSeconds(for: lifecycleState) : 0)
         set(\.volatileYouText, coordinator.transcriptStore.volatileYouText)
         set(\.volatileThemText, coordinator.transcriptStore.volatileThemText)
         set(\.isGeneratingSuggestions, sidebarGenerating)
@@ -1064,6 +1080,8 @@ final class LiveSessionController {
         set(\.transcriptionPrompt, settings.transcriptionModel.downloadPrompt)
         set(\.modelDisplayName, activeModelRaw.split(separator: "/").last.map(String.init) ?? activeModelRaw)
         set(\.showLiveTranscript, settings.showLiveTranscript)
+        set(\.liveTranscriptNotice, isRunning ? Self.liveTranscriptNotice(for: activeTranscriptionModel, issue: liveCloudIssue) : nil)
+        set(\.liveTranscriptEmptyStateMessage, isRunning ? Self.liveTranscriptEmptyStateMessage(for: activeTranscriptionModel, issue: liveCloudIssue) : nil)
         set(\.isMicMuted, coordinator.transcriptionEngine?.isMicMuted ?? false)
         set(\.isRecordingPaused, coordinator.transcriptionEngine?.isRecordingPaused ?? false)
         // scratchpadText is managed by updateScratchpad(), not refreshed from coordinator

--- a/OpenOats/Sources/OpenOats/Transcription/CloudTranscriptCopy.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/CloudTranscriptCopy.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+struct CloudTranscriptCopy {
+    struct Presentation: Sendable, Equatable {
+        let title: String
+        let detail: String
+    }
+
+    static func steadyStateNotice(for model: TranscriptionModel) -> String? {
+        guard model.isCloud else { return nil }
+        let flushSeconds = model.flushIntervalSamples / 16_000
+        return "Cloud transcript updates after pauses or about every \(flushSeconds)s of speech."
+    }
+
+    static func waitingMessage(for model: TranscriptionModel) -> String? {
+        guard model.isCloud else { return nil }
+        return "Waiting for transcript chunk…"
+    }
+
+    static let emptyChunk = Presentation(
+        title: "Latest chunk returned no text",
+        detail: "OpenOats is still listening for the next chunk."
+    )
+
+    static func presentation(for error: Error) -> Presentation {
+        if let cloudError = error as? CloudASRError {
+            switch cloudError {
+            case .invalidAPIKey(let backend):
+                return Presentation(
+                    title: "\(backend) API key rejected",
+                    detail: "Check Settings > Transcription."
+                )
+            case .httpError(let statusCode) where statusCode == 429:
+                return Presentation(
+                    title: "Cloud transcript is rate limited",
+                    detail: "OpenOats will try again on the next chunk."
+                )
+            case .timeout:
+                return Presentation(
+                    title: "Cloud transcript timed out",
+                    detail: "OpenOats is still listening for the next chunk."
+                )
+            case .httpError(let statusCode):
+                return Presentation(
+                    title: "Cloud transcript failed",
+                    detail: "Request failed with HTTP \(statusCode)."
+                )
+            case .invalidUploadURL:
+                return Presentation(
+                    title: "Cloud transcript failed",
+                    detail: "The cloud provider returned an invalid upload URL."
+                )
+            case .transcriptionFailed(let message):
+                return Presentation(
+                    title: "Cloud transcript failed",
+                    detail: String(message.prefix(160))
+                )
+            }
+        }
+
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut:
+                return Presentation(
+                    title: "Cloud transcript timed out",
+                    detail: "OpenOats is still listening for the next chunk."
+                )
+            case .networkConnectionLost:
+                return Presentation(
+                    title: "Cloud connection dropped",
+                    detail: "OpenOats will try again on the next chunk."
+                )
+            default:
+                return Presentation(
+                    title: "Cloud transcript failed",
+                    detail: StreamingTranscriber.cloudDiagnosticsErrorMessage(for: error)
+                )
+            }
+        }
+
+        return Presentation(
+            title: "Cloud transcript failed",
+            detail: StreamingTranscriber.cloudDiagnosticsErrorMessage(for: error)
+        )
+    }
+}

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
@@ -5,6 +5,17 @@ import os
 /// Consumes an audio buffer stream, detects speech via Silero VAD,
 /// and transcribes completed speech segments via the TranscriptionBackend protocol.
 final class StreamingTranscriber: @unchecked Sendable {
+    struct CloudSegmentStatus: Sendable, Equatable {
+        enum Kind: String, Sendable, Equatable {
+            case success
+            case empty
+            case error
+        }
+
+        let kind: Kind
+        let presentation: CloudTranscriptCopy.Presentation?
+    }
+
     struct CloudSegmentDiagnosticsEvent: Codable, Equatable {
         let event: String
         let sessionID: String?
@@ -28,6 +39,7 @@ final class StreamingTranscriber: @unchecked Sendable {
     private let transcriptionModel: String
     private let onPartial: @Sendable (String) -> Void
     private let onFinal: @Sendable (String) -> Void
+    private let onCloudSegmentStatus: (@Sendable (CloudSegmentStatus) -> Void)?
 
     /// Resampler from source format to 16kHz mono Float32.
     private var converter: AVAudioConverter?
@@ -73,7 +85,8 @@ final class StreamingTranscriber: @unchecked Sendable {
         flushInterval: Int,
         skipPartials: Bool = false,
         onPartial: @escaping @Sendable (String) -> Void,
-        onFinal: @escaping @Sendable (String) -> Void
+        onFinal: @escaping @Sendable (String) -> Void,
+        onCloudSegmentStatus: (@Sendable (CloudSegmentStatus) -> Void)? = nil
     ) {
         self.backend = backend
         self.locale = locale
@@ -85,6 +98,7 @@ final class StreamingTranscriber: @unchecked Sendable {
         self.skipPartials = skipPartials
         self.onPartial = onPartial
         self.onFinal = onFinal
+        self.onCloudSegmentStatus = onCloudSegmentStatus
     }
 
     /// Silero VAD expects chunks of 4096 samples (256ms at 16kHz).
@@ -242,6 +256,12 @@ final class StreamingTranscriber: @unchecked Sendable {
             try Task.checkCancellation()
             let text = try await backend.transcribe(samples, locale: locale, previousContext: previousContext)
             if text.isEmpty {
+                onCloudSegmentStatus?(
+                    CloudSegmentStatus(
+                        kind: .empty,
+                        presentation: CloudTranscriptCopy.emptyChunk
+                    )
+                )
                 recordCloudSegmentDiagnostics(
                     samples: samples,
                     startedAt: startedAt,
@@ -256,6 +276,7 @@ final class StreamingTranscriber: @unchecked Sendable {
                 return
             }
             Log.streaming.debug("[\(self.speaker.storageKey, privacy: .public)] transcribed: \(text.prefix(80), privacy: .private)")
+            onCloudSegmentStatus?(CloudSegmentStatus(kind: .success, presentation: nil))
             recordCloudSegmentDiagnostics(
                 samples: samples,
                 startedAt: startedAt,
@@ -269,6 +290,7 @@ final class StreamingTranscriber: @unchecked Sendable {
             previousContext = words.suffix(Self.contextWordCount).joined(separator: " ")
             onFinal(text)
         } catch {
+            onCloudSegmentStatus?(CloudSegmentStatus(kind: .error, presentation: CloudTranscriptCopy.presentation(for: error)))
             recordCloudSegmentDiagnostics(
                 samples: samples,
                 startedAt: startedAt,

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -98,6 +98,12 @@ final class TranscriptionEngine {
         set { withMutation(keyPath: \.lastError) { _lastError = newValue } }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _liveCloudTranscriptIssue: CloudTranscriptCopy.Presentation?
+    var liveCloudTranscriptIssue: CloudTranscriptCopy.Presentation? {
+        get { access(keyPath: \.liveCloudTranscriptIssue); return _liveCloudTranscriptIssue }
+        set { withMutation(keyPath: \.liveCloudTranscriptIssue) { _liveCloudTranscriptIssue = newValue } }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _needsModelDownload = false
     var needsModelDownload: Bool {
         get { access(keyPath: \.needsModelDownload); return _needsModelDownload }
@@ -235,6 +241,7 @@ final class TranscriptionEngine {
         guard needsModelDownload else { return }
 
         lastError = nil
+        liveCloudTranscriptIssue = nil
         assetStatus = "Downloading \(transcriptionModel.displayName)..."
         beginDownloadTracking(for: transcriptionModel)
 
@@ -267,6 +274,7 @@ final class TranscriptionEngine {
         Log.transcription.info("start() called, isRunning=\(self.isRunning, privacy: .public)")
         guard !isRunning, downloadProgress == nil else { return }
         lastError = nil
+        liveCloudTranscriptIssue = nil
         refreshModelAvailability()
 
         if case .scripted(let scriptedUtterances) = mode {
@@ -630,6 +638,7 @@ final class TranscriptionEngine {
         vadManager = nil
         transcriptStore.volatileYouText = ""
         transcriptStore.volatileThemText = ""
+        liveCloudTranscriptIssue = nil
         activeTranscriptionSession = nil
         isRunning = false
         assetStatus = "Ready"
@@ -666,6 +675,7 @@ final class TranscriptionEngine {
         vadManager = nil
         transcriptStore.volatileYouText = ""
         transcriptStore.volatileThemText = ""
+        liveCloudTranscriptIssue = nil
         activeTranscriptionSession = nil
         isRunning = false
         assetStatus = "Ready"
@@ -933,8 +943,33 @@ final class TranscriptionEngine {
             flushInterval: model.flushIntervalSamples,
             skipPartials: model.isCloud,
             onPartial: onPartial,
-            onFinal: onFinal
+            onFinal: onFinal,
+            onCloudSegmentStatus: makeCloudSegmentStatusHandler(for: model)
         )
+    }
+
+    private func makeCloudSegmentStatusHandler(
+        for model: TranscriptionModel
+    ) -> (@Sendable (StreamingTranscriber.CloudSegmentStatus) -> Void)? {
+        guard model.isCloud else { return nil }
+        return { [weak self] status in
+            Task { @MainActor [weak self] in
+                self?.handleCloudSegmentStatus(status)
+            }
+        }
+    }
+
+    private func handleCloudSegmentStatus(_ status: StreamingTranscriber.CloudSegmentStatus) {
+        switch status.kind {
+        case .success:
+            liveCloudTranscriptIssue = nil
+        case .empty:
+            if transcriptStore.utterances.isEmpty {
+                liveCloudTranscriptIssue = status.presentation
+            }
+        case .error:
+            liveCloudTranscriptIssue = status.presentation
+        }
     }
 
     func currentTranscriptionModel() -> TranscriptionModel {

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -184,8 +184,6 @@ struct ContentView: View {
             }
 
             if controllerState.isRunning {
-                Spacer(minLength: 0)
-
                 // Collapsible transcript (hidden when live transcript is disabled)
                 if controllerState.showLiveTranscript {
                     DisclosureGroup(isExpanded: $isTranscriptExpanded) {
@@ -198,6 +196,24 @@ struct ContentView: View {
                             if !controllerState.liveTranscript.isEmpty {
                                 Text("(\(controllerState.liveTranscript.count))")
                                     .font(.system(size: 11))
+                                    .foregroundStyle(.tertiary)
+                            }
+                            if let liveTranscriptNotice = controllerState.liveTranscriptNotice {
+                                Text("·")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.tertiary)
+                                Text(liveTranscriptNotice)
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                            }
+                            if controllerState.recordingElapsedSeconds > 0 {
+                                Text("·")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.tertiary)
+                                Text(ElapsedTimeFormatter.compactMinutesSeconds(controllerState.recordingElapsedSeconds))
+                                    .font(.system(size: 11, design: .monospaced))
                                     .foregroundStyle(.tertiary)
                             }
                             Spacer()
@@ -531,6 +547,7 @@ private struct IsolatedTranscriptWrapper: View {
     var body: some View {
         TranscriptView(
             utterances: state.liveTranscript,
+            emptyStateMessage: state.liveTranscriptEmptyStateMessage,
             volatileYouText: state.volatileYouText,
             volatileThemText: state.volatileThemText
         )
@@ -548,6 +565,7 @@ private struct IsolatedControlBarWrapper: View {
         ControlBar(
             isRunning: state.isRunning,
             audioLevel: state.audioLevel,
+            recordingElapsedSeconds: state.recordingElapsedSeconds,
             isMicMuted: state.isMicMuted,
             isRecordingPaused: state.isRecordingPaused,
             modelDisplayName: state.modelDisplayName,

--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ControlBar: View {
     let isRunning: Bool
     let audioLevel: Float
+    let recordingElapsedSeconds: Int
     let isMicMuted: Bool
     let isRecordingPaused: Bool
     let modelDisplayName: String
@@ -85,7 +86,7 @@ struct ControlBar: View {
                             .scaleEffect(isRecordingPaused || isMicMuted ? 1.0 : 1.0 + CGFloat(audioLevel) * 0.5)
                             .animation(.easeOut(duration: 0.1), value: audioLevel)
 
-                        Text(isRecordingPaused ? "Paused" : (isMicMuted ? "Muted" : "Live"))
+                        Text("\(isRecordingPaused ? "Paused" : (isMicMuted ? "Muted" : "Live")) \(ElapsedTimeFormatter.compactMinutesSeconds(recordingElapsedSeconds))")
                             .font(.system(size: 12, weight: .medium))
                             .foregroundStyle(isRecordingPaused ? .orange : (isMicMuted ? .red : .primary))
                     }
@@ -221,6 +222,7 @@ struct ControlBar: View {
         case .warning: Color.orange
         case .error: Color.red
         }
+        let copy = recordingHealthCopy(for: notice.message)
 
         HStack(alignment: .top, spacing: 6) {
             Image(systemName: symbolName)
@@ -228,13 +230,38 @@ struct ControlBar: View {
                 .foregroundStyle(color)
                 .padding(.top, 1)
 
-            Text(notice.message)
-                .font(.system(size: 12))
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            VStack(alignment: .leading, spacing: copy.detail == nil ? 0 : 2) {
+                Text(copy.title)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                if let detail = copy.detail {
+                    Text(detail)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
         }
         .accessibilityIdentifier("app.controlBar.recordingHealth")
     }
+
+    private func recordingHealthCopy(for message: String) -> (title: String, detail: String?) {
+        switch message {
+        case "No microphone or system audio detected. Check your input and output device settings.":
+            ("No audio detected", "Check input and output devices")
+        case "No system audio detected. Check the selected speaker/output device.":
+            ("No system audio", "Check output device")
+        case "No microphone audio detected. Check the selected microphone.":
+            ("No microphone audio", "Check microphone")
+        case "Capturing audio, but live transcription is not producing text. Recovery batch transcription will run after you stop.":
+            ("No live transcript yet", "Recovery batch will run after stop")
+        case "Capturing audio, but live transcription is not producing text.":
+            ("No live transcript yet", nil)
+        default:
+            (message, nil)
+        }
+    }
+
 }
 
 private extension BatchAudioTranscriber.Status {

--- a/OpenOats/Sources/OpenOats/Views/ElapsedTimeFormatter.swift
+++ b/OpenOats/Sources/OpenOats/Views/ElapsedTimeFormatter.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum ElapsedTimeFormatter {
+    static func compactMinutesSeconds(_ elapsedSeconds: Int) -> String {
+        let minutes = elapsedSeconds / 60
+        let seconds = elapsedSeconds % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -144,7 +144,7 @@ private struct GeneralSettingsTab: View {
                                 showAutoDetectExplanation = false
                             }
                             .keyboardShortcut(.defaultAction)
-                            .buttonStyle(OpenOatsProminentButtonStyle())
+                            .buttonStyle(.borderedProminent)
                         }
                     }
                     .padding(24)
@@ -444,7 +444,7 @@ private struct TranscriptionSettingsTab: View {
 
                     Toggle("Show live transcript", isOn: $settings.showLiveTranscript)
                         .font(.system(size: 12))
-                    Text("When disabled, the transcript panel is hidden during meetings. Transcription still runs in the background for suggestions and notes.")
+                    Text("When disabled, the transcript panel is hidden during meetings. Transcription still runs in the background for suggestions and notes. Cloud models only show finalized transcript segments after pauses; inline partial live text is unavailable.")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
 
@@ -864,7 +864,7 @@ private struct TemplatesSettingsTab: View {
                                     }
                                     resetNewTemplateForm()
                                 }
-                                .buttonStyle(OpenOatsProminentButtonStyle())
+                                .buttonStyle(.borderedProminent)
                                 .disabled(!canSaveNewTemplate)
                             }
                         }

--- a/OpenOats/Sources/OpenOats/Views/TranscriptView.swift
+++ b/OpenOats/Sources/OpenOats/Views/TranscriptView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct TranscriptView: View {
     let utterances: [Utterance]
+    var emptyStateMessage: String? = nil
     let volatileYouText: String
     let volatileThemText: String
     var showSearch: Bool = false
@@ -77,6 +78,23 @@ struct TranscriptView: View {
                         .font(.system(size: 12))
                         .foregroundStyle(.tertiary)
                         .frame(maxWidth: .infinity, minHeight: 60)
+                } else if visible.isEmpty,
+                          !isSearching,
+                          volatileYouText.isEmpty,
+                          volatileThemText.isEmpty,
+                          let emptyStateMessage {
+                    VStack(spacing: 8) {
+                        Image(systemName: "clock.badge.exclamationmark")
+                            .font(.system(size: 18))
+                            .foregroundStyle(.tertiary)
+                        Text(emptyStateMessage)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .multilineTextAlignment(.center)
+                            .frame(maxWidth: 320)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 110)
+                    .padding(16)
                 } else {
                     LazyVStack(alignment: .leading, spacing: 8) {
                         ForEach(0..<visible.count, id: \.self) { index in

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -682,6 +682,54 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertNil(LiveSessionController.transcriptIssue(for: input))
     }
 
+    func testLiveTranscriptNoticeExplainsCloudDelay() {
+        let notice = LiveSessionController.liveTranscriptNotice(for: .elevenLabsScribe)
+
+        XCTAssertNotNil(notice)
+        XCTAssertTrue(notice?.contains("Cloud transcript updates") == true)
+        XCTAssertTrue(notice?.contains("10s") == true)
+    }
+
+    func testLiveTranscriptNoticePrefersConcreteCloudIssue() {
+        let issue = CloudTranscriptCopy.Presentation(
+            title: "ElevenLabs API key rejected",
+            detail: "Check Settings > Transcription."
+        )
+
+        XCTAssertEqual(
+            LiveSessionController.liveTranscriptNotice(for: .elevenLabsScribe, issue: issue),
+            "ElevenLabs API key rejected"
+        )
+        XCTAssertEqual(
+            LiveSessionController.liveTranscriptEmptyStateMessage(for: .elevenLabsScribe, issue: issue),
+            "Check Settings > Transcription."
+        )
+    }
+
+    func testLiveTranscriptEmptyStateMessageOnlyAppliesToCloudModels() {
+        XCTAssertNil(LiveSessionController.liveTranscriptEmptyStateMessage(for: .parakeetV3))
+
+        let message = LiveSessionController.liveTranscriptEmptyStateMessage(for: .assemblyAI)
+        XCTAssertNotNil(message)
+        XCTAssertEqual(message, "Waiting for transcript chunk…")
+    }
+
+    func testRecordingElapsedSecondsUsesLifecycleStartTime() {
+        let startedAt = Date().addingTimeInterval(-9.4)
+        let metadata = MeetingMetadata(
+            detectionContext: nil,
+            calendarEvent: nil,
+            title: nil,
+            startedAt: startedAt,
+            endedAt: nil
+        )
+
+        let elapsed = LiveSessionController.recordingElapsedSeconds(for: .recording(metadata))
+
+        XCTAssertGreaterThanOrEqual(elapsed, 9)
+        XCTAssertLessThan(elapsed, 12)
+    }
+
     func testSyncProjectedStateRefreshesLastEndedSessionWhenSameSessionChanges() {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)

--- a/OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift
@@ -130,6 +130,15 @@ final class TranscriptionEngineTests: XCTestCase {
             "transport_connection_lost"
         )
     }
+
+    func testCloudSegmentStatusTurnsInvalidApiKeyIntoActionableCopy() {
+        let presentation = CloudTranscriptCopy.presentation(
+            for: CloudASRError.invalidAPIKey(backend: "ElevenLabs")
+        )
+
+        XCTAssertEqual(presentation.title, "ElevenLabs API key rejected")
+        XCTAssertEqual(presentation.detail, "Check Settings > Transcription.")
+    }
 }
 
 // MARK: - Test Helpers


### PR DESCRIPTION
Closes #533

## Summary
- tighten the in-meeting cloud transcript UI so it does not sit behind a large empty spacer
- show elapsed recording time and a short cloud transcript status inline with the transcript header
- surface actionable cloud segment failures instead of generic waiting copy
- shorten the control-bar recording health warnings into a clearer title/detail form

## Details
- add shared cloud transcript presentation mapping for waiting, empty-chunk, auth, timeout, rate-limit, and transport failures
- thread cloud segment status through the streaming/transcription engine into live session state
- add a transcript empty state for cloud waiting and failure copy
- update settings copy to explain that cloud models show finalized chunks rather than inline partials

## Validation
- `swift test --package-path OpenOats --filter TranscriptionEngineTests`
- `swift test --package-path OpenOats --filter LiveSessionControllerTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`