### PR TITLE
Mirror note assets in exported markdown packages

### DIFF
--- a/OpenOats/Sources/OpenOats/Intelligence/MarkdownMeetingWriter.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/MarkdownMeetingWriter.swift
@@ -1,13 +1,20 @@
 import Foundation
 
-/// Produces spec-compliant openoats/v1 Markdown files from session data.
+/// Produces spec-compliant openoats/v1 Markdown exports from session data.
 ///
 /// The writer is stateless: call `write(...)` with session metadata and transcript records,
-/// and it returns the URL of the generated `.md` file. All I/O is synchronous and runs
-/// on the caller's context (designed for `nonisolated static` or actor-isolated use).
+/// and it returns the markdown output target. Exports are a single `.md` file by default,
+/// but callers can request a package directory when session-local assets must be mirrored
+/// alongside the markdown. All I/O is synchronous and runs on the caller's context
+/// (designed for `nonisolated static` or actor-isolated use).
 enum MarkdownMeetingWriter {
 
     // MARK: - Public API
+
+    struct OutputTarget: Sendable {
+        let markdownFileURL: URL
+        let packageDirectoryURL: URL?
+    }
 
     /// Metadata needed to produce the Markdown file, extracted from SessionIndex + sidecar.
     struct Metadata: Sendable {
@@ -30,21 +37,22 @@ enum MarkdownMeetingWriter {
         }
     }
 
-    /// Write a spec-compliant `.md` file to the output directory.
+    /// Write a spec-compliant Markdown export to the output directory.
     ///
     /// - Parameters:
     ///   - metadata: Session metadata (title, dates, app, engine).
     ///   - records: The transcript records from the JSONL session store.
     ///   - notesMarkdown: Optional LLM-generated notes markdown to include before the transcript.
     ///   - outputDirectory: The directory to write into (e.g. `~/Documents/OpenOats/`).
-    /// - Returns: The URL of the written file, or `nil` on failure.
+    /// - Returns: The written markdown target, or `nil` on failure.
     @discardableResult
     static func write(
         metadata: Metadata,
         records: [SessionRecord],
         notesMarkdown: String? = nil,
-        outputDirectory: URL
-    ) -> URL? {
+        outputDirectory: URL,
+        preferPackage: Bool = false
+    ) -> OutputTarget? {
         guard !records.isEmpty else {
             Log.markdownMeetingWriter.warning("MarkdownMeetingWriter: no records, skipping write")
             return nil
@@ -56,19 +64,31 @@ enum MarkdownMeetingWriter {
         // Build the Markdown content
         let content = buildMarkdown(metadata: metadata, records: records, notesMarkdown: notesMarkdown)
 
-        // Generate filename with collision handling
-        let fileURL = resolveFilename(
-            title: metadata.title,
-            startedAt: metadata.startedAt,
-            directory: outputDirectory
-        )
+        guard let target = resolveOutputTarget(
+            metadata: metadata,
+            directory: outputDirectory,
+            preferPackage: preferPackage
+        ) else {
+            Log.markdownMeetingWriter.error("Failed to resolve markdown output target")
+            return nil
+        }
+        let fileURL = target.markdownFileURL
+
+        if let packageDirectoryURL = target.packageDirectoryURL {
+            do {
+                try fm.createDirectory(at: packageDirectoryURL, withIntermediateDirectories: true)
+            } catch {
+                Log.markdownMeetingWriter.error("Failed to create markdown package: \(error, privacy: .public)")
+                return nil
+            }
+        }
 
         // Write with restricted permissions
         do {
             try content.write(to: fileURL, atomically: true, encoding: .utf8)
             try fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
             Log.markdownMeetingWriter.info("Wrote meeting markdown: \(fileURL.lastPathComponent, privacy: .public)")
-            return fileURL
+            return target
         } catch {
             Log.markdownMeetingWriter.error("Failed to write markdown: \(error, privacy: .public)")
             return nil
@@ -309,20 +329,129 @@ enum MarkdownMeetingWriter {
     /// Generate the filename: `YYYY-MM-DD-HHMM-kebab-title.md`
     /// Handles collisions by appending -2, -3, etc.
     static func resolveFilename(title: String?, startedAt: Date, directory: URL) -> URL {
+        let baseName = resolveBaseName(title: title, startedAt: startedAt)
+        let fm = FileManager.default
+        var candidate = directory.appendingPathComponent("\(baseName).md")
+        var counter = 2
+
+        while fm.fileExists(atPath: candidate.path) || fm.fileExists(atPath: directory.appendingPathComponent(candidate.deletingPathExtension().lastPathComponent).path) {
+            candidate = directory.appendingPathComponent("\(baseName)-\(counter).md")
+            counter += 1
+        }
+
+        return candidate
+    }
+
+    static func resolveOutputTarget(
+        metadata: Metadata,
+        directory: URL,
+        preferPackage: Bool
+    ) -> OutputTarget? {
+        let fm = FileManager.default
+
+        if let existing = findExistingOutputTarget(sessionID: metadata.sessionID, in: directory) {
+            switch existing {
+            case let .file(fileURL):
+                if preferPackage {
+                    let baseName = fileURL.deletingPathExtension().lastPathComponent
+                    let packageDirectoryURL = directory.appendingPathComponent(baseName, isDirectory: true)
+                    do {
+                        try fm.removeItem(at: fileURL)
+                    } catch {
+                        Log.markdownMeetingWriter.error("Failed to replace mirrored markdown file with package: \(error, privacy: .public)")
+                        return nil
+                    }
+                    return OutputTarget(
+                        markdownFileURL: packageDirectoryURL.appendingPathComponent("notes.md"),
+                        packageDirectoryURL: packageDirectoryURL
+                    )
+                }
+
+                return OutputTarget(markdownFileURL: fileURL, packageDirectoryURL: nil)
+
+            case let .package(packageDirectoryURL):
+                return OutputTarget(
+                    markdownFileURL: packageDirectoryURL.appendingPathComponent("notes.md"),
+                    packageDirectoryURL: packageDirectoryURL
+                )
+            }
+        }
+
+        let baseName = resolveBaseName(title: metadata.title, startedAt: metadata.startedAt)
+        if preferPackage {
+            let packageDirectoryURL = resolvePackageDirectory(baseName: baseName, directory: directory)
+            return OutputTarget(
+                markdownFileURL: packageDirectoryURL.appendingPathComponent("notes.md"),
+                packageDirectoryURL: packageDirectoryURL
+            )
+        }
+
+        return OutputTarget(
+            markdownFileURL: resolveFilename(title: metadata.title, startedAt: metadata.startedAt, directory: directory),
+            packageDirectoryURL: nil
+        )
+    }
+
+    private enum ExistingOutputTarget {
+        case file(URL)
+        case package(URL)
+    }
+
+    private static func findExistingOutputTarget(sessionID: String, in directory: URL) -> ExistingOutputTarget? {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+
+        for item in contents {
+            let values = try? item.resourceValues(forKeys: [.isDirectoryKey])
+            if values?.isDirectory == true {
+                let markdownURL = item.appendingPathComponent("notes.md")
+                if fm.fileExists(atPath: markdownURL.path),
+                   markdownContainsSessionID(markdownURL, sessionID: sessionID) {
+                    return .package(item)
+                }
+                continue
+            }
+
+            if item.pathExtension == "md",
+               markdownContainsSessionID(item, sessionID: sessionID) {
+                return .file(item)
+            }
+        }
+
+        return nil
+    }
+
+    private static func markdownContainsSessionID(_ url: URL, sessionID: String) -> Bool {
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else {
+            return false
+        }
+        return content.contains("x_openoats_session: \(yamlQuote(sessionID))")
+    }
+
+    private static func resolveBaseName(title: String?, startedAt: Date) -> String {
         let dateFmt = DateFormatter()
         dateFmt.dateFormat = "yyyy-MM-dd-HHmm"
         dateFmt.timeZone = TimeZone.current
         let datePrefix = dateFmt.string(from: startedAt)
 
         let titleSlug = toKebabCase(title ?? "meeting")
-        let baseName = "\(datePrefix)-\(titleSlug)"
+        return "\(datePrefix)-\(titleSlug)"
+    }
 
+    private static func resolvePackageDirectory(baseName: String, directory: URL) -> URL {
         let fm = FileManager.default
-        var candidate = directory.appendingPathComponent("\(baseName).md")
+        var candidate = directory.appendingPathComponent(baseName, isDirectory: true)
         var counter = 2
 
-        while fm.fileExists(atPath: candidate.path) {
-            candidate = directory.appendingPathComponent("\(baseName)-\(counter).md")
+        while fm.fileExists(atPath: candidate.path)
+            || fm.fileExists(atPath: directory.appendingPathComponent("\(candidate.lastPathComponent).md").path) {
+            candidate = directory.appendingPathComponent("\(baseName)-\(counter)", isDirectory: true)
             counter += 1
         }
 

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -1885,6 +1885,8 @@ actor SessionRepository {
     // MARK: - Notes Folder Mirroring
 
     /// Schedule a background mirror of the session's notes and transcript to notesFolderPath.
+    /// When notes reference session-local assets, the mirror is written as a small package
+    /// directory so relative links remain valid.
     /// Captures all actor-isolated state before spawning so the work runs entirely off-actor.
     /// - Parameter notesMarkdown: Pass the markdown when already in memory (e.g. from saveNotes)
     ///   to avoid a redundant disk read; nil causes the background task to read it from disk.
@@ -1925,6 +1927,7 @@ actor SessionRepository {
 
         let resolvedMarkdown = notesMarkdown
             ?? readNotes(sessionID: sessionID, dir: dir, sessionsDirectory: sessionsDirectory)?.markdown
+        let referencedAssetPaths = resolvedMarkdown.map(Self.referencedMirrorAssetPaths(in:)) ?? []
 
         let index = SessionIndex(
             id: meta?.id ?? sessionID,
@@ -1945,12 +1948,115 @@ actor SessionRepository {
             transcriptRecovery: meta?.transcriptRecovery
         )
 
-        MarkdownMeetingWriter.write(
+        let outputTarget = MarkdownMeetingWriter.write(
             metadata: .init(from: index),
             records: records,
             notesMarkdown: resolvedMarkdown,
-            outputDirectory: outputDir
+            outputDirectory: outputDir,
+            preferPackage: !referencedAssetPaths.isEmpty
         )
+
+        guard let outputTarget else { return }
+
+        if let packageDirectoryURL = outputTarget.packageDirectoryURL {
+            synchronizeMirroredAssets(
+                referencedAssetPaths: referencedAssetPaths,
+                from: dir,
+                into: packageDirectoryURL
+            )
+        }
+    }
+
+    private nonisolated static func referencedMirrorAssetPaths(in markdown: String) -> Set<String> {
+        guard let regex = try? NSRegularExpression(pattern: #"!?\[[^\]]*\]\(([^)]+)\)"#) else {
+            return []
+        }
+
+        let nsMarkdown = markdown as NSString
+        let range = NSRange(location: 0, length: nsMarkdown.length)
+        var paths: Set<String> = []
+
+        for match in regex.matches(in: markdown, range: range) {
+            guard match.numberOfRanges > 1 else { continue }
+            let rawTarget = nsMarkdown.substring(with: match.range(at: 1))
+            if let normalizedPath = normalizedMirrorAssetPath(rawTarget) {
+                paths.insert(normalizedPath)
+            }
+        }
+
+        return paths
+    }
+
+    private nonisolated static func normalizedMirrorAssetPath(_ rawTarget: String) -> String? {
+        var target = rawTarget.trimmingCharacters(in: .whitespacesAndNewlines)
+        if target.hasPrefix("<"), target.hasSuffix(">"), target.count >= 2 {
+            target.removeFirst()
+            target.removeLast()
+        }
+
+        guard !target.isEmpty else { return nil }
+
+        if let fragmentIndex = target.firstIndex(of: "#") {
+            target = String(target[..<fragmentIndex])
+        }
+        if let queryIndex = target.firstIndex(of: "?") {
+            target = String(target[..<queryIndex])
+        }
+
+        guard !target.isEmpty,
+              !target.hasPrefix("/"),
+              !target.hasPrefix("~"),
+              URL(string: target)?.scheme == nil else {
+            return nil
+        }
+
+        let components = target
+            .split(separator: "/", omittingEmptySubsequences: true)
+            .map(String.init)
+        guard let first = components.first,
+              first == "attachments" || first == "images",
+              !components.contains(".."),
+              !components.contains(".") else {
+            return nil
+        }
+
+        return components.joined(separator: "/")
+    }
+
+    private nonisolated static func synchronizeMirroredAssets(
+        referencedAssetPaths: Set<String>,
+        from sessionDirectory: URL,
+        into packageDirectory: URL
+    ) {
+        let fm = FileManager.default
+        let mirroredAssetDirectories = [
+            packageDirectory.appendingPathComponent("attachments", isDirectory: true),
+            packageDirectory.appendingPathComponent("images", isDirectory: true),
+        ]
+
+        for directory in mirroredAssetDirectories {
+            try? fm.removeItem(at: directory)
+        }
+
+        guard !referencedAssetPaths.isEmpty else { return }
+
+        for relativePath in referencedAssetPaths.sorted() {
+            let sourceURL = sessionDirectory.appendingPathComponent(relativePath)
+            guard fm.fileExists(atPath: sourceURL.path) else { continue }
+
+            let destinationURL = packageDirectory.appendingPathComponent(relativePath)
+            let parentDirectory = destinationURL.deletingLastPathComponent()
+            do {
+                try fm.createDirectory(at: parentDirectory, withIntermediateDirectories: true)
+                if fm.fileExists(atPath: destinationURL.path) {
+                    try fm.removeItem(at: destinationURL)
+                }
+                try fm.copyItem(at: sourceURL, to: destinationURL)
+                try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destinationURL.path)
+            } catch {
+                Log.sessionRepository.error("Failed to mirror note asset \(relativePath, privacy: .public): \(error, privacy: .public)")
+            }
+        }
     }
 
     // MARK: - Spotlight

--- a/OpenOats/Tests/OpenOatsTests/MarkdownMeetingWriterTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MarkdownMeetingWriterTests.swift
@@ -425,22 +425,64 @@ final class MarkdownMeetingWriterTests: XCTestCase {
 
         let records = [SessionRecord(speaker: .you, text: "Test", timestamp: start)]
 
-        let fileURL = MarkdownMeetingWriter.write(
+        let target = MarkdownMeetingWriter.write(
             metadata: metadata,
             records: records,
             outputDirectory: tmpDir
         )
 
-        XCTAssertNotNil(fileURL)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: fileURL!.path))
-        XCTAssertTrue(fileURL!.lastPathComponent.hasSuffix(".md"))
+        XCTAssertNotNil(target)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: target!.markdownFileURL.path))
+        XCTAssertTrue(target!.markdownFileURL.lastPathComponent.hasSuffix(".md"))
+        XCTAssertNil(target?.packageDirectoryURL)
 
         // Verify content
-        let content = try! String(contentsOf: fileURL!, encoding: .utf8)
+        let content = try! String(contentsOf: target!.markdownFileURL, encoding: .utf8)
         XCTAssertTrue(content.contains("schema: openoats/v1"))
     }
 
     func testWriteHandlesFilenameCollision() {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenOatsTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let start = Date()
+        let firstMetadata = MarkdownMeetingWriter.Metadata(
+            from: SessionIndex(
+                id: "test_session_a",
+                startedAt: start,
+                endedAt: start.addingTimeInterval(60),
+                utteranceCount: 1,
+                hasNotes: false
+            )
+        )
+        let secondMetadata = MarkdownMeetingWriter.Metadata(
+            from: SessionIndex(
+                id: "test_session_b",
+                startedAt: start,
+                endedAt: start.addingTimeInterval(60),
+                utteranceCount: 1,
+                hasNotes: false
+            )
+        )
+
+        let records = [SessionRecord(speaker: .you, text: "Test", timestamp: start)]
+
+        // Write first file
+        let first = MarkdownMeetingWriter.write(
+            metadata: firstMetadata, records: records, outputDirectory: tmpDir
+        )!
+
+        // Write second file with same metadata (collision)
+        let second = MarkdownMeetingWriter.write(
+            metadata: secondMetadata, records: records, outputDirectory: tmpDir
+        )!
+
+        XCTAssertNotEqual(first.markdownFileURL.lastPathComponent, second.markdownFileURL.lastPathComponent)
+        XCTAssertTrue(second.markdownFileURL.lastPathComponent.contains("-2"))
+    }
+
+    func testWriteReusesExistingFileForSameSession() {
         let tmpDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("OpenOatsTest-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tmpDir) }
@@ -456,20 +498,98 @@ final class MarkdownMeetingWriterTests: XCTestCase {
             )
         )
 
+        let firstRecords = [SessionRecord(speaker: .you, text: "First", timestamp: start)]
+        let secondRecords = [SessionRecord(speaker: .you, text: "Second", timestamp: start)]
+
+        let first = MarkdownMeetingWriter.write(
+            metadata: metadata,
+            records: firstRecords,
+            outputDirectory: tmpDir
+        )!
+        let second = MarkdownMeetingWriter.write(
+            metadata: metadata,
+            records: secondRecords,
+            outputDirectory: tmpDir
+        )!
+
+        XCTAssertEqual(
+            first.markdownFileURL.resolvingSymlinksInPath(),
+            second.markdownFileURL.resolvingSymlinksInPath()
+        )
+        let contents = try! String(contentsOf: second.markdownFileURL, encoding: .utf8)
+        XCTAssertTrue(contents.contains("**You:** Second"))
+        XCTAssertFalse(contents.contains("**You:** First"))
+    }
+
+    func testWriteCreatesPackageDirectoryWhenPreferred() {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenOatsTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let start = Date()
+        let metadata = MarkdownMeetingWriter.Metadata(
+            from: SessionIndex(
+                id: "test_session",
+                startedAt: start,
+                endedAt: start.addingTimeInterval(60),
+                utteranceCount: 1,
+                hasNotes: true
+            )
+        )
+
         let records = [SessionRecord(speaker: .you, text: "Test", timestamp: start)]
 
-        // Write first file
-        let first = MarkdownMeetingWriter.write(
-            metadata: metadata, records: records, outputDirectory: tmpDir
+        let target = MarkdownMeetingWriter.write(
+            metadata: metadata,
+            records: records,
+            notesMarkdown: "[Doc](attachments/doc.pdf)",
+            outputDirectory: tmpDir,
+            preferPackage: true
+        )
+
+        XCTAssertNotNil(target)
+        XCTAssertNotNil(target?.packageDirectoryURL)
+        XCTAssertEqual(target?.markdownFileURL.lastPathComponent, "notes.md")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: target!.markdownFileURL.path))
+    }
+
+    func testWriteMigratesExistingFileToPackageForSameSession() {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("OpenOatsTest-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let start = Date()
+        let metadata = MarkdownMeetingWriter.Metadata(
+            from: SessionIndex(
+                id: "test_session",
+                startedAt: start,
+                endedAt: start.addingTimeInterval(60),
+                utteranceCount: 1,
+                hasNotes: true
+            )
+        )
+
+        let records = [SessionRecord(speaker: .you, text: "Test", timestamp: start)]
+
+        let initialTarget = MarkdownMeetingWriter.write(
+            metadata: metadata,
+            records: records,
+            outputDirectory: tmpDir
+        )!
+        XCTAssertNil(initialTarget.packageDirectoryURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: initialTarget.markdownFileURL.path))
+
+        let migratedTarget = MarkdownMeetingWriter.write(
+            metadata: metadata,
+            records: records,
+            notesMarkdown: "[Doc](attachments/doc.pdf)",
+            outputDirectory: tmpDir,
+            preferPackage: true
         )!
 
-        // Write second file with same metadata (collision)
-        let second = MarkdownMeetingWriter.write(
-            metadata: metadata, records: records, outputDirectory: tmpDir
-        )!
-
-        XCTAssertNotEqual(first.lastPathComponent, second.lastPathComponent)
-        XCTAssertTrue(second.lastPathComponent.contains("-2"))
+        XCTAssertNotNil(migratedTarget.packageDirectoryURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: initialTarget.markdownFileURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: migratedTarget.markdownFileURL.path))
     }
 
     func testWriteReturnsNilForEmptyRecords() {

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -375,7 +375,77 @@ final class SessionRepositoryTests: XCTestCase {
         }
         
         XCTAssertTrue(didMirror, "Background mirror task did not complete in time")
-        
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
+    func testSaveNotesMirrorsReferencedAssetsIntoPackageDirectory() async throws {
+        let exportDir = rootDir.appendingPathComponent("exported_notes_with_assets", isDirectory: true)
+        try? FileManager.default.createDirectory(at: exportDir, withIntermediateDirectories: true)
+
+        await repo.setNotesFolderPath(exportDir)
+
+        let sessionID = "test_mirror_assets_session"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date(),
+            title: "Mirror Assets Meeting"
+        )
+
+        let sourceURL = rootDir.appendingPathComponent("Quarterly Plan.pdf")
+        try Data("attachment".utf8).write(to: sourceURL)
+        let attachment = await repo.importAttachment(sessionID: sessionID, sourceURL: sourceURL)
+        XCTAssertNotNil(attachment)
+
+        let imageFilename = await repo.saveImage(sessionID: sessionID, imageData: Data("png".utf8))
+
+        let template = TemplateSnapshot(
+            id: UUID(), name: "Mirror", icon: "star", systemPrompt: "Be helpful"
+        )
+        let notes = GeneratedNotes(
+            template: template,
+            generatedAt: Date(),
+            markdown: """
+            # Mirror Notes
+
+            [Plan](\(attachment!.relativePath))
+
+            ![](images/\(imageFilename))
+            """
+        )
+
+        await repo.saveNotes(sessionID: sessionID, notes: notes)
+
+        var mirroredPackage: URL?
+        for _ in 0..<20 {
+            try? await Task.sleep(for: .milliseconds(100))
+            let contents = try? FileManager.default.contentsOfDirectory(
+                at: exportDir,
+                includingPropertiesForKeys: [.isDirectoryKey]
+            )
+            mirroredPackage = contents?.first(where: {
+                ((try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false)
+                && $0.lastPathComponent.contains("mirror-assets-meeting")
+            })
+            if mirroredPackage != nil {
+                break
+            }
+        }
+
+        guard let mirroredPackage else {
+            XCTFail("Background mirror package did not complete in time")
+            return
+        }
+
+        let markdownURL = mirroredPackage.appendingPathComponent("notes.md")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: markdownURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mirroredPackage.appendingPathComponent(attachment!.relativePath).path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mirroredPackage.appendingPathComponent("images").appendingPathComponent(imageFilename).path))
+
+        let topLevelFiles = try? FileManager.default.contentsOfDirectory(at: exportDir, includingPropertiesForKeys: [.isDirectoryKey])
+        XCTAssertFalse(topLevelFiles?.contains(where: { $0.pathExtension == "md" && $0.lastPathComponent.contains("mirror-assets-meeting") }) ?? true)
+
         await repo.deleteSession(sessionID: sessionID)
     }
 


### PR DESCRIPTION
## Summary
- mirror referenced `attachments/` and `images/` alongside exported notes
- keep asset-free exports as plain `.md` files, but switch asset-backed exports to a package directory with `notes.md`
- reuse the same mirrored export for a session and migrate an existing plain export to a package when assets are later added

Closes #547

## Validation
- `swift test --package-path OpenOats --filter MarkdownMeetingWriterTests`
- `swift test --package-path OpenOats --filter SessionRepositoryTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
