### PR TITLE
Add drag-and-drop and paste support for note assets

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -2,6 +2,7 @@ import Foundation
 import Observation
 import CoreAudio
 import AppKit
+import UniformTypeIdentifiers
 
 struct RecordingHealthNotice: Equatable {
     enum Severity: Equatable {
@@ -57,6 +58,12 @@ final class LiveSessionState {
 @Observable
 @MainActor
 final class LiveSessionController {
+    enum ScratchpadAssetInsertion: Sendable {
+        case attachmentFile(URL)
+        case imageFile(URL)
+        case imageData(Data)
+    }
+
     enum EmptySessionDiagnosticClassification: String, Equatable {
         case noAudioDetected = "no_audio_detected"
         case transcriptionProducedNoText = "transcription_produced_no_text"
@@ -346,6 +353,70 @@ final class LiveSessionController {
         }
     }
 
+    func insertScratchpadImage(_ imageData: Data) {
+        insertScratchpadAssets([.imageData(imageData)])
+    }
+
+    func insertScratchpadAssets(_ insertions: [ScratchpadAssetInsertion]) {
+        guard let sessionID = _currentSessionID, !insertions.isEmpty else { return }
+
+        Task {
+            var updatedText = state.scratchpadText
+            var insertedAnyAssets = false
+
+            for insertion in insertions {
+                switch insertion {
+                case .attachmentFile(let sourceURL):
+                    guard let attachment = await coordinator.sessionRepository.importAttachment(
+                        sessionID: sessionID,
+                        sourceURL: sourceURL
+                    ) else {
+                        continue
+                    }
+                    updatedText = Self.appendingMarkdownBlock(
+                        Self.markdownLink(for: attachment),
+                        to: updatedText
+                    )
+                    insertedAnyAssets = true
+
+                case .imageFile(let fileURL):
+                    guard let normalizedImageData = Self.normalizedPNGImageData(fromFileURL: fileURL) else {
+                        continue
+                    }
+                    let filename = await coordinator.sessionRepository.saveImage(
+                        sessionID: sessionID,
+                        imageData: normalizedImageData
+                    )
+                    updatedText = Self.appendingMarkdownBlock(
+                        "![](images/\(filename))",
+                        to: updatedText
+                    )
+                    insertedAnyAssets = true
+
+                case .imageData(let imageData):
+                    guard let normalizedImageData = Self.normalizedPNGImageData(from: imageData) else {
+                        continue
+                    }
+                    let filename = await coordinator.sessionRepository.saveImage(
+                        sessionID: sessionID,
+                        imageData: normalizedImageData
+                    )
+                    updatedText = Self.appendingMarkdownBlock(
+                        "![](images/\(filename))",
+                        to: updatedText
+                    )
+                    insertedAnyAssets = true
+                }
+            }
+
+            guard insertedAnyAssets else { return }
+
+            state.scratchpadText = updatedText
+            scratchpadSaveTask?.cancel()
+            await coordinator.sessionRepository.saveScratchpad(sessionID: sessionID, text: updatedText)
+        }
+    }
+
     // MARK: - KB Indexing
 
     func indexKBIfNeeded(settings: AppSettings) {
@@ -439,6 +510,52 @@ final class LiveSessionController {
         _currentSessionID
     }
     private var _currentSessionID: String?
+
+    private static func appendingMarkdownBlock(_ block: String, to existing: String) -> String {
+        guard !existing.isEmpty else { return block }
+        return existing + "\n\n" + block
+    }
+
+    private static func markdownLink(for attachment: NoteAttachment) -> String {
+        let label = attachment.displayName
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "[", with: "\\[")
+            .replacingOccurrences(of: "]", with: "\\]")
+        return "[\(label)](\(attachment.relativePath))"
+    }
+
+    static func isImageFile(url: URL) -> Bool {
+        if let resourceValues = try? url.resourceValues(forKeys: [.contentTypeKey]),
+           let contentType = resourceValues.contentType {
+            return contentType.conforms(to: .image)
+        }
+        if let inferredType = UTType(filenameExtension: url.pathExtension) {
+            return inferredType.conforms(to: .image)
+        }
+        return false
+    }
+
+    private static func normalizedPNGImageData(fromFileURL fileURL: URL) -> Data? {
+        guard let image = NSImage(contentsOf: fileURL) else { return nil }
+        return normalizedPNGImageData(from: image)
+    }
+
+    private static func normalizedPNGImageData(from imageData: Data) -> Data? {
+        guard let image = NSImage(data: imageData),
+              let tiffRepresentation = image.tiffRepresentation,
+              let bitmapRepresentation = NSBitmapImageRep(data: tiffRepresentation) else {
+            return nil
+        }
+        return bitmapRepresentation.representation(using: .png, properties: [:])
+    }
+
+    private static func normalizedPNGImageData(from image: NSImage) -> Data? {
+        guard let tiffRepresentation = image.tiffRepresentation,
+              let bitmapRepresentation = NSBitmapImageRep(data: tiffRepresentation) else {
+            return nil
+        }
+        return bitmapRepresentation.representation(using: .png, properties: [:])
+    }
 
     private func handleNewUtterances(startingAt startIndex: Int, settings: AppSettings) {
         let utterances = coordinator.transcriptStore.utterances

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -2,6 +2,7 @@ import AppKit
 import AVFoundation
 import Foundation
 import Observation
+import UniformTypeIdentifiers
 
 // MARK: - State
 
@@ -153,6 +154,17 @@ struct MeetingFamilyKnowledgeBaseCoverage: Equatable {
 @Observable
 @MainActor
 final class NotesController {
+    enum DroppedNoteAsset: Sendable {
+        case file(URL)
+        case imageData(Data)
+    }
+
+    private enum NoteAssetInsertion: Sendable {
+        case attachmentFile(URL)
+        case imageFile(URL)
+        case imageData(Data)
+    }
+
     private(set) var state = NotesState()
 
     private let coordinator: AppCoordinator
@@ -606,89 +618,23 @@ final class NotesController {
     // MARK: - Image Insertion
 
     func insertImage(imageData: Data) {
-        guard let sessionID = state.selectedSessionID else { return }
-
-        Task {
-            let filename = await coordinator.sessionRepository.saveImage(
-                sessionID: sessionID, imageData: imageData
-            )
-            let imageRef = "\n\n![](images/\(filename))\n"
-            let isManualNotesSession = state.loadedTranscript.isEmpty
-
-            if let existing = state.loadedNotes {
-                let baseMarkdown = isManualNotesSession ? state.manualNotesDraft : existing.markdown
-                let updated = GeneratedNotes(
-                    template: existing.template,
-                    generatedAt: existing.generatedAt,
-                    markdown: baseMarkdown + imageRef
-                )
-                await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: updated)
-                state.loadedNotes = updated
-                state.manualNotesDraft = updated.markdown
-                state.savedManualNotesMarkdown = updated.markdown
-            } else {
-                let template = state.selectedTemplate
-                    ?? coordinator.templateStore.template(for: TemplateStore.genericID)
-                    ?? TemplateStore.builtInTemplates.first!
-                let baseMarkdown = isManualNotesSession ? state.manualNotesDraft : ""
-                let notes = GeneratedNotes(
-                    template: coordinator.templateStore.snapshot(of: template),
-                    generatedAt: Date(),
-                    markdown: baseMarkdown + (baseMarkdown.isEmpty ? "" : "\n\n") + "![](images/\(filename))"
-                )
-                await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
-                state.loadedNotes = notes
-                state.manualNotesDraft = notes.markdown
-                state.savedManualNotesMarkdown = notes.markdown
-                await loadHistory()
-            }
-        }
+        insertAssets([.imageData(imageData)])
     }
 
     func importAttachment(from sourceURL: URL) {
-        guard let sessionID = state.selectedSessionID else { return }
+        insertAssets([.attachmentFile(sourceURL)])
+    }
 
-        Task {
-            guard let attachment = await coordinator.sessionRepository.importAttachment(
-                sessionID: sessionID,
-                sourceURL: sourceURL
-            ) else {
-                return
+    func importDroppedItems(_ items: [DroppedNoteAsset]) {
+        let insertions: [NoteAssetInsertion] = items.map { item in
+            switch item {
+            case .file(let fileURL):
+                Self.isImageFile(url: fileURL) ? NoteAssetInsertion.imageFile(fileURL) : .attachmentFile(fileURL)
+            case .imageData(let imageData):
+                NoteAssetInsertion.imageData(imageData)
             }
-            let markdownLink = Self.markdownLink(for: attachment)
-            let isManualNotesSession = state.loadedTranscript.isEmpty
-
-            if let existing = state.loadedNotes {
-                let baseMarkdown = isManualNotesSession ? state.manualNotesDraft : existing.markdown
-                let updated = GeneratedNotes(
-                    template: existing.template,
-                    generatedAt: existing.generatedAt,
-                    markdown: Self.appendingMarkdownBlock(markdownLink, to: baseMarkdown)
-                )
-                await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: updated)
-                state.loadedNotes = updated
-                state.manualNotesDraft = updated.markdown
-                state.savedManualNotesMarkdown = updated.markdown
-            } else {
-                let template = state.selectedTemplate
-                    ?? coordinator.templateStore.template(for: TemplateStore.genericID)
-                    ?? TemplateStore.builtInTemplates.first!
-                let baseMarkdown = isManualNotesSession ? state.manualNotesDraft : ""
-                let notes = GeneratedNotes(
-                    template: coordinator.templateStore.snapshot(of: template),
-                    generatedAt: Date(),
-                    markdown: Self.appendingMarkdownBlock(markdownLink, to: baseMarkdown)
-                )
-                await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
-                state.loadedNotes = notes
-                state.manualNotesDraft = notes.markdown
-                state.savedManualNotesMarkdown = notes.markdown
-                await loadHistory()
-            }
-
-            guard state.selectedSessionID == sessionID else { return }
-            state.loadedAttachments = await coordinator.sessionRepository.loadNoteAttachments(sessionID: sessionID)
         }
+        insertAssets(insertions)
     }
 
     func openAttachment(_ attachment: NoteAttachment) {
@@ -699,6 +645,86 @@ final class NotesController {
     func revealAttachment(_ attachment: NoteAttachment) {
         guard let url = selectedAttachmentURL(for: attachment) else { return }
         NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    private func insertAssets(_ insertions: [NoteAssetInsertion]) {
+        guard let sessionID = state.selectedSessionID, !insertions.isEmpty else { return }
+
+        Task {
+            let isManualNotesSession = state.loadedTranscript.isEmpty
+            let existingNotes = state.loadedNotes
+            var updatedMarkdown = isManualNotesSession
+                ? state.manualNotesDraft
+                : (existingNotes?.markdown ?? "")
+            var insertedAnyAssets = false
+
+            for insertion in insertions {
+                switch insertion {
+                case .attachmentFile(let sourceURL):
+                    guard let attachment = await coordinator.sessionRepository.importAttachment(
+                        sessionID: sessionID,
+                        sourceURL: sourceURL
+                    ) else {
+                        continue
+                    }
+                    updatedMarkdown = Self.appendingMarkdownBlock(
+                        Self.markdownLink(for: attachment),
+                        to: updatedMarkdown
+                    )
+                    insertedAnyAssets = true
+
+                case .imageFile(let fileURL):
+                    guard let imageData = Self.normalizedPNGImageData(fromFileURL: fileURL) else {
+                        continue
+                    }
+                    let filename = await coordinator.sessionRepository.saveImage(
+                        sessionID: sessionID,
+                        imageData: imageData
+                    )
+                    updatedMarkdown = Self.appendingMarkdownBlock(
+                        "![](images/\(filename))",
+                        to: updatedMarkdown
+                    )
+                    insertedAnyAssets = true
+
+                case .imageData(let imageData):
+                    guard let normalizedImageData = Self.normalizedPNGImageData(from: imageData) else {
+                        continue
+                    }
+                    let filename = await coordinator.sessionRepository.saveImage(
+                        sessionID: sessionID,
+                        imageData: normalizedImageData
+                    )
+                    updatedMarkdown = Self.appendingMarkdownBlock(
+                        "![](images/\(filename))",
+                        to: updatedMarkdown
+                    )
+                    insertedAnyAssets = true
+                }
+            }
+
+            guard insertedAnyAssets else { return }
+
+            let template = existingNotes.flatMap { existing in
+                coordinator.templateStore.template(for: existing.template.id)
+            } ?? state.selectedTemplate
+                ?? coordinator.templateStore.template(for: TemplateStore.genericID)
+                ?? TemplateStore.builtInTemplates.first!
+            let notes = GeneratedNotes(
+                template: coordinator.templateStore.snapshot(of: template),
+                generatedAt: existingNotes?.generatedAt ?? Date(),
+                markdown: updatedMarkdown
+            )
+
+            await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
+            await loadHistory()
+
+            guard state.selectedSessionID == sessionID else { return }
+            state.loadedNotes = notes
+            state.manualNotesDraft = notes.markdown
+            state.savedManualNotesMarkdown = notes.markdown
+            state.loadedAttachments = await coordinator.sessionRepository.loadNoteAttachments(sessionID: sessionID)
+        }
     }
 
     // MARK: - Manual Notes
@@ -1216,6 +1242,35 @@ final class NotesController {
     static func appendingMarkdownBlock(_ block: String, to existing: String) -> String {
         guard !existing.isEmpty else { return block }
         return existing + "\n\n" + block
+    }
+
+    private static func isImageFile(url: URL) -> Bool {
+        if let resourceValues = try? url.resourceValues(forKeys: [.contentTypeKey]),
+           let contentType = resourceValues.contentType {
+            return contentType.conforms(to: .image)
+        }
+        if let inferredType = UTType(filenameExtension: url.pathExtension) {
+            return inferredType.conforms(to: .image)
+        }
+        return false
+    }
+
+    private static func normalizedPNGImageData(fromFileURL fileURL: URL) -> Data? {
+        guard let image = NSImage(contentsOf: fileURL) else { return nil }
+        return normalizedPNGImageData(from: image)
+    }
+
+    private static func normalizedPNGImageData(from imageData: Data) -> Data? {
+        guard let image = NSImage(data: imageData) else { return nil }
+        return normalizedPNGImageData(from: image)
+    }
+
+    private static func normalizedPNGImageData(from image: NSImage) -> Data? {
+        guard let tiffRepresentation = image.tiffRepresentation,
+              let bitmapRepresentation = NSBitmapImageRep(data: tiffRepresentation) else {
+            return nil
+        }
+        return bitmapRepresentation.representation(using: .png, properties: [:])
     }
 
     private func reloadSessionAfterTranscriptMutation(sessionID: String) async {

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct ContentView: View {
     private enum ControlBarAction {
@@ -194,7 +195,10 @@ struct ContentView: View {
                     text: Binding(
                         get: { controllerState.scratchpadText },
                         set: { liveSessionController?.updateScratchpad($0) }
-                    )
+                    ),
+                    onPasteAssetProviders: { providers in
+                        handleScratchpadAssetPaste(providers)
+                    }
                 )
             } else {
                 IdleHomeDashboardView(settings: settings)
@@ -445,6 +449,78 @@ struct ContentView: View {
         NSPasteboard.general.setString(lines.joined(separator: "\n"), forType: .string)
     }
 
+    private func handleScratchpadAssetPaste(_ providers: [NSItemProvider]) {
+        guard liveSessionController?.state.isRunning == true else { return }
+
+        Task {
+            let assets = await loadPastedScratchpadAssets(from: providers)
+            guard !assets.isEmpty else { return }
+            await MainActor.run {
+                liveSessionController?.insertScratchpadAssets(assets)
+            }
+        }
+    }
+
+    private func loadPastedScratchpadAssets(
+        from providers: [NSItemProvider]
+    ) async -> [LiveSessionController.ScratchpadAssetInsertion] {
+        var assets: [LiveSessionController.ScratchpadAssetInsertion] = []
+
+        for provider in providers {
+            if let fileURL = await loadPastedFileURL(from: provider) {
+                if LiveSessionController.isImageFile(url: fileURL) {
+                    assets.append(.imageFile(fileURL))
+                } else {
+                    assets.append(.attachmentFile(fileURL))
+                }
+                continue
+            }
+            if let imageData = await loadPastedImageData(from: provider) {
+                assets.append(.imageData(imageData))
+            }
+        }
+
+        return assets
+    }
+
+    private func loadPastedFileURL(from provider: NSItemProvider) async -> URL? {
+        guard provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) else {
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+                let resolvedURL: URL?
+                switch item {
+                case let url as URL:
+                    resolvedURL = url
+                case let data as Data:
+                    resolvedURL = NSURL(absoluteURLWithDataRepresentation: data, relativeTo: nil) as URL?
+                case let string as String:
+                    resolvedURL = URL(string: string)
+                default:
+                    resolvedURL = nil
+                }
+                continuation.resume(returning: resolvedURL)
+            }
+        }
+    }
+
+    private func loadPastedImageData(from provider: NSItemProvider) async -> Data? {
+        for identifier in [UTType.png.identifier, UTType.jpeg.identifier, UTType.tiff.identifier, UTType.image.identifier] {
+            guard provider.hasItemConformingToTypeIdentifier(identifier) else { continue }
+            let data = await withCheckedContinuation { continuation in
+                provider.loadDataRepresentation(forTypeIdentifier: identifier) { data, _ in
+                    continuation.resume(returning: data)
+                }
+            }
+            if data != nil {
+                return data
+            }
+        }
+        return nil
+    }
+
     @MainActor
     private func handleControlBarAction(_ action: ControlBarAction) {
         switch action {
@@ -586,7 +662,10 @@ private struct PostSessionBanner: View {
 
 private struct ScratchpadSection: View {
     @Binding var text: String
+    let onPasteAssetProviders: ([NSItemProvider]) -> Void
     @AppStorage("isScratchpadExpanded") private var isExpanded = true
+
+    private let pasteAssetTypes: [UTType] = [.png, .jpeg, .tiff, .image, .fileURL]
 
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
@@ -597,6 +676,9 @@ private struct ScratchpadSection: View {
                 .padding(4)
                 .background(Color(nsColor: .textBackgroundColor).opacity(0.5))
                 .clipShape(RoundedRectangle(cornerRadius: 6))
+                .onPasteCommand(of: pasteAssetTypes) { providers in
+                    onPasteAssetProviders(providers)
+                }
         } label: {
             HStack(spacing: 6) {
                 Text("My Notes")

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -30,6 +30,7 @@ struct NotesView: View {
     @State private var showingAddTranscriptSheet = false
     @State private var manualTranscriptDraft = ""
     @State private var collapsedSidebarGroupIDs = Self.loadCollapsedSidebarGroupIDs()
+    @State private var isNotesAssetDropTarget = false
 
     enum DetailViewMode: String, CaseIterable {
         case transcript = "Transcript"
@@ -2345,6 +2346,131 @@ struct NotesView: View {
         controller.importAttachment(from: url)
     }
 
+    private var notesAssetDropTypeIdentifiers: [String] {
+        [
+            UTType.fileURL.identifier,
+            UTType.png.identifier,
+            UTType.jpeg.identifier,
+            UTType.tiff.identifier,
+            UTType.image.identifier,
+        ]
+    }
+
+    private var notesPasteAssetContentTypes: [UTType] {
+        [.png, .jpeg, .tiff, .image, .fileURL]
+    }
+
+    private func handleNotesAssetDrop(
+        providers: [NSItemProvider],
+        controller: NotesController,
+        state: NotesState
+    ) -> Bool {
+        guard state.notesGenerationStatus != .generating,
+              state.selectedSessionID != nil else {
+            return false
+        }
+
+        let supportedProviders = providers.filter { provider in
+            provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier)
+                || provider.hasItemConformingToTypeIdentifier(UTType.image.identifier)
+                || provider.hasItemConformingToTypeIdentifier(UTType.png.identifier)
+                || provider.hasItemConformingToTypeIdentifier(UTType.jpeg.identifier)
+                || provider.hasItemConformingToTypeIdentifier(UTType.tiff.identifier)
+        }
+        guard !supportedProviders.isEmpty else { return false }
+
+        Task {
+            let assets = await loadDroppedNoteAssets(from: supportedProviders)
+            guard !assets.isEmpty else { return }
+            await MainActor.run {
+                controller.importDroppedItems(assets)
+            }
+        }
+
+        return true
+    }
+
+    private func handleNotesAssetPaste(
+        providers: [NSItemProvider],
+        controller: NotesController,
+        state: NotesState
+    ) {
+        guard state.notesGenerationStatus != .generating,
+              state.selectedSessionID != nil else {
+            return
+        }
+
+        Task {
+            let assets = await loadDroppedNoteAssets(from: providers)
+            guard !assets.isEmpty else { return }
+            await MainActor.run {
+                controller.importDroppedItems(assets)
+            }
+        }
+    }
+
+    private func loadDroppedNoteAssets(
+        from providers: [NSItemProvider]
+    ) async -> [NotesController.DroppedNoteAsset] {
+        var assets: [NotesController.DroppedNoteAsset] = []
+
+        for provider in providers {
+            if let fileURL = await loadDroppedFileURL(from: provider) {
+                assets.append(.file(fileURL))
+                continue
+            }
+            if let imageData = await loadDroppedImageData(from: provider) {
+                assets.append(.imageData(imageData))
+            }
+        }
+
+        return assets
+    }
+
+    private func loadDroppedFileURL(from provider: NSItemProvider) async -> URL? {
+        guard provider.hasItemConformingToTypeIdentifier(UTType.fileURL.identifier) else {
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, _ in
+                let resolvedURL: URL?
+                switch item {
+                case let url as URL:
+                    resolvedURL = url
+                case let data as Data:
+                    resolvedURL = NSURL(absoluteURLWithDataRepresentation: data, relativeTo: nil) as URL?
+                case let string as String:
+                    resolvedURL = URL(string: string)
+                default:
+                    resolvedURL = nil
+                }
+                continuation.resume(returning: resolvedURL)
+            }
+        }
+    }
+
+    private func loadDroppedImageData(from provider: NSItemProvider) async -> Data? {
+        for identifier in [UTType.png.identifier, UTType.jpeg.identifier, UTType.tiff.identifier, UTType.image.identifier] {
+            guard provider.hasItemConformingToTypeIdentifier(identifier) else { continue }
+            if let data = await loadDataRepresentation(from: provider, typeIdentifier: identifier) {
+                return data
+            }
+        }
+        return nil
+    }
+
+    private func loadDataRepresentation(
+        from provider: NSItemProvider,
+        typeIdentifier: String
+    ) async -> Data? {
+        await withCheckedContinuation { continuation in
+            provider.loadDataRepresentation(forTypeIdentifier: typeIdentifier) { data, _ in
+                continuation.resume(returning: data)
+            }
+        }
+    }
+
     private func clipboardHasImage() -> Bool {
         let pb = NSPasteboard.general
         return pb.canReadItem(withDataConformingToTypes: [UTType.png.identifier, UTType.tiff.identifier, UTType.jpeg.identifier])
@@ -2406,13 +2532,24 @@ struct NotesView: View {
 
     @ViewBuilder
     private func notesTab(controller: NotesController, state: NotesState, sessionID: String) -> some View {
-        switch state.notesGenerationStatus {
-        case .generating:
-            generatingView(controller: controller, state: state)
-        case .idle, .completed, .error:
-            if state.loadedTranscript.isEmpty {
-                if state.isEditingManualNotes {
-                    notesNoTranscriptState(controller: controller, state: state)
+        notesAssetDropSurface(controller: controller, state: state) {
+            switch state.notesGenerationStatus {
+            case .generating:
+                generatingView(controller: controller, state: state)
+            case .idle, .completed, .error:
+                if state.loadedTranscript.isEmpty {
+                    if state.isEditingManualNotes {
+                        notesNoTranscriptState(controller: controller, state: state)
+                    } else if let notes = state.loadedNotes {
+                        notesContentView(
+                            controller: controller,
+                            notes: notes,
+                            sessionDirectory: state.selectedSessionDirectory,
+                            attachments: state.loadedAttachments
+                        )
+                    } else {
+                        notesNoTranscriptState(controller: controller, state: state)
+                    }
                 } else if let notes = state.loadedNotes {
                     notesContentView(
                         controller: controller,
@@ -2421,17 +2558,61 @@ struct NotesView: View {
                         attachments: state.loadedAttachments
                     )
                 } else {
-                    notesNoTranscriptState(controller: controller, state: state)
+                    notesEmptyState(controller: controller, state: state, sessionID: sessionID)
                 }
-            } else if let notes = state.loadedNotes {
-                notesContentView(
-                    controller: controller,
-                    notes: notes,
-                    sessionDirectory: state.selectedSessionDirectory,
-                    attachments: state.loadedAttachments
-                )
+            }
+        }
+    }
+
+    private func notesAssetDropSurface<Content: View>(
+        controller: NotesController,
+        state: NotesState,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        let canAcceptDrop = state.notesGenerationStatus != .generating && state.selectedSessionID != nil
+
+        return Group {
+            if canAcceptDrop {
+                content()
+                    .contentShape(Rectangle())
+                    .onDrop(
+                        of: notesAssetDropTypeIdentifiers,
+                        isTargeted: $isNotesAssetDropTarget
+                    ) { providers in
+                        handleNotesAssetDrop(providers: providers, controller: controller, state: state)
+                    }
+                    .onPasteCommand(of: notesPasteAssetContentTypes) { providers in
+                        handleNotesAssetPaste(providers: providers, controller: controller, state: state)
+                    }
+                    .overlay {
+                        if isNotesAssetDropTarget {
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color.accentColor.opacity(0.08))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .strokeBorder(Color.accentColor.opacity(0.45), style: StrokeStyle(lineWidth: 1.5, dash: [6, 4]))
+                                )
+                                .padding(12)
+                                .overlay {
+                                    VStack(spacing: 8) {
+                                        Image(systemName: "paperclip.circle.fill")
+                                            .font(.system(size: 22))
+                                            .foregroundStyle(Color.accentColor)
+                                        Text("Drop files or images into notes")
+                                            .font(.system(size: 13, weight: .medium))
+                                            .foregroundStyle(.primary)
+                                    }
+                                    .padding(16)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 12)
+                                            .fill(Color(nsColor: .windowBackgroundColor).opacity(0.95))
+                                    )
+                                }
+                                .allowsHitTesting(false)
+                        }
+                    }
             } else {
-                notesEmptyState(controller: controller, state: state, sessionID: sessionID)
+                content()
             }
         }
     }

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import OpenOatsKit
 
@@ -35,6 +36,17 @@ final class LiveSessionControllerTests: XCTestCase {
             runMigrations: false
         )
         return AppSettings(storage: storage)
+    }
+
+    private func makePNGData() -> Data {
+        let image = NSImage(size: NSSize(width: 2, height: 2))
+        image.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSBezierPath(rect: NSRect(x: 0, y: 0, width: 2, height: 2)).fill()
+        image.unlockFocus()
+
+        let bitmap = NSBitmapImageRep(data: image.tiffRepresentation!)!
+        return bitmap.representation(using: .png, properties: [:])!
     }
 
     private func makeController(
@@ -316,6 +328,93 @@ final class LiveSessionControllerTests: XCTestCase {
         } else {
             XCTFail("Expected recording state after on-demand initialization")
         }
+    }
+
+    func testInsertScratchpadImagePersistsMarkdownAndImage() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings,
+            scripted: [Utterance(text: "Hello", speaker: .you)]
+        )
+
+        controller.startSession(settings: settings)
+
+        var sessionID: String?
+        for _ in 0..<20 {
+            sessionID = await coordinator.sessionRepository.getCurrentSessionID()
+            if sessionID != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        guard let sessionID else {
+            return XCTFail("Expected session ID after starting session")
+        }
+
+        controller.updateScratchpad("Prep observations")
+        controller.insertScratchpadImage(makePNGData())
+        try? await Task.sleep(for: .milliseconds(250))
+
+        let savedScratchpad = await coordinator.sessionRepository.loadScratchpad(sessionID: sessionID)
+        XCTAssertTrue(savedScratchpad.hasPrefix("Prep observations"))
+        XCTAssertTrue(savedScratchpad.contains("![](images/"))
+        XCTAssertEqual(controller.state.scratchpadText, savedScratchpad)
+
+        let imagesDirectory = coordinator.sessionRepository.sessionsDirectoryURL
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("images", isDirectory: true)
+        let imageURLs = (try? FileManager.default.contentsOfDirectory(
+            at: imagesDirectory,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        XCTAssertEqual(imageURLs.count, 1)
+    }
+
+    func testInsertScratchpadImageFilePersistsMarkdownAndImage() async throws {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings,
+            scripted: [Utterance(text: "Hello", speaker: .you)]
+        )
+
+        controller.startSession(settings: settings)
+
+        var sessionID: String?
+        for _ in 0..<20 {
+            sessionID = await coordinator.sessionRepository.getCurrentSessionID()
+            if sessionID != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        guard let sessionID else {
+            return XCTFail("Expected session ID after starting session")
+        }
+
+        let imageURL = dirs.root.appendingPathComponent("clipboard-screenshot.png")
+        try makePNGData().write(to: imageURL)
+
+        controller.updateScratchpad("Prep observations")
+        controller.insertScratchpadAssets([.imageFile(imageURL)])
+        try? await Task.sleep(for: .milliseconds(250))
+
+        let savedScratchpad = await coordinator.sessionRepository.loadScratchpad(sessionID: sessionID)
+        XCTAssertTrue(savedScratchpad.hasPrefix("Prep observations"))
+        XCTAssertTrue(savedScratchpad.contains("![](images/"))
+        XCTAssertEqual(controller.state.scratchpadText, savedScratchpad)
+
+        let imagesDirectory = coordinator.sessionRepository.sessionsDirectoryURL
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("images", isDirectory: true)
+        let imageURLs = (try? FileManager.default.contentsOfDirectory(
+            at: imagesDirectory,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        XCTAssertEqual(imageURLs.count, 1)
     }
 
     func testCoordinatorStartProjectsRunningStateBeforeEngineStarts() {

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import OpenOatsKit
 
@@ -29,6 +30,17 @@ final class NotesControllerTests: XCTestCase {
             runMigrations: false
         )
         return AppSettings(storage: storage)
+    }
+
+    private func makePNGData() -> Data {
+        let image = NSImage(size: NSSize(width: 2, height: 2))
+        image.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSBezierPath(rect: NSRect(x: 0, y: 0, width: 2, height: 2)).fill()
+        image.unlockFocus()
+
+        let bitmap = NSBitmapImageRep(data: image.tiffRepresentation!)!
+        return bitmap.representation(using: .png, properties: [:])!
     }
 
     private func seedSession(
@@ -464,7 +476,7 @@ final class NotesControllerTests: XCTestCase {
 
         controller.startManualNotesEditing()
         controller.updateManualNotesDraft("Prep observations")
-        controller.insertImage(imageData: Data([0x89, 0x50, 0x4E, 0x47]))
+        controller.insertImage(imageData: makePNGData())
         try? await Task.sleep(for: .milliseconds(250))
 
         let savedNotes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
@@ -494,6 +506,80 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertNotNil(savedNotes)
         XCTAssertTrue(savedNotes?.markdown.contains("Prep observations") ?? false)
         XCTAssertTrue(savedNotes?.markdown.contains("[Agenda v2.pdf](attachments/") ?? false)
+        XCTAssertEqual(controller.state.loadedAttachments.map(\.displayName), ["Agenda v2.pdf"])
+    }
+
+    func testImportDroppedItemsPreservesOrderAndDraft() async throws {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_manual_notes_drop"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID, utterances: [])
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        let attachmentURL = root.appendingPathComponent("Agenda v2.pdf")
+        try Data("attachment".utf8).write(to: attachmentURL)
+        let imageURL = root.appendingPathComponent("diagram.png")
+        try makePNGData().write(to: imageURL)
+
+        controller.startManualNotesEditing()
+        controller.updateManualNotesDraft("Prep observations")
+        controller.importDroppedItems([.file(attachmentURL), .file(imageURL)])
+        try? await Task.sleep(for: .milliseconds(350))
+
+        let savedNotes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
+        XCTAssertNotNil(savedNotes)
+        XCTAssertTrue(savedNotes?.markdown.hasPrefix("Prep observations") ?? false)
+        XCTAssertTrue(savedNotes?.markdown.contains("[Agenda v2.pdf](attachments/") ?? false)
+        XCTAssertTrue(savedNotes?.markdown.contains("![](images/") ?? false)
+        let attachmentRange = savedNotes?.markdown.range(of: "[Agenda v2.pdf](attachments/")
+        let imageRange = savedNotes?.markdown.range(of: "![](images/")
+        XCTAssertNotNil(attachmentRange)
+        XCTAssertNotNil(imageRange)
+        if let attachmentRange, let imageRange {
+            XCTAssertLessThan(
+                savedNotes!.markdown.distance(from: savedNotes!.markdown.startIndex, to: attachmentRange.lowerBound),
+                savedNotes!.markdown.distance(from: savedNotes!.markdown.startIndex, to: imageRange.lowerBound)
+            )
+        }
+        XCTAssertEqual(controller.state.loadedAttachments.map(\.displayName), ["Agenda v2.pdf"])
+    }
+
+    func testImportDroppedItemsPreservesMixedDropOrder() async throws {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_manual_notes_mixed_drop"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID, utterances: [])
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+
+        let attachmentURL = root.appendingPathComponent("Agenda v2.pdf")
+        try Data("attachment".utf8).write(to: attachmentURL)
+
+        controller.startManualNotesEditing()
+        controller.updateManualNotesDraft("Prep observations")
+        controller.importDroppedItems([
+            .imageData(makePNGData()),
+            .file(attachmentURL),
+            .imageData(makePNGData()),
+        ])
+        try? await Task.sleep(for: .milliseconds(350))
+
+        let savedNotes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
+        XCTAssertNotNil(savedNotes)
+        let firstImageRange = savedNotes?.markdown.range(of: "![](images/")
+        let attachmentRange = savedNotes?.markdown.range(of: "[Agenda v2.pdf](attachments/")
+        XCTAssertNotNil(firstImageRange)
+        XCTAssertNotNil(attachmentRange)
+        if let firstImageRange, let attachmentRange {
+            XCTAssertLessThan(
+                savedNotes!.markdown.distance(from: savedNotes!.markdown.startIndex, to: firstImageRange.lowerBound),
+                savedNotes!.markdown.distance(from: savedNotes!.markdown.startIndex, to: attachmentRange.lowerBound)
+            )
+        }
+        XCTAssertEqual(savedNotes?.markdown.components(separatedBy: "![](images/").count, 3)
         XCTAssertEqual(controller.state.loadedAttachments.map(\.displayName), ["Agenda v2.pdf"])
     }
 


### PR DESCRIPTION
Closes #550

## Summary
- add drag-and-drop support for files and images in the Notes tab
- add image paste support in both the Notes tab and the live `My Notes` scratchpad
- save pasted and dropped assets into the active session and insert relative Markdown references instead of raw file paths

## Validation
- `swift test --package-path OpenOats --filter NotesControllerTests`
- `swift test --package-path OpenOats --filter LiveSessionControllerTests`
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
