### PR TITLE
Preflight broken cloud live starts

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -114,6 +114,7 @@ final class LiveSessionController {
     private let container: AppContainer
 
     private var downloadTask: Task<Void, Never>?
+    private var startPreflightTask: Task<Void, Never>?
     private var scratchpadSaveTask: Task<Void, Never>?
     private var pendingInitialScratchpad: String?
 
@@ -269,7 +270,7 @@ final class LiveSessionController {
         calendarEventOverride: CalendarEvent? = nil,
         initialScratchpad: String? = nil
     ) {
-        guard !state.isRunning else { return }
+        guard !state.isRunning, startPreflightTask == nil else { return }
         container.ensureMeetingServicesInitialized(settings: settings, coordinator: coordinator)
         coordinator.suggestionEngine?.clear()
         coordinator.sidecastEngine?.clear()
@@ -282,6 +283,23 @@ final class LiveSessionController {
         )
         pendingInitialScratchpad = initialScratchpad?.trimmingCharacters(in: .newlines)
         let metadata = MeetingMetadata.manual(calendarEvent: calEvent)
+
+        if settings.transcriptionModel.isCloud {
+            state.errorMessage = nil
+            state.statusMessage = "Validating \(settings.transcriptionModel.displayName)..."
+            startPreflightTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                defer { self.startPreflightTask = nil }
+                let issue = await self.coordinator.transcriptionEngine?.preflightStart(
+                    transcriptionModel: settings.transcriptionModel
+                )
+                self.syncProjectedState(settings: settings)
+                guard issue == nil else { return }
+                self.coordinator.handle(.userStarted(metadata), settings: settings)
+            }
+            return
+        }
+
         coordinator.handle(.userStarted(metadata), settings: settings)
     }
 

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -66,6 +66,15 @@ struct CaptureHealthSnapshot: Sendable, Equatable {
 @Observable
 @MainActor
 final class TranscriptionEngine {
+    struct StartPreflightIssue: Equatable {
+        let message: String
+    }
+
+    private struct PreparedCloudStartBackend {
+        let model: TranscriptionModel
+        let backend: any TranscriptionBackend
+    }
+
     enum Mode {
         case live
         case scripted([Utterance])
@@ -196,6 +205,7 @@ final class TranscriptionEngine {
 
     /// Active transcription model captured for the current session/startup.
     @ObservationIgnored nonisolated(unsafe) var activeTranscriptionSession: ActiveTranscriptionSession?
+    @ObservationIgnored private var preparedCloudStartBackend: PreparedCloudStartBackend?
 
     /// Tracks the resolved mic device ID currently in use.
     private var currentMicDeviceID: AudioDeviceID = 0
@@ -230,6 +240,76 @@ final class TranscriptionEngine {
             needsModelDownload = Self.modelNeedsDownload(settings.transcriptionModel)
         case .scripted:
             needsModelDownload = false
+        }
+    }
+
+    func preflightStart(transcriptionModel: TranscriptionModel) async -> StartPreflightIssue? {
+        guard case .live = mode else { return nil }
+
+        lastError = nil
+        liveCloudTranscriptIssue = nil
+        preparedCloudStartBackend = nil
+
+        if let inputIssue = validateConfiguredInputDevice() {
+            lastError = inputIssue.message
+            assetStatus = "Ready"
+            return inputIssue
+        }
+
+        if let outputIssue = validateConfiguredOutputDevice() {
+            lastError = outputIssue.message
+            assetStatus = "Ready"
+            return outputIssue
+        }
+
+        guard transcriptionModel.isCloud else {
+            assetStatus = "Ready"
+            return nil
+        }
+
+        let apiKey = settings.cloudASRApiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apiKey.isEmpty else {
+            let issue = StartPreflightIssue(
+                message: "Missing \(transcriptionModel.displayName) API key. Check Settings > Transcription."
+            )
+            lastError = issue.message
+            assetStatus = "Ready"
+            return issue
+        }
+
+        assetStatus = "Validating \(transcriptionModel.displayName)..."
+
+        do {
+            let backend = transcriptionModel.makeBackend(
+                customVocabulary: settings.transcriptionCustomVocabulary,
+                apiKey: apiKey,
+                removeFillerWords: settings.removeFillerWords
+            )
+            try await prepareBackend(backend)
+            preparedCloudStartBackend = PreparedCloudStartBackend(model: transcriptionModel, backend: backend)
+            assetStatus = "Ready"
+            return nil
+        } catch let error as CloudASRError {
+            assetStatus = "Ready"
+            switch error {
+            case .invalidAPIKey:
+                let issue = StartPreflightIssue(message: error.localizedDescription)
+                lastError = issue.message
+                return issue
+            default:
+                Log.transcription.error(
+                    "Cloud start preflight validation fell back to runtime start after non-blocking error: \(error, privacy: .public)"
+                )
+                lastError = nil
+                return nil
+            }
+        } catch {
+            assetStatus = "Ready"
+            Log.transcription.error(
+                "Cloud start preflight validation fell back to runtime start after unexpected error: \(error, privacy: .public)"
+            )
+            lastError = nil
+            return nil
         }
     }
 
@@ -326,8 +406,20 @@ final class TranscriptionEngine {
             let vocab = settings.transcriptionCustomVocabulary
             let apiKey = settings.cloudASRApiKey
             let noFiller = settings.removeFillerWords
-            let mic = transcriptionModel.makeBackend(customVocabulary: vocab, apiKey: apiKey, removeFillerWords: noFiller)
-            try await prepareBackend(mic)
+            let mic: any TranscriptionBackend
+            if transcriptionModel.isCloud,
+               let preparedCloudStartBackend,
+               preparedCloudStartBackend.model == transcriptionModel {
+                mic = preparedCloudStartBackend.backend
+                self.preparedCloudStartBackend = nil
+            } else {
+                mic = transcriptionModel.makeBackend(
+                    customVocabulary: vocab,
+                    apiKey: apiKey,
+                    removeFillerWords: noFiller
+                )
+                try await prepareBackend(mic)
+            }
             self.micBackend = mic
 
             // Parakeet needs a separate backend for system audio (mutable decoder state).
@@ -639,6 +731,7 @@ final class TranscriptionEngine {
         transcriptStore.volatileYouText = ""
         transcriptStore.volatileThemText = ""
         liveCloudTranscriptIssue = nil
+        preparedCloudStartBackend = nil
         activeTranscriptionSession = nil
         isRunning = false
         assetStatus = "Ready"
@@ -676,6 +769,7 @@ final class TranscriptionEngine {
         transcriptStore.volatileYouText = ""
         transcriptStore.volatileThemText = ""
         liveCloudTranscriptIssue = nil
+        preparedCloudStartBackend = nil
         activeTranscriptionSession = nil
         isRunning = false
         assetStatus = "Ready"
@@ -969,6 +1063,10 @@ final class TranscriptionEngine {
             }
         case .error:
             liveCloudTranscriptIssue = status.presentation
+            if let presentation = status.presentation,
+               presentation.title.localizedCaseInsensitiveContains("API key rejected") {
+                lastError = "\(presentation.title). \(presentation.detail)"
+            }
         }
     }
 
@@ -1008,6 +1106,69 @@ final class TranscriptionEngine {
             return true
         }
         return false
+    }
+
+    private func validateConfiguredInputDevice() -> StartPreflightIssue? {
+        guard settings.inputDeviceID > 0 else {
+            guard MicCapture.defaultInputDeviceID() != nil else {
+                return StartPreflightIssue(
+                    message: "No default microphone is currently available."
+                )
+            }
+            return nil
+        }
+
+        if MicCapture.availableInputDevices().contains(where: { $0.id == settings.inputDeviceID }) {
+            return nil
+        }
+        if let uid = settings.inputDeviceUID,
+           let resolved = MicCapture.inputDeviceID(forUID: uid) {
+            settings.inputDeviceID = resolved
+            return nil
+        }
+
+        return StartPreflightIssue(
+            message: "The selected microphone is no longer available. Choose another microphone in Settings > Transcription."
+        )
+    }
+
+    private func validateConfiguredOutputDevice() -> StartPreflightIssue? {
+        var configuredOutputID: AudioDeviceID? = settings.outputDeviceID != 0 ? settings.outputDeviceID : nil
+
+        if let id = configuredOutputID {
+            if SystemAudioCapture.availableOutputDevices().contains(where: { $0.id == id }) {
+                return nil
+            }
+            if let uid = settings.outputDeviceUID,
+               let resolved = SystemAudioCapture.outputDeviceID(forUID: uid) {
+                settings.outputDeviceID = resolved
+                configuredOutputID = resolved
+            } else {
+                return StartPreflightIssue(
+                    message: "The selected output device is no longer available. Choose another output device in Settings > Transcription."
+                )
+            }
+        }
+
+        if configuredOutputID == nil {
+            do {
+                _ = try SystemAudioCapture.defaultOutputDeviceID()
+            } catch SystemAudioCapture.CaptureError.noOutputDevice {
+                return StartPreflightIssue(
+                    message: "No system audio output device is currently available."
+                )
+            } catch {
+                logOutputValidationFallback(error)
+            }
+        }
+
+        return nil
+    }
+
+    private func logOutputValidationFallback(_ error: Error) {
+        Log.transcription.error(
+            "Output-device preflight validation fell back to runtime start after unexpected error: \(error, privacy: .public)"
+        )
     }
 
     /// Wrap an audio stream to forward each buffer to a synchronous tap before yielding it downstream.

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -217,6 +217,12 @@ struct ContentView: View {
                 },
                 onConfirmDownload: {
                     pendingControlBarAction = .confirmDownload
+                },
+                onOpenSettings: {
+                    openSettingsWindow()
+                },
+                onOpenMicrophonePrivacySettings: {
+                    openMicrophonePrivacySettings()
                 }
             )
         }
@@ -381,6 +387,19 @@ struct ContentView: View {
 
     private func stopSession() {
         liveSessionController?.stopSession(settings: settings)
+    }
+
+    private func openSettingsWindow() {
+        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+    }
+
+    private func openMicrophonePrivacySettings() {
+        guard let url = URL(
+            string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+        ) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
     }
 
     private func showMiniBar(controller: LiveSessionController?, miniBarManager: MiniBarManager?) {
@@ -616,6 +635,8 @@ private struct IsolatedControlBarWrapper: View {
     let onMuteToggle: () -> Void
     let onPauseToggle: () -> Void
     let onConfirmDownload: () -> Void
+    let onOpenSettings: () -> Void
+    let onOpenMicrophonePrivacySettings: () -> Void
 
     var body: some View {
         ControlBar(
@@ -638,7 +659,9 @@ private struct IsolatedControlBarWrapper: View {
             onToggle: onToggle,
             onMuteToggle: onMuteToggle,
             onPauseToggle: onPauseToggle,
-            onConfirmDownload: onConfirmDownload
+            onConfirmDownload: onConfirmDownload,
+            onOpenSettings: onOpenSettings,
+            onOpenMicrophonePrivacySettings: onOpenMicrophonePrivacySettings
         )
     }
 }

--- a/OpenOats/Sources/OpenOats/Views/ControlBar.swift
+++ b/OpenOats/Sources/OpenOats/Views/ControlBar.swift
@@ -1,6 +1,22 @@
 import SwiftUI
 
 struct ControlBar: View {
+    private enum BannerActionKind {
+        case openSettings
+        case openMicrophonePrivacySettings
+    }
+
+    private struct BannerAction {
+        let title: String
+        let kind: BannerActionKind
+    }
+
+    private struct BannerCopy {
+        let title: String
+        let detail: String?
+        let action: BannerAction?
+    }
+
     let isRunning: Bool
     let audioLevel: Float
     let recordingElapsedSeconds: Int
@@ -21,17 +37,18 @@ struct ControlBar: View {
     let onMuteToggle: () -> Void
     let onPauseToggle: () -> Void
     let onConfirmDownload: () -> Void
+    let onOpenSettings: () -> Void
+    let onOpenMicrophonePrivacySettings: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
             // Error banner
             if let error = errorMessage {
-                Text(error)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.red)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 4)
+                statusBanner(
+                    symbolName: "xmark.octagon.fill",
+                    color: .red,
+                    copy: errorBannerCopy(for: error)
+                )
             }
 
             // Download prompt
@@ -222,9 +239,21 @@ struct ControlBar: View {
         case .warning: Color.orange
         case .error: Color.red
         }
-        let copy = recordingHealthCopy(for: notice.message)
+        statusBanner(
+            symbolName: symbolName,
+            color: color,
+            copy: recordingHealthBannerCopy(for: notice.message)
+        )
+        .accessibilityIdentifier("app.controlBar.recordingHealth")
+    }
 
-        HStack(alignment: .top, spacing: 6) {
+    @ViewBuilder
+    private func statusBanner(
+        symbolName: String,
+        color: Color,
+        copy: BannerCopy
+    ) -> some View {
+        HStack(alignment: .top, spacing: 8) {
             Image(systemName: symbolName)
                 .font(.system(size: 11))
                 .foregroundStyle(color)
@@ -241,24 +270,105 @@ struct ControlBar: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
+
+            Spacer(minLength: 8)
+
+            if let action = copy.action {
+                Button(action.title) {
+                    performBannerAction(action.kind)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.mini)
+            }
         }
-        .accessibilityIdentifier("app.controlBar.recordingHealth")
     }
 
-    private func recordingHealthCopy(for message: String) -> (title: String, detail: String?) {
+    private func performBannerAction(_ action: BannerActionKind) {
+        switch action {
+        case .openSettings:
+            onOpenSettings()
+        case .openMicrophonePrivacySettings:
+            onOpenMicrophonePrivacySettings()
+        }
+    }
+
+    private func errorBannerCopy(for message: String) -> BannerCopy {
+        switch message {
+        case "The selected microphone is no longer available. Choose another microphone in Settings > Transcription.":
+            BannerCopy(
+                title: "Microphone unavailable",
+                detail: "Choose another microphone in Settings",
+                action: BannerAction(title: "Open Settings", kind: .openSettings)
+            )
+        case "No default microphone is currently available.":
+            BannerCopy(
+                title: "No microphone",
+                detail: "Connect or choose a microphone in Settings",
+                action: BannerAction(title: "Open Settings", kind: .openSettings)
+            )
+        case "The selected output device is no longer available. Choose another output device in Settings > Transcription.":
+            BannerCopy(
+                title: "Output device unavailable",
+                detail: "Choose another output device in Settings",
+                action: BannerAction(title: "Open Settings", kind: .openSettings)
+            )
+        case "No system audio output device is currently available.":
+            BannerCopy(
+                title: "No output device",
+                detail: "Connect or choose an output device in Settings",
+                action: BannerAction(title: "Open Settings", kind: .openSettings)
+            )
+        case "Failed to start system audio: No audio output device is currently available.":
+            BannerCopy(
+                title: "No output device",
+                detail: "Connect or choose an output device in Settings",
+                action: BannerAction(title: "Open Settings", kind: .openSettings)
+            )
+        case let message where message.contains("API key") && message.contains("Settings > Transcription"):
+            BannerCopy(
+                title: message.replacingOccurrences(of: ". Check Settings > Transcription.", with: ""),
+                detail: "Update the cloud transcription key in Settings",
+                action: BannerAction(title: "Open Settings", kind: .openSettings)
+            )
+        case let message where message.contains("Microphone access denied"),
+             let message where message.contains("Microphone access is disabled"),
+             let message where message.contains("Unable to verify microphone permission"):
+            BannerCopy(
+                title: "Microphone access disabled",
+                detail: "Enable microphone access in System Settings",
+                action: BannerAction(title: "Open System Settings", kind: .openMicrophonePrivacySettings)
+            )
+        default:
+            BannerCopy(title: message, detail: nil, action: nil)
+        }
+    }
+
+    private func recordingHealthBannerCopy(for message: String) -> BannerCopy {
         switch message {
         case "No microphone or system audio detected. Check your input and output device settings.":
-            ("No audio detected", "Check input and output devices")
+            BannerCopy(
+                title: "No audio detected",
+                detail: "Check input and output devices",
+                action: BannerAction(title: "Open Settings", kind: .openSettings)
+            )
         case "No system audio detected. Check the selected speaker/output device.":
-            ("No system audio", "Check output device")
+            BannerCopy(
+                title: "No system audio",
+                detail: "Check output device",
+                action: BannerAction(title: "Open Settings", kind: .openSettings)
+            )
         case "No microphone audio detected. Check the selected microphone.":
-            ("No microphone audio", "Check microphone")
+            BannerCopy(
+                title: "No microphone audio",
+                detail: "Check microphone",
+                action: BannerAction(title: "Open Settings", kind: .openSettings)
+            )
         case "Capturing audio, but live transcription is not producing text. Recovery batch transcription will run after you stop.":
-            ("No live transcript yet", "Recovery batch will run after stop")
+            BannerCopy(title: "No live transcript yet", detail: "Recovery batch will run after stop", action: nil)
         case "Capturing audio, but live transcription is not producing text.":
-            ("No live transcript yet", nil)
+            BannerCopy(title: "No live transcript yet", detail: nil, action: nil)
         default:
-            (message, nil)
+            BannerCopy(title: message, detail: nil, action: nil)
         }
     }
 

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -67,6 +67,34 @@ final class LiveSessionControllerTests: XCTestCase {
         return (controller, coordinator)
     }
 
+    private func makeLiveController(
+        root: URL,
+        notesDirectory: URL,
+        settings: AppSettings
+    ) -> (LiveSessionController, AppCoordinator) {
+        let transcriptStore = TranscriptStore()
+        let coordinator = AppCoordinator(
+            sessionRepository: SessionRepository(rootDirectory: root),
+            templateStore: TemplateStore(rootDirectory: root),
+            notesEngine: NotesEngine(mode: .scripted(markdown: "Test")),
+            transcriptStore: transcriptStore
+        )
+        coordinator.transcriptionEngine = TranscriptionEngine(
+            transcriptStore: transcriptStore,
+            settings: settings
+        )
+
+        let container = AppContainer(
+            mode: .live,
+            defaults: .standard,
+            appSupportDirectory: root,
+            notesDirectory: notesDirectory
+        )
+        let controller = LiveSessionController(coordinator: coordinator, container: container)
+        coordinator.liveSessionController = controller
+        return (controller, coordinator)
+    }
+
     private func makeUninitializedController(
         root: URL,
         notesDirectory: URL,
@@ -112,6 +140,79 @@ final class LiveSessionControllerTests: XCTestCase {
         } else {
             XCTFail("Expected .recording state immediately after startSession, got \(coordinator.state)")
         }
+    }
+
+    func testCloudStartPreflightBlocksMissingAPIKey() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        settings.transcriptionModel = .elevenLabsScribe
+        let (controller, coordinator) = makeLiveController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings
+        )
+
+        controller.startSession(settings: settings)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(coordinator.state, .idle)
+        XCTAssertFalse(controller.state.isRunning)
+        XCTAssertEqual(
+            controller.state.errorMessage,
+            "Missing ElevenLabs Scribe API key. Check Settings > Transcription."
+        )
+    }
+
+    func testCloudStartPreflightBlocksUnavailableOutputDevice() async {
+        let dirs = makeTempDirs()
+        let secretStore = AppSecretStore(
+            loadValue: { _ in "test-key" },
+            saveValue: { _, _ in }
+        )
+        let settings = makeSettings(notesDirectory: dirs.notes, secretStore: secretStore)
+        settings.transcriptionModel = .assemblyAI
+        settings.outputDeviceID = 999_999_999
+        let (controller, coordinator) = makeLiveController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings
+        )
+
+        controller.startSession(settings: settings)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(coordinator.state, .idle)
+        XCTAssertFalse(controller.state.isRunning)
+        XCTAssertEqual(
+            controller.state.errorMessage,
+            "The selected output device is no longer available. Choose another output device in Settings > Transcription."
+        )
+    }
+
+    func testCloudStartPreflightBlocksUnavailableMicrophone() async {
+        let dirs = makeTempDirs()
+        let secretStore = AppSecretStore(
+            loadValue: { _ in "test-key" },
+            saveValue: { _, _ in }
+        )
+        let settings = makeSettings(notesDirectory: dirs.notes, secretStore: secretStore)
+        settings.transcriptionModel = .assemblyAI
+        settings.inputDeviceID = 999_999_999
+        let (controller, coordinator) = makeLiveController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings
+        )
+
+        controller.startSession(settings: settings)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertEqual(coordinator.state, .idle)
+        XCTAssertFalse(controller.state.isRunning)
+        XCTAssertEqual(
+            controller.state.errorMessage,
+            "The selected microphone is no longer available. Choose another microphone in Settings > Transcription."
+        )
     }
 
     func testStartSessionWhileRunningIsNoOp() async {


### PR DESCRIPTION
Closes #540

## Summary
- preflight cloud live starts for missing API keys and stale microphone/output-device selections
- reuse validated cloud backends on actual start so auth validation is not repeated
- surface direct control-bar actions for deterministic failures, including Settings and microphone privacy shortcuts
- escalate cloud API-key rejections into a blocking error banner instead of only transcript-area copy

## Validation
- `swift test --filter LiveSessionControllerTests`
- `swift test --filter TranscriptionEngineTests`
- `swift build -c debug`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`