### PR TITLE
Improve cloud live responsiveness during chunk processing

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -1065,20 +1065,28 @@ final class LiveSessionController {
 
     static func liveTranscriptNotice(
         for model: TranscriptionModel,
-        issue: CloudTranscriptCopy.Presentation? = nil
+        issue: CloudTranscriptCopy.Presentation? = nil,
+        isProcessing: Bool = false
     ) -> String? {
         if let issue {
             return issue.title
+        }
+        if isProcessing {
+            return CloudTranscriptCopy.processingChunk.title
         }
         return CloudTranscriptCopy.steadyStateNotice(for: model)
     }
 
     static func liveTranscriptEmptyStateMessage(
         for model: TranscriptionModel,
-        issue: CloudTranscriptCopy.Presentation? = nil
+        issue: CloudTranscriptCopy.Presentation? = nil,
+        isProcessing: Bool = false
     ) -> String? {
         if let issue {
             return issue.detail
+        }
+        if isProcessing {
+            return CloudTranscriptCopy.processingChunk.detail
         }
         return CloudTranscriptCopy.waitingMessage(for: model)
     }
@@ -1170,6 +1178,7 @@ final class LiveSessionController {
         let engineIsRunning = coordinator.transcriptionEngine?.isRunning ?? false
         let activeTranscriptionModel = coordinator.transcriptionEngine?.currentTranscriptionModel() ?? settings.transcriptionModel
         let liveCloudIssue = coordinator.transcriptionEngine?.liveCloudTranscriptIssue
+        let liveCloudIsProcessing = coordinator.transcriptionEngine?.liveCloudTranscriptionIsProcessing ?? false
         let isRunning: Bool
         let matchedCalendarEvent: CalendarEvent?
         switch lifecycleState {
@@ -1215,8 +1224,8 @@ final class LiveSessionController {
         set(\.transcriptionPrompt, settings.transcriptionModel.downloadPrompt)
         set(\.modelDisplayName, activeModelRaw.split(separator: "/").last.map(String.init) ?? activeModelRaw)
         set(\.showLiveTranscript, settings.showLiveTranscript)
-        set(\.liveTranscriptNotice, isRunning ? Self.liveTranscriptNotice(for: activeTranscriptionModel, issue: liveCloudIssue) : nil)
-        set(\.liveTranscriptEmptyStateMessage, isRunning ? Self.liveTranscriptEmptyStateMessage(for: activeTranscriptionModel, issue: liveCloudIssue) : nil)
+        set(\.liveTranscriptNotice, isRunning ? Self.liveTranscriptNotice(for: activeTranscriptionModel, issue: liveCloudIssue, isProcessing: liveCloudIsProcessing) : nil)
+        set(\.liveTranscriptEmptyStateMessage, isRunning ? Self.liveTranscriptEmptyStateMessage(for: activeTranscriptionModel, issue: liveCloudIssue, isProcessing: liveCloudIsProcessing) : nil)
         set(\.isMicMuted, coordinator.transcriptionEngine?.isMicMuted ?? false)
         set(\.isRecordingPaused, coordinator.transcriptionEngine?.isRecordingPaused ?? false)
         // scratchpadText is managed by updateScratchpad(), not refreshed from coordinator

--- a/OpenOats/Sources/OpenOats/Transcription/CloudTranscriptCopy.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/CloudTranscriptCopy.swift
@@ -17,6 +17,11 @@ struct CloudTranscriptCopy {
         return "Waiting for transcript chunk…"
     }
 
+    static let processingChunk = Presentation(
+        title: "Processing transcript chunk…",
+        detail: "Cloud transcription is working on the latest chunk."
+    )
+
     static let emptyChunk = Presentation(
         title: "Latest chunk returned no text",
         detail: "OpenOats is still listening for the next chunk."

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
@@ -40,6 +40,7 @@ final class StreamingTranscriber: @unchecked Sendable {
     private let onPartial: @Sendable (String) -> Void
     private let onFinal: @Sendable (String) -> Void
     private let onCloudSegmentStatus: (@Sendable (CloudSegmentStatus) -> Void)?
+    private let onCloudProcessingChanged: (@Sendable (Bool) -> Void)?
 
     /// Resampler from source format to 16kHz mono Float32.
     private var converter: AVAudioConverter?
@@ -86,7 +87,8 @@ final class StreamingTranscriber: @unchecked Sendable {
         skipPartials: Bool = false,
         onPartial: @escaping @Sendable (String) -> Void,
         onFinal: @escaping @Sendable (String) -> Void,
-        onCloudSegmentStatus: (@Sendable (CloudSegmentStatus) -> Void)? = nil
+        onCloudSegmentStatus: (@Sendable (CloudSegmentStatus) -> Void)? = nil,
+        onCloudProcessingChanged: (@Sendable (Bool) -> Void)? = nil
     ) {
         self.backend = backend
         self.locale = locale
@@ -99,6 +101,7 @@ final class StreamingTranscriber: @unchecked Sendable {
         self.onPartial = onPartial
         self.onFinal = onFinal
         self.onCloudSegmentStatus = onCloudSegmentStatus
+        self.onCloudProcessingChanged = onCloudProcessingChanged
     }
 
     /// Silero VAD expects chunks of 4096 samples (256ms at 16kHz).
@@ -113,6 +116,7 @@ final class StreamingTranscriber: @unchecked Sendable {
 
     /// Main loop: reads audio buffers, runs VAD, transcribes speech segments.
     func run(stream: AsyncStream<AVAudioPCMBuffer>) async {
+        let segmentQueue = makeSegmentQueueIfNeeded()
         var vadState = await vadManager.makeStreamState()
         var speechSamples: [Float] = []
         var vadBuffer: [Float] = []
@@ -199,7 +203,7 @@ final class StreamingTranscriber: @unchecked Sendable {
                             let segment = speechSamples
                             speechSamples.removeAll(keepingCapacity: true)
                             onPartial("")  // Clear partial display
-                            await transcribeSegment(segment)
+                            await submitSegment(segment, using: segmentQueue)
                         } else {
                             speechSamples.removeAll(keepingCapacity: true)
                             onPartial("")  // Clear partial display
@@ -232,7 +236,7 @@ final class StreamingTranscriber: @unchecked Sendable {
                             let segment = speechSamples
                             speechSamples.removeAll(keepingCapacity: true)
                             onPartial("")  // Clear partial display
-                            await transcribeSegment(segment)
+                            await submitSegment(segment, using: segmentQueue)
                         }
                     }
                 } catch {
@@ -243,12 +247,40 @@ final class StreamingTranscriber: @unchecked Sendable {
 
         if speechSamples.count > Self.minimumSpeechSamples {
             onPartial("")  // Clear partial display
-            await transcribeSegment(speechSamples)
+            await submitSegment(speechSamples, using: segmentQueue)
+        }
+
+        if let segmentQueue {
+            if Task.isCancelled {
+                await segmentQueue.cancel()
+            } else {
+                await segmentQueue.finish()
+            }
         }
     }
 
     /// Trailing words from the last transcribed segment, used to prime the next segment's decoder.
     private var previousContext: String?
+
+    private func makeSegmentQueueIfNeeded() -> StreamingTranscriptionSegmentQueue? {
+        guard skipPartials else { return nil }
+        return StreamingTranscriptionSegmentQueue(
+            onProcessingChanged: onCloudProcessingChanged
+        ) { [self] segment in
+            await transcribeSegment(segment)
+        }
+    }
+
+    private func submitSegment(
+        _ samples: [Float],
+        using queue: StreamingTranscriptionSegmentQueue?
+    ) async {
+        if let queue {
+            await queue.enqueue(samples)
+        } else {
+            await transcribeSegment(samples)
+        }
+    }
 
     private func transcribeSegment(_ samples: [Float]) async {
         let startedAt = Date()

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriptionSegmentQueue.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriptionSegmentQueue.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Serializes asynchronous segment processing without blocking the capture loop.
+final class StreamingTranscriptionSegmentQueue: @unchecked Sendable {
+    private actor State {
+        private var pendingCount = 0
+
+        func didEnqueue() -> Bool {
+            let becameActive = pendingCount == 0
+            pendingCount += 1
+            return becameActive
+        }
+
+        func didComplete() -> Bool {
+            pendingCount = max(0, pendingCount - 1)
+            return pendingCount == 0
+        }
+
+        func reset() {
+            pendingCount = 0
+        }
+    }
+
+    private let state = State()
+    private let continuation: AsyncStream<[Float]>.Continuation
+    private let workerTask: Task<Void, Never>
+    private let onProcessingChanged: (@Sendable (Bool) -> Void)?
+
+    init(
+        onProcessingChanged: (@Sendable (Bool) -> Void)? = nil,
+        process: @escaping @Sendable ([Float]) async -> Void
+    ) {
+        let (stream, continuation) = AsyncStream<[Float]>.makeStream()
+        let state = self.state
+        self.continuation = continuation
+        self.onProcessingChanged = onProcessingChanged
+        self.workerTask = Task {
+            for await segment in stream {
+                guard !Task.isCancelled else { break }
+                await process(segment)
+                if let onProcessingChanged, await state.didComplete() {
+                    onProcessingChanged(false)
+                }
+            }
+        }
+    }
+
+    func enqueue(_ samples: [Float]) async {
+        if let onProcessingChanged, await state.didEnqueue() {
+            onProcessingChanged(true)
+        }
+        continuation.yield(samples)
+    }
+
+    func finish() async {
+        continuation.finish()
+        await workerTask.value
+    }
+
+    func cancel() async {
+        workerTask.cancel()
+        continuation.finish()
+        await workerTask.value
+        await state.reset()
+        onProcessingChanged?(false)
+    }
+}

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -113,6 +113,12 @@ final class TranscriptionEngine {
         set { withMutation(keyPath: \.liveCloudTranscriptIssue) { _liveCloudTranscriptIssue = newValue } }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _liveCloudTranscriptionIsProcessing = false
+    var liveCloudTranscriptionIsProcessing: Bool {
+        get { access(keyPath: \.liveCloudTranscriptionIsProcessing); return _liveCloudTranscriptionIsProcessing }
+        set { withMutation(keyPath: \.liveCloudTranscriptionIsProcessing) { _liveCloudTranscriptionIsProcessing = newValue } }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _needsModelDownload = false
     var needsModelDownload: Bool {
         get { access(keyPath: \.needsModelDownload); return _needsModelDownload }
@@ -248,6 +254,7 @@ final class TranscriptionEngine {
 
         lastError = nil
         liveCloudTranscriptIssue = nil
+        liveCloudTranscriptionIsProcessing = false
         preparedCloudStartBackend = nil
 
         if let inputIssue = validateConfiguredInputDevice() {
@@ -322,6 +329,7 @@ final class TranscriptionEngine {
 
         lastError = nil
         liveCloudTranscriptIssue = nil
+        liveCloudTranscriptionIsProcessing = false
         assetStatus = "Downloading \(transcriptionModel.displayName)..."
         beginDownloadTracking(for: transcriptionModel)
 
@@ -355,6 +363,7 @@ final class TranscriptionEngine {
         guard !isRunning, downloadProgress == nil else { return }
         lastError = nil
         liveCloudTranscriptIssue = nil
+        liveCloudTranscriptionIsProcessing = false
         refreshModelAvailability()
 
         if case .scripted(let scriptedUtterances) = mode {
@@ -731,6 +740,7 @@ final class TranscriptionEngine {
         transcriptStore.volatileYouText = ""
         transcriptStore.volatileThemText = ""
         liveCloudTranscriptIssue = nil
+        liveCloudTranscriptionIsProcessing = false
         preparedCloudStartBackend = nil
         activeTranscriptionSession = nil
         isRunning = false
@@ -743,6 +753,8 @@ final class TranscriptionEngine {
             assetStatus = "Ready"
             transcriptStore.volatileYouText = ""
             transcriptStore.volatileThemText = ""
+            liveCloudTranscriptIssue = nil
+            liveCloudTranscriptionIsProcessing = false
             return
         }
 
@@ -769,6 +781,7 @@ final class TranscriptionEngine {
         transcriptStore.volatileYouText = ""
         transcriptStore.volatileThemText = ""
         liveCloudTranscriptIssue = nil
+        liveCloudTranscriptionIsProcessing = false
         preparedCloudStartBackend = nil
         activeTranscriptionSession = nil
         isRunning = false
@@ -1038,7 +1051,8 @@ final class TranscriptionEngine {
             skipPartials: model.isCloud,
             onPartial: onPartial,
             onFinal: onFinal,
-            onCloudSegmentStatus: makeCloudSegmentStatusHandler(for: model)
+            onCloudSegmentStatus: makeCloudSegmentStatusHandler(for: model),
+            onCloudProcessingChanged: makeCloudProcessingChangedHandler(for: model)
         )
     }
 
@@ -1049,6 +1063,17 @@ final class TranscriptionEngine {
         return { [weak self] status in
             Task { @MainActor [weak self] in
                 self?.handleCloudSegmentStatus(status)
+            }
+        }
+    }
+
+    private func makeCloudProcessingChangedHandler(
+        for model: TranscriptionModel
+    ) -> (@Sendable (Bool) -> Void)? {
+        guard model.isCloud else { return nil }
+        return { [weak self] isProcessing in
+            Task { @MainActor [weak self] in
+                self?.liveCloudTranscriptionIsProcessing = isProcessing
             }
         }
     }

--- a/OpenOats/Tests/OpenOatsTests/StreamingTranscriptionSegmentQueueTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/StreamingTranscriptionSegmentQueueTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class StreamingTranscriptionSegmentQueueTests: XCTestCase {
+    func testQueueProcessesSegmentsInOrder() async {
+        let recorder = SegmentQueueRecorder()
+        let queue = StreamingTranscriptionSegmentQueue { segment in
+            await recorder.record(segment)
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        await queue.enqueue([1, 2])
+        await queue.enqueue([3, 4])
+        await queue.enqueue([5, 6])
+        await queue.finish()
+
+        let processed = await recorder.processedSegments
+        XCTAssertEqual(processed, [[1, 2], [3, 4], [5, 6]])
+    }
+
+    func testQueueSignalsProcessingLifecycle() async {
+        let stateRecorder = SegmentQueueStateRecorder()
+        let expectation = XCTestExpectation(description: "processing lifecycle")
+        expectation.expectedFulfillmentCount = 2
+        let queue = StreamingTranscriptionSegmentQueue(
+            onProcessingChanged: { isProcessing in
+                Task {
+                    await stateRecorder.record(isProcessing)
+                    expectation.fulfill()
+                }
+            },
+            process: { _ in
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+        )
+
+        await queue.enqueue([1])
+        await queue.enqueue([2])
+        await queue.finish()
+        await fulfillment(of: [expectation], timeout: 1.0)
+
+        let recordedStates = await stateRecorder.states
+        XCTAssertEqual(recordedStates, [true, false])
+    }
+}
+
+private actor SegmentQueueRecorder {
+    private(set) var processedSegments: [[Float]] = []
+
+    func record(_ segment: [Float]) {
+        processedSegments.append(segment)
+    }
+}
+
+private actor SegmentQueueStateRecorder {
+    private(set) var states: [Bool] = []
+
+    func record(_ isProcessing: Bool) {
+        states.append(isProcessing)
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift
@@ -139,6 +139,23 @@ final class TranscriptionEngineTests: XCTestCase {
         XCTAssertEqual(presentation.title, "ElevenLabs API key rejected")
         XCTAssertEqual(presentation.detail, "Check Settings > Transcription.")
     }
+
+    func testLiveTranscriptCopyShowsProcessingStateWhenCloudChunkIsInFlight() {
+        XCTAssertEqual(
+            LiveSessionController.liveTranscriptNotice(
+                for: .elevenLabsScribe,
+                isProcessing: true
+            ),
+            CloudTranscriptCopy.processingChunk.title
+        )
+        XCTAssertEqual(
+            LiveSessionController.liveTranscriptEmptyStateMessage(
+                for: .elevenLabsScribe,
+                isProcessing: true
+            ),
+            CloudTranscriptCopy.processingChunk.detail
+        )
+    }
 }
 
 // MARK: - Test Helpers


### PR DESCRIPTION
Closes #558

## Summary
- decouple cloud chunk transcription from the live capture/VAD loop
- keep cloud chunk processing serialized in the background instead of blocking live capture
- show a clearer in-meeting distinction between waiting for the first chunk and actively processing a chunk

## Validation
- swift build -c debug --package-path OpenOats
- swift test --package-path OpenOats --filter StreamingTranscriptionSegmentQueueTests
- swift test --package-path OpenOats --filter TranscriptionEngineTests
- swift test --package-path OpenOats --filter LiveSessionControllerTests
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh

## Scope note
This improves responsiveness and status handling. It does **not** fully solve transcript lag when cloud latency is slower than incoming speech. A follow-up should add queue backlog policy and then revisit chunk cadence with real measurements.
