### PR TITLE
Add ElevenLabs API key validation

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -338,6 +338,9 @@ private struct TranscriptionSettingsTab: View {
     @Bindable var settings: AppSettings
     @State private var inputDevices: [(id: AudioDeviceID, name: String)] = []
     @State private var outputDevices: [(id: AudioDeviceID, name: String)] = []
+    @State private var isValidatingElevenLabsKey = false
+    @State private var elevenLabsValidation: APIKeyValidator.ValidationResult?
+    @State private var elevenLabsValidationTask: Task<Void, Never>?
 
     var body: some View {
         ScrollView {
@@ -415,8 +418,25 @@ private struct TranscriptionSettingsTab: View {
                                 .foregroundStyle(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)
                         case .elevenLabsScribe:
-                            SecureField("ElevenLabs API Key", text: $settings.elevenLabsApiKey)
-                                .font(.system(size: 12, design: .monospaced))
+                            HStack(spacing: 8) {
+                                SecureField("ElevenLabs API Key", text: $settings.elevenLabsApiKey)
+                                    .font(.system(size: 12, design: .monospaced))
+                                    .accessibilityIdentifier("settings.elevenLabsApiKeyField")
+
+                                apiKeyValidationIndicator(
+                                    isValidating: isValidatingElevenLabsKey,
+                                    result: elevenLabsValidation
+                                )
+                            }
+                            .onAppear {
+                                scheduleElevenLabsValidation(for: settings.elevenLabsApiKey)
+                            }
+                            .onChange(of: settings.elevenLabsApiKey) { _, newValue in
+                                scheduleElevenLabsValidation(for: newValue)
+                            }
+
+                            apiKeyValidationMessage(result: elevenLabsValidation)
+
                             Text("Audio segments are sent to ElevenLabs for transcription. Review their privacy policy at elevenlabs.io/privacy.")
                                 .font(.system(size: 11))
                                 .foregroundStyle(.secondary)
@@ -542,6 +562,90 @@ private struct TranscriptionSettingsTab: View {
                 settings.outputDeviceID = resolved
             }
         }
+        .onDisappear {
+            cancelElevenLabsValidation()
+        }
+    }
+
+    @ViewBuilder
+    private func apiKeyValidationIndicator(
+        isValidating: Bool,
+        result: APIKeyValidator.ValidationResult?
+    ) -> some View {
+        Group {
+            if isValidating {
+                ProgressView()
+                    .controlSize(.mini)
+            } else if let result {
+                switch result {
+                case .valid:
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                case .invalid:
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.red)
+                case .networkError:
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                }
+            } else {
+                Color.clear
+            }
+        }
+        .font(.system(size: 14))
+        .frame(width: 18, height: 18)
+    }
+
+    @ViewBuilder
+    private func apiKeyValidationMessage(result: APIKeyValidator.ValidationResult?) -> some View {
+        if let result {
+            switch result {
+            case .valid:
+                Text("Connected to ElevenLabs")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.green)
+            case .invalid(let message):
+                Text(message)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.red)
+            case .networkError(let message):
+                Text(message)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    private func scheduleElevenLabsValidation(for key: String) {
+        elevenLabsValidationTask?.cancel()
+
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            elevenLabsValidation = nil
+            isValidatingElevenLabsKey = false
+            return
+        }
+
+        isValidatingElevenLabsKey = true
+        elevenLabsValidation = nil
+        elevenLabsValidationTask = Task {
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+
+            let result = await APIKeyValidator.validateElevenLabsKey(trimmed)
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                elevenLabsValidation = result
+                isValidatingElevenLabsKey = false
+            }
+        }
+    }
+
+    private func cancelElevenLabsValidation() {
+        elevenLabsValidationTask?.cancel()
+        elevenLabsValidationTask = nil
+        isValidatingElevenLabsKey = false
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Wizard/APIKeyValidator.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/APIKeyValidator.swift
@@ -12,6 +12,33 @@ enum APIKeyValidator {
         case networkError(message: String)
     }
 
+    /// Validate an ElevenLabs API key by hitting the voices endpoint.
+    static func validateElevenLabsKey(_ key: String) async -> ValidationResult {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .invalid(message: "API key is empty")
+        }
+
+        guard let url = URL(string: "https://api.elevenlabs.io/v1/voices") else {
+            return .networkError(message: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(trimmed, forHTTPHeaderField: "xi-api-key")
+        request.timeoutInterval = 5
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            return validationResult(
+                for: response,
+                authFailureMessage: "This key didn't work - double-check it on elevenlabs.io"
+            )
+        } catch {
+            return .networkError(message: "Could not verify - will test when you go online")
+        }
+    }
+
     /// Validate an OpenRouter API key by hitting the models list endpoint.
     static func validateOpenRouterKey(_ key: String) async -> ValidationResult {
         let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -30,17 +57,10 @@ enum APIKeyValidator {
 
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse else {
-                return .networkError(message: "Unexpected response type")
-            }
-
-            if (200...299).contains(http.statusCode) {
-                return .valid
-            }
-            if http.statusCode == 401 || http.statusCode == 403 {
-                return .invalid(message: "This key didn't work - double-check it on openrouter.ai")
-            }
-            return .networkError(message: "Unexpected status: \(http.statusCode)")
+            return validationResult(
+                for: response,
+                authFailureMessage: "This key didn't work - double-check it on openrouter.ai"
+            )
         } catch {
             return .networkError(message: "Could not verify - will test when you go online")
         }
@@ -71,19 +91,29 @@ enum APIKeyValidator {
 
         do {
             let (_, response) = try await URLSession.shared.data(for: request)
-            guard let http = response as? HTTPURLResponse else {
-                return .networkError(message: "Unexpected response type")
-            }
-
-            if (200...299).contains(http.statusCode) {
-                return .valid
-            }
-            if http.statusCode == 401 || http.statusCode == 403 {
-                return .invalid(message: "This key didn't work - double-check it on dash.voyageai.com")
-            }
-            return .networkError(message: "Unexpected status: \(http.statusCode)")
+            return validationResult(
+                for: response,
+                authFailureMessage: "This key didn't work - double-check it on dash.voyageai.com"
+            )
         } catch {
             return .networkError(message: "Could not verify - will test when you go online")
         }
+    }
+
+    static func validationResult(
+        for response: URLResponse,
+        authFailureMessage: String
+    ) -> ValidationResult {
+        guard let http = response as? HTTPURLResponse else {
+            return .networkError(message: "Unexpected response type")
+        }
+
+        if (200...299).contains(http.statusCode) {
+            return .valid
+        }
+        if http.statusCode == 401 || http.statusCode == 403 {
+            return .invalid(message: authFailureMessage)
+        }
+        return .networkError(message: "Unexpected status: \(http.statusCode)")
     }
 }

--- a/OpenOats/Tests/OpenOatsTests/APIKeyValidatorTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/APIKeyValidatorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class APIKeyValidatorTests: XCTestCase {
+    func testValidateElevenLabsKeyRejectsEmptyKey() async {
+        let result = await APIKeyValidator.validateElevenLabsKey(" \n ")
+
+        XCTAssertEqual(result, .invalid(message: "API key is empty"))
+    }
+
+    func testValidationResultTreatsSuccessAsValid() {
+        let response = makeResponse(statusCode: 200)
+
+        let result = APIKeyValidator.validationResult(for: response, authFailureMessage: "bad key")
+
+        XCTAssertEqual(result, .valid)
+    }
+
+    func testValidationResultTreatsAuthFailureAsInvalid() {
+        let response = makeResponse(statusCode: 401)
+
+        let result = APIKeyValidator.validationResult(for: response, authFailureMessage: "bad key")
+
+        XCTAssertEqual(result, .invalid(message: "bad key"))
+    }
+
+    func testValidationResultTreatsUnexpectedStatusAsNetworkError() {
+        let response = makeResponse(statusCode: 500)
+
+        let result = APIKeyValidator.validationResult(for: response, authFailureMessage: "bad key")
+
+        XCTAssertEqual(result, .networkError(message: "Unexpected status: 500"))
+    }
+
+    private func makeResponse(statusCode: Int) -> URLResponse {
+        HTTPURLResponse(
+            url: URL(string: "https://api.elevenlabs.io/v1/voices")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}


### PR DESCRIPTION
## What changed

- Added a read-only ElevenLabs API key validator using the same `/v1/voices` endpoint the Scribe backend already uses for preflight validation.
- Added debounced validation state to the Transcription settings key field, showing progress, success, rejected-key, and network-warning states.
- Added focused unit coverage for empty ElevenLabs keys and shared HTTP response mapping.

## Why

Users can now catch broken ElevenLabs credentials when entering the key instead of discovering the problem only when a transcription session starts.

## Validation

- `swift test --package-path OpenOats --filter APIKeyValidatorTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
