### PR TITLE
Render local note assets as previews in view mode

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/NoteAssetMarkdownParser.swift
+++ b/OpenOats/Sources/OpenOats/Views/NoteAssetMarkdownParser.swift
@@ -1,0 +1,127 @@
+import Foundation
+import UniformTypeIdentifiers
+
+enum NoteAssetMarkdownBlock: Equatable {
+    case text(String)
+    case image(altText: String, relativePath: String)
+    case fileLink(label: String, relativePath: String)
+}
+
+enum NoteAssetMarkdownParser {
+    static func parseBody(_ body: String) -> [NoteAssetMarkdownBlock] {
+        splitParagraphs(body).map(parseParagraph)
+    }
+
+    static func isLocalImagePath(_ relativePath: String) -> Bool {
+        guard case .image = localAssetKind(for: relativePath) else { return false }
+        return true
+    }
+
+    private enum LocalAssetKind {
+        case image
+        case file
+    }
+
+    private static func parseParagraph(_ paragraph: String) -> NoteAssetMarkdownBlock {
+        let trimmed = paragraph.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if let image = parseStandaloneImage(trimmed) {
+            return image
+        }
+
+        if let fileLink = parseStandaloneFileLink(trimmed) {
+            return fileLink
+        }
+
+        return .text(paragraph)
+    }
+
+    private static func splitParagraphs(_ body: String) -> [String] {
+        var paragraphs: [String] = []
+        var currentLines: [String] = []
+
+        for rawLine in body.components(separatedBy: .newlines) {
+            if rawLine.trimmingCharacters(in: .whitespaces).isEmpty {
+                if !currentLines.isEmpty {
+                    paragraphs.append(currentLines.joined(separator: "\n"))
+                    currentLines.removeAll(keepingCapacity: true)
+                }
+            } else {
+                currentLines.append(rawLine)
+            }
+        }
+
+        if !currentLines.isEmpty {
+            paragraphs.append(currentLines.joined(separator: "\n"))
+        }
+
+        return paragraphs
+    }
+
+    private static func parseStandaloneImage(_ text: String) -> NoteAssetMarkdownBlock? {
+        guard let (label, path) = parseMarkdownLink(text, image: true),
+              case .image = localAssetKind(for: path) else {
+            return nil
+        }
+
+        return .image(altText: label, relativePath: path)
+    }
+
+    private static func parseStandaloneFileLink(_ text: String) -> NoteAssetMarkdownBlock? {
+        guard let (label, path) = parseMarkdownLink(text, image: false),
+              let assetKind = localAssetKind(for: path) else {
+            return nil
+        }
+
+        switch assetKind {
+        case .image:
+            return .image(altText: label, relativePath: path)
+        case .file:
+            return .fileLink(label: label, relativePath: path)
+        }
+    }
+
+    private static func parseMarkdownLink(_ text: String, image: Bool) -> (String, String)? {
+        let prefix = image ? "![" : "["
+        guard text.hasPrefix(prefix), text.hasSuffix(")") else { return nil }
+
+        let labelStart = text.index(text.startIndex, offsetBy: prefix.count)
+        guard let separatorRange = text[labelStart...].range(of: "]("),
+              separatorRange.upperBound < text.endIndex else {
+            return nil
+        }
+
+        let label = String(text[labelStart..<separatorRange.lowerBound])
+        let pathEnd = text.index(before: text.endIndex)
+        let path = String(text[separatorRange.upperBound..<pathEnd])
+        guard !path.isEmpty else { return nil }
+        return (label, path)
+    }
+
+    private static func localAssetKind(for relativePath: String) -> LocalAssetKind? {
+        let trimmed = relativePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              !trimmed.contains("://"),
+              !trimmed.hasPrefix("/") else {
+            return nil
+        }
+
+        let components = trimmed.split(separator: "/", omittingEmptySubsequences: false)
+        guard !components.isEmpty,
+              !components.contains(".."),
+              !components.contains(".") else {
+            return nil
+        }
+
+        guard trimmed.hasPrefix("images/") || trimmed.hasPrefix("attachments/") else {
+            return nil
+        }
+
+        if let type = UTType(filenameExtension: URL(fileURLWithPath: trimmed).pathExtension),
+           type.conforms(to: .image) {
+            return .image
+        }
+
+        return .file
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -3314,7 +3314,7 @@ struct NotesView: View {
 
     @ViewBuilder
     private func sectionBodyView(_ body: String, sessionDirectory: URL?) -> some View {
-        let blocks = parseBodyBlocks(body)
+        let blocks = NoteAssetMarkdownParser.parseBody(body)
         ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
             switch block {
             case .text(let text):
@@ -3329,56 +3329,140 @@ struct NotesView: View {
                         .textSelection(.enabled)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-            case .image(let path):
-                if let dir = sessionDirectory,
-                   let nsImage = NSImage(contentsOf: dir.appendingPathComponent(path)) {
+            case .image(let altText, let relativePath):
+                localImagePreview(relativePath: relativePath, altText: altText, sessionDirectory: sessionDirectory)
+            case .fileLink(let label, let relativePath):
+                localAttachmentPreview(label: label, relativePath: relativePath, sessionDirectory: sessionDirectory)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func localImagePreview(
+        relativePath: String,
+        altText: String,
+        sessionDirectory: URL?
+    ) -> some View {
+        if let url = resolvedSessionAssetURL(relativePath: relativePath, sessionDirectory: sessionDirectory),
+           let nsImage = NSImage(contentsOf: url) {
+            VStack(alignment: .leading, spacing: 8) {
+                Button {
+                    NSWorkspace.shared.open(url)
+                } label: {
                     Image(nsImage: nsImage)
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(maxWidth: 500, maxHeight: 400)
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                } else {
-                    Label("Image not found", systemImage: "photo")
-                        .font(.system(size: 12))
+                        .frame(maxWidth: 420, maxHeight: 280)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+                .buttonStyle(.plain)
+                .help("Open image")
+
+                HStack(spacing: 8) {
+                    Image(systemName: "photo")
+                        .font(.system(size: 11))
                         .foregroundStyle(.secondary)
+                    Text(imagePreviewCaption(altText: altText, url: url))
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                    Button {
+                        NSWorkspace.shared.activateFileViewerSelecting([url])
+                    } label: {
+                        Image(systemName: "folder")
+                            .font(.system(size: 11))
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+                    .help("Reveal in Finder")
                 }
             }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(.quaternary, lineWidth: 1)
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            missingAssetLabel("Image not found", systemImage: "photo")
         }
     }
 
-    private enum BodyBlock {
-        case text(String)
-        case image(path: String)
+    @ViewBuilder
+    private func localAttachmentPreview(
+        label: String,
+        relativePath: String,
+        sessionDirectory: URL?
+    ) -> some View {
+        if let url = resolvedSessionAssetURL(relativePath: relativePath, sessionDirectory: sessionDirectory) {
+            Button {
+                NSWorkspace.shared.open(url)
+            } label: {
+                HStack(spacing: 10) {
+                    Image(nsImage: NSWorkspace.shared.icon(forFile: url.path))
+                        .resizable()
+                        .frame(width: 22, height: 22)
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(label.isEmpty ? url.lastPathComponent : label)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.primary)
+                            .lineLimit(1)
+                        Text(url.lastPathComponent)
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    Image(systemName: "arrow.up.forward.app")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color(nsColor: .controlBackgroundColor))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .strokeBorder(.quaternary, lineWidth: 1)
+                )
+            }
+            .buttonStyle(.plain)
+            .help("Open attachment")
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            missingAssetLabel("Attachment not found", systemImage: "paperclip")
+        }
     }
 
-    private func parseBodyBlocks(_ body: String) -> [BodyBlock] {
-        var blocks: [BodyBlock] = []
-        var scanner = body[...]
-
-        while let imgStart = scanner.range(of: "![") {
-            let before = String(scanner[scanner.startIndex..<imgStart.lowerBound])
-            if !before.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                blocks.append(.text(before))
-            }
-
-            let afterBracket = scanner[imgStart.upperBound...]
-            guard let closeBracket = afterBracket.range(of: "]("),
-                  let closeParen = afterBracket[closeBracket.upperBound...].range(of: ")") else {
-                blocks.append(.text(String(scanner)))
-                return blocks
-            }
-
-            let path = String(afterBracket[closeBracket.upperBound..<closeParen.lowerBound])
-            blocks.append(.image(path: path))
-            scanner = afterBracket[closeParen.upperBound...]
+    private func resolvedSessionAssetURL(relativePath: String, sessionDirectory: URL?) -> URL? {
+        guard let sessionDirectory else { return nil }
+        let baseURL = sessionDirectory.standardizedFileURL
+        let assetURL = baseURL.appendingPathComponent(relativePath).standardizedFileURL
+        guard assetURL.path.hasPrefix(baseURL.path + "/") || assetURL.path == baseURL.path else {
+            return nil
         }
+        return assetURL
+    }
 
-        let tail = String(scanner)
-        if !tail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            blocks.append(.text(tail))
-        }
+    private func imagePreviewCaption(altText: String, url: URL) -> String {
+        let trimmedAltText = altText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedAltText.isEmpty ? url.lastPathComponent : trimmedAltText
+    }
 
-        return blocks
+    private func missingAssetLabel(_ text: String, systemImage: String) -> some View {
+        Label(text, systemImage: systemImage)
+            .font(.system(size: 12))
+            .foregroundStyle(.secondary)
     }
 
     private struct MarkdownSection {

--- a/OpenOats/Tests/OpenOatsTests/NoteAssetMarkdownParserTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NoteAssetMarkdownParserTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class NoteAssetMarkdownParserTests: XCTestCase {
+    func testParseBodyKeepsPlainTextParagraphs() {
+        let blocks = NoteAssetMarkdownParser.parseBody("First paragraph\nwith two lines.\n\nSecond paragraph")
+
+        XCTAssertEqual(
+            blocks,
+            [
+                .text("First paragraph\nwith two lines."),
+                .text("Second paragraph"),
+            ]
+        )
+    }
+
+    func testParseBodyPromotesStandaloneImageMarkdown() {
+        let blocks = NoteAssetMarkdownParser.parseBody("Before\n\n![Whiteboard](images/diagram.png)\n\nAfter")
+
+        XCTAssertEqual(
+            blocks,
+            [
+                .text("Before"),
+                .image(altText: "Whiteboard", relativePath: "images/diagram.png"),
+                .text("After"),
+            ]
+        )
+    }
+
+    func testParseBodyPromotesStandaloneLocalAttachmentLinks() {
+        let blocks = NoteAssetMarkdownParser.parseBody("[Spec Deck](attachments/spec-deck.pdf)")
+
+        XCTAssertEqual(
+            blocks,
+            [
+                .fileLink(label: "Spec Deck", relativePath: "attachments/spec-deck.pdf"),
+            ]
+        )
+    }
+
+    func testParseBodyPromotesImageAttachmentsAsImages() {
+        let blocks = NoteAssetMarkdownParser.parseBody("[Mockup](attachments/mockup.png)")
+
+        XCTAssertEqual(
+            blocks,
+            [
+                .image(altText: "Mockup", relativePath: "attachments/mockup.png"),
+            ]
+        )
+    }
+
+    func testParseBodyLeavesInlineLinksInsideTextUntouched() {
+        let blocks = NoteAssetMarkdownParser.parseBody("See [Spec Deck](attachments/spec-deck.pdf) before Friday.")
+
+        XCTAssertEqual(
+            blocks,
+            [
+                .text("See [Spec Deck](attachments/spec-deck.pdf) before Friday."),
+            ]
+        )
+    }
+
+    func testParseBodyRejectsTraversalPaths() {
+        let blocks = NoteAssetMarkdownParser.parseBody("[Bad](attachments/../secret.txt)")
+
+        XCTAssertEqual(
+            blocks,
+            [
+                .text("[Bad](attachments/../secret.txt)"),
+            ]
+        )
+    }
+}


### PR DESCRIPTION
Closes #553

## Summary
- render standalone local images in notes as inline thumbnails in view mode
- render standalone local attachment links as attachment cards with open/reveal actions
- keep inline links inside normal text paragraphs unchanged

## Validation
- swift test --package-path OpenOats --filter NoteAssetMarkdownParserTests
- swift test --package-path OpenOats --filter NotesControllerTests
- swift build -c debug --package-path OpenOats
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh