### PR TITLE
Bump Homebrew cask to v1.73.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.72.1"
-  sha256 "b74ee3654fe095e3536337aa53a58f184cfcb46588da4a2f5a865aca2566d1da"
+  version "1.73.0"
+  sha256 "937d3235b1038174c7a7b7b9dc0f83e26ead0d25bd25a812da19b2a4631235a2"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Update Homebrew cask version from 1.72.1 to 1.73.0
- Update sha256 checksum for the new DMG