### PR TITLE
Add session-local attachments to notes

### DIFF
--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -28,8 +28,10 @@ struct NotesState {
     var streamingMarkdown: String = ""
     /// Active tag filter for sidebar (nil = show all).
     var tagFilter: String?
-    /// Directory for the currently selected session (used for image loading).
+    /// Directory for the currently selected session (used for note asset loading).
     var selectedSessionDirectory: URL?
+    /// Session-local files referenced from notes markdown.
+    var loadedAttachments: [NoteAttachment] = []
     /// All playable audio sources for the selected session.
     var availableAudioSources: [SessionAudioSource] = []
     /// URL of the currently selected playable audio source for the session (nil if no audio).
@@ -271,6 +273,7 @@ final class NotesController {
             state.loadedTranscript = []
             state.loadedCalendarEvent = nil
             state.selectedSessionDirectory = nil
+            state.loadedAttachments = []
             state.availableAudioSources = []
             state.audioFileURL = nil
             state.canRetranscribeSelectedSession = false
@@ -285,6 +288,7 @@ final class NotesController {
         state.isEditingManualNotes = false
         state.loadedTranscript = []
         state.loadedCalendarEvent = nil
+        state.loadedAttachments = []
         state.availableAudioSources = []
         state.audioFileURL = nil
         state.canRetranscribeSelectedSession = false
@@ -317,6 +321,7 @@ final class NotesController {
             state.isEditingManualNotes = unsavedDraft != nil
             state.loadedTranscript = data.transcript
             state.loadedCalendarEvent = data.calendarEvent
+            state.loadedAttachments = data.attachments
             state.availableAudioSources = data.audioSources
             state.audioFileURL = data.audioURL
             state.canRetranscribeSelectedSession = await canRetranscribe
@@ -367,6 +372,7 @@ final class NotesController {
         state.loadedTranscript = []
         state.loadedCalendarEvent = nil
         state.selectedSessionDirectory = nil
+        state.loadedAttachments = []
         state.availableAudioSources = []
         state.audioFileURL = nil
         state.showingOriginal = false
@@ -431,6 +437,7 @@ final class NotesController {
         state.isEditingManualNotes = false
         state.loadedTranscript = []
         state.loadedCalendarEvent = nil
+        state.loadedAttachments = []
         state.availableAudioSources = []
         state.audioFileURL = nil
         state.canRetranscribeSelectedSession = false
@@ -636,6 +643,62 @@ final class NotesController {
                 await loadHistory()
             }
         }
+    }
+
+    func importAttachment(from sourceURL: URL) {
+        guard let sessionID = state.selectedSessionID else { return }
+
+        Task {
+            guard let attachment = await coordinator.sessionRepository.importAttachment(
+                sessionID: sessionID,
+                sourceURL: sourceURL
+            ) else {
+                return
+            }
+            let markdownLink = Self.markdownLink(for: attachment)
+            let isManualNotesSession = state.loadedTranscript.isEmpty
+
+            if let existing = state.loadedNotes {
+                let baseMarkdown = isManualNotesSession ? state.manualNotesDraft : existing.markdown
+                let updated = GeneratedNotes(
+                    template: existing.template,
+                    generatedAt: existing.generatedAt,
+                    markdown: Self.appendingMarkdownBlock(markdownLink, to: baseMarkdown)
+                )
+                await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: updated)
+                state.loadedNotes = updated
+                state.manualNotesDraft = updated.markdown
+                state.savedManualNotesMarkdown = updated.markdown
+            } else {
+                let template = state.selectedTemplate
+                    ?? coordinator.templateStore.template(for: TemplateStore.genericID)
+                    ?? TemplateStore.builtInTemplates.first!
+                let baseMarkdown = isManualNotesSession ? state.manualNotesDraft : ""
+                let notes = GeneratedNotes(
+                    template: coordinator.templateStore.snapshot(of: template),
+                    generatedAt: Date(),
+                    markdown: Self.appendingMarkdownBlock(markdownLink, to: baseMarkdown)
+                )
+                await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
+                state.loadedNotes = notes
+                state.manualNotesDraft = notes.markdown
+                state.savedManualNotesMarkdown = notes.markdown
+                await loadHistory()
+            }
+
+            guard state.selectedSessionID == sessionID else { return }
+            state.loadedAttachments = await coordinator.sessionRepository.loadNoteAttachments(sessionID: sessionID)
+        }
+    }
+
+    func openAttachment(_ attachment: NoteAttachment) {
+        guard let url = selectedAttachmentURL(for: attachment) else { return }
+        _ = NSWorkspace.shared.open(url)
+    }
+
+    func revealAttachment(_ attachment: NoteAttachment) {
+        guard let url = selectedAttachmentURL(for: attachment) else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
     }
 
     // MARK: - Manual Notes
@@ -1136,6 +1199,23 @@ final class NotesController {
         } else {
             unsavedManualNotesDraftsBySessionID[sessionID] = state.manualNotesDraft
         }
+    }
+
+    private func selectedAttachmentURL(for attachment: NoteAttachment) -> URL? {
+        state.selectedSessionDirectory?.appendingPathComponent(attachment.relativePath)
+    }
+
+    static func markdownLink(for attachment: NoteAttachment) -> String {
+        let label = attachment.displayName
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "[", with: "\\[")
+            .replacingOccurrences(of: "]", with: "\\]")
+        return "[\(label)](\(attachment.relativePath))"
+    }
+
+    static func appendingMarkdownBlock(_ block: String, to existing: String) -> String {
+        guard !existing.isEmpty else { return block }
+        return existing + "\n\n" + block
     }
 
     private func reloadSessionAfterTranscriptMutation(sessionID: String) async {

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -342,6 +342,16 @@ struct GeneratedNotes: Codable, Sendable {
     let markdown: String
 }
 
+struct NoteAttachment: Codable, Sendable, Equatable, Identifiable {
+    let displayName: String
+    let relativePath: String
+    let contentType: String?
+    let byteSize: Int64
+    let createdAt: Date
+
+    var id: String { relativePath }
+}
+
 enum SessionAudioSourceKind: String, Sendable, Hashable {
     case recording
     case system

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -106,6 +106,7 @@ struct SessionDetail: Sendable {
     let liveTranscript: [SessionRecord]
     let notes: GeneratedNotes?
     let notesMeta: NotesMeta?
+    let attachments: [NoteAttachment]
     let calendarEvent: CalendarEvent?
 
     init(
@@ -114,6 +115,7 @@ struct SessionDetail: Sendable {
         liveTranscript: [SessionRecord],
         notes: GeneratedNotes?,
         notesMeta: NotesMeta?,
+        attachments: [NoteAttachment] = [],
         calendarEvent: CalendarEvent? = nil
     ) {
         self.index = index
@@ -121,6 +123,7 @@ struct SessionDetail: Sendable {
         self.liveTranscript = liveTranscript
         self.notes = notes
         self.notesMeta = notesMeta
+        self.attachments = attachments
         self.calendarEvent = calendarEvent
     }
 }
@@ -129,6 +132,7 @@ struct SessionDetail: Sendable {
 struct NotesMeta: Codable, Sendable {
     let templateSnapshot: TemplateSnapshot
     let generatedAt: Date
+    let attachments: [NoteAttachment]?
 }
 
 // MARK: - Canonical session.json
@@ -166,6 +170,7 @@ struct SessionMetadata: Codable, Sendable {
 /// sessions/<id>/transcript.final.jsonl
 /// sessions/<id>/notes.md
 /// sessions/<id>/notes.meta.json
+/// sessions/<id>/attachments/
 /// sessions/<id>/audio/
 /// ```
 actor SessionRepository {
@@ -672,14 +677,13 @@ actor SessionRepository {
         try? notes.markdown.write(to: mdURL, atomically: true, encoding: .utf8)
 
         // Write notes.meta.json
+        let existingAttachments = loadNotesMeta(sessionID: sessionID)?.attachments
         let meta = NotesMeta(
             templateSnapshot: notes.template,
-            generatedAt: notes.generatedAt
+            generatedAt: notes.generatedAt,
+            attachments: existingAttachments
         )
-        if let data = try? encoder.encode(meta) {
-            let metaURL = dir.appendingPathComponent("notes.meta.json")
-            try? data.write(to: metaURL, options: .atomic)
-        }
+        saveNotesMeta(meta, sessionID: sessionID)
 
         // Update session.json hasNotes flag
         if var sessionMeta = loadSessionMetadataFile(sessionID: sessionID) {
@@ -694,11 +698,8 @@ actor SessionRepository {
     func loadNotes(sessionID: String) -> GeneratedNotes? {
         let dir = sessionDirectory(for: sessionID)
         let mdURL = dir.appendingPathComponent("notes.md")
-        let metaURL = dir.appendingPathComponent("notes.meta.json")
-
         guard let markdown = try? String(contentsOf: mdURL, encoding: .utf8),
-              let metaData = try? Data(contentsOf: metaURL),
-              let meta = try? decoder.decode(NotesMeta.self, from: metaData) else {
+              let meta = loadNotesMeta(sessionID: sessionID) else {
             // Fall back to legacy
             return LegacySessionReader.loadNotes(sessionID: sessionID, sessionsDirectory: sessionsDirectory)
         }
@@ -708,6 +709,67 @@ actor SessionRepository {
             generatedAt: meta.generatedAt,
             markdown: markdown
         )
+    }
+
+    func importAttachment(sessionID: String, sourceURL: URL) -> NoteAttachment? {
+        let dir = attachmentsDirectory(for: sessionID)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let sanitizedBaseName = Self.sanitizedAttachmentFilename(sourceURL.deletingPathExtension().lastPathComponent)
+        let pathExtension = sourceURL.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+        let storedFilename: String
+        if pathExtension.isEmpty {
+            storedFilename = "\(UUID().uuidString)-\(sanitizedBaseName)"
+        } else {
+            storedFilename = "\(UUID().uuidString)-\(sanitizedBaseName).\(pathExtension)"
+        }
+
+        let destinationURL = dir.appendingPathComponent(storedFilename)
+        do {
+            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+        } catch {
+            Log.sessionRepository.error("Failed to import attachment: \(error, privacy: .public)")
+            return nil
+        }
+
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destinationURL.path)
+
+        let resourceValues = try? destinationURL.resourceValues(forKeys: [.contentTypeKey, .fileSizeKey])
+        let contentType = resourceValues?.contentType?.identifier
+            ?? UTType(filenameExtension: destinationURL.pathExtension)?.identifier
+        let byteSize = Int64(resourceValues?.fileSize ?? 0)
+        let attachment = NoteAttachment(
+            displayName: sourceURL.lastPathComponent,
+            relativePath: "attachments/\(storedFilename)",
+            contentType: contentType,
+            byteSize: byteSize,
+            createdAt: Date()
+        )
+
+        let existingMeta = loadNotesMeta(sessionID: sessionID)
+        let attachments = (existingMeta?.attachments ?? []) + [attachment]
+        let fallbackTemplate = existingMeta?.templateSnapshot
+            ?? TemplateSnapshot(
+                id: UUID(),
+                name: "Generic",
+                icon: "doc.text",
+                systemPrompt: ""
+            )
+        let fallbackGeneratedAt = existingMeta?.generatedAt ?? Date()
+        let updatedMeta = NotesMeta(
+            templateSnapshot: fallbackTemplate,
+            generatedAt: fallbackGeneratedAt,
+            attachments: attachments
+        )
+        saveNotesMeta(updatedMeta, sessionID: sessionID)
+        return attachment
+    }
+
+    func loadNoteAttachments(sessionID: String) -> [NoteAttachment] {
+        (loadNotesMeta(sessionID: sessionID)?.attachments ?? []).sorted { lhs, rhs in
+            if lhs.createdAt != rhs.createdAt { return lhs.createdAt < rhs.createdAt }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+        }
     }
 
     // MARK: - Custom Notes Guidance
@@ -835,13 +897,15 @@ actor SessionRepository {
             let transcript = loadTranscript(sessionID: id)
             let liveTranscript = loadLiveTranscript(sessionID: id)
             let notes = loadNotes(sessionID: id)
+            let notesMeta = loadNotesMeta(sessionID: id)
 
             return SessionDetail(
                 index: index,
                 transcript: transcript,
                 liveTranscript: liveTranscript,
                 notes: notes,
-                notesMeta: nil,
+                notesMeta: notesMeta,
+                attachments: notesMeta?.attachments ?? [],
                 calendarEvent: meta.calendarEvent
             )
         }
@@ -1507,7 +1571,8 @@ actor SessionRepository {
         transcript: [SessionRecord],
         audioURL: URL?,
         audioSources: [SessionAudioSource],
-        calendarEvent: CalendarEvent?
+        calendarEvent: CalendarEvent?,
+        attachments: [NoteAttachment]
     ) {
         let sessDir = sessionsDirectoryURL
         let dir = sessDir.appendingPathComponent(sessionID, isDirectory: true)
@@ -1524,24 +1589,45 @@ actor SessionRepository {
         async let calendarEvent = Task.detached(priority: .userInitiated) {
             SessionRepository.readCalendarEvent(dir: dir)
         }.value
+        async let attachments = Task.detached(priority: .userInitiated) {
+            SessionRepository.readNoteAttachments(dir: dir)
+        }.value
 
         let resolvedAudioSources = await audioSources
-        return await (notes, transcript, resolvedAudioSources.first?.url, resolvedAudioSources, calendarEvent)
+        return await (
+            notes,
+            transcript,
+            resolvedAudioSources.first?.url,
+            resolvedAudioSources,
+            calendarEvent,
+            attachments
+        )
     }
 
     private nonisolated static func readNotes(sessionID: String, dir: URL, sessionsDirectory: URL) -> GeneratedNotes? {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
         let mdURL = dir.appendingPathComponent("notes.md")
-        let metaURL = dir.appendingPathComponent("notes.meta.json")
 
         if let markdown = try? String(contentsOf: mdURL, encoding: .utf8),
-           let metaData = try? Data(contentsOf: metaURL),
-           let meta = try? decoder.decode(NotesMeta.self, from: metaData) {
+           let meta = readNotesMeta(dir: dir) {
             return GeneratedNotes(template: meta.templateSnapshot, generatedAt: meta.generatedAt, markdown: markdown)
         }
 
         return LegacySessionReader.loadNotes(sessionID: sessionID, sessionsDirectory: sessionsDirectory)
+    }
+
+    private nonisolated static func readNoteAttachments(dir: URL) -> [NoteAttachment] {
+        (readNotesMeta(dir: dir)?.attachments ?? []).sorted { lhs, rhs in
+            if lhs.createdAt != rhs.createdAt { return lhs.createdAt < rhs.createdAt }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+        }
+    }
+
+    private nonisolated static func readNotesMeta(dir: URL) -> NotesMeta? {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let metaURL = dir.appendingPathComponent("notes.meta.json")
+        guard let metaData = try? Data(contentsOf: metaURL) else { return nil }
+        return try? decoder.decode(NotesMeta.self, from: metaData)
     }
 
     private nonisolated static func readCalendarEvent(dir: URL) -> CalendarEvent? {
@@ -1651,6 +1737,10 @@ actor SessionRepository {
         sessionsDirectory.appendingPathComponent(sessionID, isDirectory: true)
     }
 
+    private func attachmentsDirectory(for sessionID: String) -> URL {
+        sessionDirectory(for: sessionID).appendingPathComponent("attachments", isDirectory: true)
+    }
+
     private func writeSessionMetadata(_ metadata: SessionMetadata, sessionID: String) {
         let dir = sessionDirectory(for: sessionID)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -1672,6 +1762,29 @@ actor SessionRepository {
         let url = sessionDirectory(for: sessionID).appendingPathComponent("session.json")
         guard let data = try? Data(contentsOf: url) else { return nil }
         return try? decoder.decode(SessionMetadata.self, from: data)
+    }
+
+    private func loadNotesMeta(sessionID: String) -> NotesMeta? {
+        Self.readNotesMeta(dir: sessionDirectory(for: sessionID))
+    }
+
+    private func saveNotesMeta(_ meta: NotesMeta, sessionID: String) {
+        let metaURL = sessionDirectory(for: sessionID).appendingPathComponent("notes.meta.json")
+        if let data = try? encoder.encode(meta) {
+            try? data.write(to: metaURL, options: .atomic)
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: metaURL.path)
+        }
+    }
+
+    private nonisolated static func sanitizedAttachmentFilename(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(.init(charactersIn: "-_"))
+        let scalars = value.unicodeScalars.map { scalar -> Character in
+            allowed.contains(scalar) ? Character(scalar) : "-"
+        }
+        let raw = String(scalars)
+            .replacingOccurrences(of: "--+", with: "-", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        return raw.isEmpty ? "attachment" : raw
     }
 
     private func parseJSONL(_ content: String) -> [SessionRecord] {

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -2194,6 +2194,7 @@ struct NotesView: View {
     private func notesToolbarActions(controller: NotesController, state: NotesState) -> some View {
         if controller.isManualNotesSession {
             if state.isEditingManualNotes {
+                attachmentInsertButton(controller: controller, state: state)
                 imageInsertMenu(controller: controller, state: state)
             } else if state.loadedNotes != nil {
                 Button {
@@ -2203,6 +2204,7 @@ struct NotesView: View {
                         .font(.system(size: 12))
                 }
                 .buttonStyle(.bordered)
+                attachmentInsertButton(controller: controller, state: state)
                 imageInsertMenu(controller: controller, state: state)
                 if settings.appleNotesEnabled {
                     appleNotesSyncButton(controller: controller, state: state)
@@ -2231,11 +2233,13 @@ struct NotesView: View {
             .help(controller.isAnyGenerationInProgress
                 ? "Generating notes for \"\(controller.generatingSessionName)\"..."
                 : "Click to regenerate, or pick a different template")
+            attachmentInsertButton(controller: controller, state: state)
             imageInsertMenu(controller: controller, state: state)
             if settings.appleNotesEnabled {
                 appleNotesSyncButton(controller: controller, state: state)
             }
         } else {
+            attachmentInsertButton(controller: controller, state: state)
             imageInsertMenu(controller: controller, state: state)
             if settings.appleNotesEnabled, !state.loadedTranscript.isEmpty {
                 appleNotesSyncButton(controller: controller, state: state)
@@ -2288,6 +2292,20 @@ struct NotesView: View {
     }
 
     @ViewBuilder
+    private func attachmentInsertButton(controller: NotesController, state: NotesState) -> some View {
+        Button {
+            insertAttachmentFromFile(controller: controller)
+        } label: {
+            Label("Add Attachment", systemImage: "paperclip.badge.plus")
+                .font(.system(size: 12))
+        }
+        .buttonStyle(.bordered)
+        .fixedSize()
+        .disabled(state.notesGenerationStatus == .generating || state.selectedSessionID == nil)
+        .help("Attach a file and insert a relative link into notes")
+    }
+
+    @ViewBuilder
     private func imageInsertMenu(controller: NotesController, state: NotesState) -> some View {
         Menu {
             Button {
@@ -2315,6 +2333,16 @@ struct NotesView: View {
         .fixedSize()
         .disabled(state.notesGenerationStatus == .generating || state.selectedSessionID == nil)
         .help("Insert an image into notes")
+    }
+
+    private func insertAttachmentFromFile(controller: NotesController) {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = false
+        panel.canChooseDirectories = false
+        panel.canCreateDirectories = false
+        panel.message = "Choose a file to attach to notes"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        controller.importAttachment(from: url)
     }
 
     private func clipboardHasImage() -> Bool {
@@ -2386,12 +2414,22 @@ struct NotesView: View {
                 if state.isEditingManualNotes {
                     notesNoTranscriptState(controller: controller, state: state)
                 } else if let notes = state.loadedNotes {
-                    notesContentView(notes, sessionDirectory: state.selectedSessionDirectory)
+                    notesContentView(
+                        controller: controller,
+                        notes: notes,
+                        sessionDirectory: state.selectedSessionDirectory,
+                        attachments: state.loadedAttachments
+                    )
                 } else {
                     notesNoTranscriptState(controller: controller, state: state)
                 }
             } else if let notes = state.loadedNotes {
-                notesContentView(notes, sessionDirectory: state.selectedSessionDirectory)
+                notesContentView(
+                    controller: controller,
+                    notes: notes,
+                    sessionDirectory: state.selectedSessionDirectory,
+                    attachments: state.loadedAttachments
+                )
             } else {
                 notesEmptyState(controller: controller, state: state, sessionID: sessionID)
             }
@@ -2448,6 +2486,10 @@ struct NotesView: View {
                         .disabled(!controller.hasUnsavedManualNotesChanges)
                     }
                     .controlSize(.small)
+
+                    if !state.loadedAttachments.isEmpty {
+                        attachmentsSection(controller: controller, attachments: state.loadedAttachments)
+                    }
 
                     TextEditor(text: Binding(
                         get: { state.manualNotesDraft },
@@ -2651,11 +2693,75 @@ struct NotesView: View {
         }
     }
 
-    private func notesContentView(_ notes: GeneratedNotes, sessionDirectory: URL?) -> some View {
+    private func notesContentView(
+        controller: NotesController,
+        notes: GeneratedNotes,
+        sessionDirectory: URL?,
+        attachments: [NoteAttachment]
+    ) -> some View {
         ScrollView {
-            markdownContent(notes.markdown, sessionDirectory: sessionDirectory)
-                .padding(16)
-                .accessibilityIdentifier("notes.renderedMarkdown")
+            VStack(alignment: .leading, spacing: 12) {
+                if !attachments.isEmpty {
+                    attachmentsSection(controller: controller, attachments: attachments)
+                }
+
+                markdownContent(notes.markdown, sessionDirectory: sessionDirectory)
+                    .accessibilityIdentifier("notes.renderedMarkdown")
+            }
+            .padding(16)
+            .environment(\.openURL, markdownOpenURLAction(sessionDirectory: sessionDirectory))
+        }
+    }
+
+    @ViewBuilder
+    private func attachmentsSection(controller: NotesController, attachments: [NoteAttachment]) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Attachments")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(attachments) { attachment in
+                        Menu {
+                            Button {
+                                controller.openAttachment(attachment)
+                            } label: {
+                                Label("Open", systemImage: "arrow.up.right.square")
+                            }
+
+                            Button {
+                                controller.revealAttachment(attachment)
+                            } label: {
+                                Label("Reveal in Finder", systemImage: "folder")
+                            }
+                        } label: {
+                            Label(attachment.displayName, systemImage: "paperclip")
+                                .font(.system(size: 12))
+                                .lineLimit(1)
+                        } primaryAction: {
+                            controller.openAttachment(attachment)
+                        }
+                        .menuStyle(.button)
+                        .buttonStyle(.bordered)
+                        .fixedSize()
+                        .help("Open \(attachment.displayName)")
+                    }
+                }
+            }
+        }
+    }
+
+    private func markdownOpenURLAction(sessionDirectory: URL?) -> OpenURLAction {
+        OpenURLAction { url in
+            if url.isFileURL {
+                return NSWorkspace.shared.open(url) ? .handled : .discarded
+            }
+            if url.scheme == nil, let sessionDirectory {
+                let resolvedURL = sessionDirectory.appendingPathComponent(url.relativeString)
+                return NSWorkspace.shared.open(resolvedURL) ? .handled : .discarded
+            }
+            return NSWorkspace.shared.open(url) ? .handled : .discarded
         }
     }
 

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -473,6 +473,30 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertTrue(savedNotes?.markdown.contains("![](images/") ?? false)
     }
 
+    func testImportAttachmentPreservesUnsavedManualNotesDraft() async throws {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_manual_notes_attachment"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID, utterances: [])
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        let sourceURL = root.appendingPathComponent("Agenda v2.pdf")
+        try Data("attachment".utf8).write(to: sourceURL)
+
+        controller.startManualNotesEditing()
+        controller.updateManualNotesDraft("Prep observations")
+        controller.importAttachment(from: sourceURL)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        let savedNotes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
+        XCTAssertNotNil(savedNotes)
+        XCTAssertTrue(savedNotes?.markdown.contains("Prep observations") ?? false)
+        XCTAssertTrue(savedNotes?.markdown.contains("[Agenda v2.pdf](attachments/") ?? false)
+        XCTAssertEqual(controller.state.loadedAttachments.map(\.displayName), ["Agenda v2.pdf"])
+    }
+
     func testUnsavedManualNotesDraftSurvivesSessionSwitch() async {
         let (root, _) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -379,6 +379,66 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    func testImportAttachmentPersistsMetadataAndFile() async throws {
+        let sessionID = "test_attachment_session"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date()
+        )
+
+        let sourceURL = rootDir.appendingPathComponent("Quarterly Plan.pdf")
+        try Data("attachment".utf8).write(to: sourceURL)
+
+        let attachment = await repo.importAttachment(sessionID: sessionID, sourceURL: sourceURL)
+        XCTAssertNotNil(attachment)
+        XCTAssertEqual(attachment?.displayName, "Quarterly Plan.pdf")
+        XCTAssertTrue(attachment?.relativePath.hasPrefix("attachments/") ?? false)
+
+        let storedAttachments = await repo.loadNoteAttachments(sessionID: sessionID)
+        XCTAssertEqual(storedAttachments.count, 1)
+        XCTAssertEqual(storedAttachments.first?.displayName, "Quarterly Plan.pdf")
+
+        let sessionDir = rootDir
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+        if let relativePath = attachment?.relativePath {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: sessionDir.appendingPathComponent(relativePath).path))
+        }
+
+        let detail = await repo.loadSession(id: sessionID)
+        XCTAssertEqual(detail.attachments.count, 1)
+        XCTAssertEqual(detail.attachments.first?.displayName, "Quarterly Plan.pdf")
+    }
+
+    func testSaveNotesPreservesExistingAttachments() async throws {
+        let sessionID = "test_attachment_preserve_session"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date()
+        )
+
+        let sourceURL = rootDir.appendingPathComponent("Customer Feedback.txt")
+        try Data("attachment".utf8).write(to: sourceURL)
+        let attachment = await repo.importAttachment(sessionID: sessionID, sourceURL: sourceURL)
+        XCTAssertNotNil(attachment)
+
+        let template = TemplateSnapshot(
+            id: UUID(), name: "Test", icon: "star", systemPrompt: "Be helpful"
+        )
+        let notes = GeneratedNotes(
+            template: template,
+            generatedAt: Date(),
+            markdown: "# Notes\n\n[Customer Feedback](attachments/file.txt)"
+        )
+        await repo.saveNotes(sessionID: sessionID, notes: notes)
+
+        let storedAttachments = await repo.loadNoteAttachments(sessionID: sessionID)
+        XCTAssertEqual(storedAttachments.count, 1)
+        XCTAssertEqual(storedAttachments.first?.displayName, "Customer Feedback.txt")
+    }
+
     // MARK: - listSessions returns all sessions
 
     func testListSessionsReturnsAllSessions() async {


### PR DESCRIPTION
## Summary
- add session-local note attachments stored under each session directory
- persist attachment metadata in `notes.meta.json` and preserve it across note saves
- insert relative markdown links into notes and expose basic add/open/reveal actions in Notes

## Validation
- `swift test --package-path OpenOats --filter SessionRepositoryTests`
- `swift test --package-path OpenOats --filter NotesControllerTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`

## Notes
- this PR intentionally keeps attachment export/mirroring out of scope; attachments are session-local only for now
- closes #543