### PR TITLE
Bump Homebrew cask to v1.70.1

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.70.0"
-  sha256 "f8944e2033e7aa531d84a748faa8715564fcc30fec51301d5d47a1019b9d1357"
+  version "1.70.1"
+  sha256 "0629abd8931e24ce208e1dba0c4c6dbaa53892d90a1a4f67dcfa6144e5ba06c6"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Update Homebrew cask version and sha256 to match the latest v1.70.1 release.