### PR TITLE
Prepare AVAudioEngine before accessing inputNode audioUnit

### DIFF
--- a/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/MicCapture.swift
@@ -79,6 +79,8 @@ final class MicCapture: @unchecked Sendable {
                 }
             }
 
+            engine.prepare()
+
             // Set input device before accessing inputNode format
             var resolvedDeviceID: AudioDeviceID?
             if let id = deviceID {


### PR DESCRIPTION
Fixes #555

## Summary
- Add missing `engine.prepare()` call before accessing `inputNode.audioUnit` in `MicCapture.bufferStream()`

## Root cause
On macOS 26.4+, `inputNode.audioUnit` returns `nil` when the engine hasn't been prepared. The guard clause at line 85 catches this and finishes the stream early — before `engine.start()` is ever called. Since `engine.start()` is what triggers the TCC microphone permission prompt, the prompt never fires and zero audio frames are captured.

The existing error message ("inputNode has no audio unit after prepare") confirms `prepare()` was intended to be called beforehand but was missing.

## Validation
- `swift build -c debug --package-path OpenOats` — passes
- `swift test --package-path OpenOats` — 615 tests pass, 0 failures