### PR TITLE
Show meeting readiness signals in the idle dashboard

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -316,6 +316,7 @@ struct ContentView: View {
             overlayManager.defaults = container.defaults
             miniBarManager.defaults = container.defaults
             await container.seedIfNeeded(coordinator: coordinator)
+            await coordinator.loadHistory()
             controller.handlePendingExternalCommandIfPossible(settings: settings) {
                 openWindow(id: "notes")
             }

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -651,6 +651,12 @@ private struct ComingUpEventRow: View {
     @State private var isHovering = false
     @State private var isFolderHovering = false
     var body: some View {
+        let readiness = UpcomingMeetingReadiness.resolve(
+            for: event,
+            settings: settings,
+            sessionHistory: sessionHistory
+        )
+
         HStack(alignment: .center, spacing: 8) {
             Button(action: {
                 onOpenRelatedNotes(event)
@@ -658,7 +664,7 @@ private struct ComingUpEventRow: View {
                 HStack(alignment: .top, spacing: 10) {
                     RoundedRectangle(cornerRadius: 2)
                         .fill(calendarColor(for: event))
-                        .frame(width: 4, height: 34)
+                        .frame(width: 4, height: 44)
 
                     VStack(alignment: .leading, spacing: 2) {
                         Text(event.title)
@@ -668,6 +674,11 @@ private struct ComingUpEventRow: View {
                             .font(.system(size: 13))
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
+                        Text(readiness.summaryText)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .accessibilityIdentifier("idle.comingUp.readiness.\(event.id)")
                     }
 
                     Spacer(minLength: 0)
@@ -687,7 +698,7 @@ private struct ComingUpEventRow: View {
             .help("Open meeting history")
             .accessibilityIdentifier("idle.comingUp.event.\(event.id)")
 
-            folderMenu
+            folderMenu(readiness: readiness)
 
             if showJoinButton, event.meetingURL != nil {
                 Button(action: {
@@ -709,7 +720,7 @@ private struct ComingUpEventRow: View {
         }
     }
 
-    private var folderMenu: some View {
+    private func folderMenu(readiness: UpcomingMeetingReadiness) -> some View {
         let preferredFolderPath = settings.meetingFamilyPreferences(for: event)?.folderPath
         let choices = meetingFamilyFolderChoices(including: preferredFolderPath)
 
@@ -792,7 +803,7 @@ private struct ComingUpEventRow: View {
         .onHover { hovering in
             isFolderHovering = hovering
         }
-        .help(folderHelpText(for: preferredFolderPath))
+        .help(folderHelpText(for: preferredFolderPath, historyCount: readiness.historyCount))
         .accessibilityIdentifier("idle.comingUp.folder.\(event.id)")
     }
 
@@ -814,16 +825,11 @@ private struct ComingUpEventRow: View {
         return color
     }
 
-    private func folderHelpText(for preferredFolderPath: String?) -> String {
-        let matchingHistoryCount = MeetingHistoryResolver.matchingSessions(
-            forHistoryKey: settings.canonicalMeetingHistoryKey(for: event),
-            sessionHistory: sessionHistory,
-            aliases: settings.meetingHistoryAliasesByKey
-        ).count
+    private func folderHelpText(for preferredFolderPath: String?, historyCount: Int) -> String {
         let base = "Default folder: \(folderDisplayName(for: preferredFolderPath))"
-        guard matchingHistoryCount > 0 else { return base }
-        let noun = matchingHistoryCount == 1 ? "saved meeting" : "saved meetings"
-        return "\(base). \(matchingHistoryCount) \(noun) already exist for this meeting family."
+        guard historyCount > 0 else { return base }
+        let noun = historyCount == 1 ? "saved meeting" : "saved meetings"
+        return "\(base). \(historyCount) \(noun) already exist for this meeting family."
     }
 
     private func meetingFamilyFolderChoices(including preferredFolderPath: String?) -> [NotesFolderDefinition] {
@@ -884,6 +890,53 @@ private struct ComingUpEventRow: View {
         case .red:
             return .red
         }
+    }
+}
+
+struct UpcomingMeetingReadiness: Equatable {
+    let historyCount: Int
+    let folderPath: String?
+
+    var summaryText: String {
+        var parts = [historySummaryText]
+        if let folderSummaryText {
+            parts.append(folderSummaryText)
+        }
+        return parts.joined(separator: "  •  ")
+    }
+
+    var historySummaryText: String {
+        switch historyCount {
+        case 0:
+            return "No history"
+        case 1:
+            return "1 previous"
+        default:
+            return "\(historyCount) previous"
+        }
+    }
+
+    var folderSummaryText: String? {
+        guard let folderPath else { return nil }
+        return "Folder: \(folderPath.replacingOccurrences(of: "/", with: " › "))"
+    }
+
+    @MainActor
+    static func resolve(
+        for event: CalendarEvent,
+        settings: AppSettings,
+        sessionHistory: [SessionIndex]
+    ) -> UpcomingMeetingReadiness {
+        let historyCount = MeetingHistoryResolver.matchingSessions(
+            for: event,
+            sessionHistory: sessionHistory,
+            aliases: settings.meetingHistoryAliasesByKey
+        ).count
+        let folderPath = settings.meetingFamilyPreferences(for: event)?.folderPath
+        return UpcomingMeetingReadiness(
+            historyCount: historyCount,
+            folderPath: folderPath
+        )
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -898,11 +898,7 @@ struct UpcomingMeetingReadiness: Equatable {
     let folderPath: String?
 
     var summaryText: String {
-        var parts = [historySummaryText]
-        if let folderSummaryText {
-            parts.append(folderSummaryText)
-        }
-        return parts.joined(separator: "  •  ")
+        historySummaryText
     }
 
     var historySummaryText: String {
@@ -915,12 +911,6 @@ struct UpcomingMeetingReadiness: Equatable {
             return "\(historyCount) previous"
         }
     }
-
-    var folderSummaryText: String? {
-        guard let folderPath else { return nil }
-        return "Folder: \(folderPath.replacingOccurrences(of: "/", with: " › "))"
-    }
-
     @MainActor
     static func resolve(
         for event: CalendarEvent,

--- a/OpenOats/Tests/OpenOatsTests/IdleHomeDashboardReadinessTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/IdleHomeDashboardReadinessTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import OpenOatsKit
+
+@MainActor
+final class IdleHomeDashboardReadinessTests: XCTestCase {
+    private func makeSettings() -> AppSettings {
+        let suiteName = "com.openoats.tests.idle-dashboard.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let storage = AppSettingsStorage(
+            defaults: defaults,
+            secretStore: .ephemeral,
+            defaultNotesDirectory: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("IdleDashboardReadinessTests"),
+            runMigrations: false
+        )
+        return AppSettings(storage: storage)
+    }
+
+    func testResolveReportsNoHistoryWhenMeetingFamilyHasNoSavedSessions() {
+        let settings = makeSettings()
+        let event = makeEvent(id: "evt-1", title: "Product Planning")
+
+        let readiness = UpcomingMeetingReadiness.resolve(
+            for: event,
+            settings: settings,
+            sessionHistory: []
+        )
+
+        XCTAssertEqual(readiness.historyCount, 0)
+        XCTAssertNil(readiness.folderPath)
+        XCTAssertEqual(readiness.summaryText, "No history")
+    }
+
+    func testResolveIncludesHistoryCountAndFolderPath() {
+        let settings = makeSettings()
+        let event = makeEvent(
+            id: "evt-2",
+            title: "Payment Ops / Merchant stand up",
+            externalIdentifier: "series-merchant-standup"
+        )
+        settings.notesFolders = [
+            NotesFolderDefinition(path: "Work/Standups", color: .orange)
+        ]
+        settings.setMeetingFamilyFolderPreference("Work/Standups", for: event)
+
+        let startedAt = Date(timeIntervalSince1970: 1_700_000_000)
+        let sessionHistory = [
+            SessionIndex(
+                id: "older",
+                startedAt: startedAt.addingTimeInterval(-600),
+                endedAt: nil,
+                templateSnapshot: nil,
+                title: "Payment Ops Merchant stand-up",
+                utteranceCount: 8,
+                hasNotes: true,
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                tags: nil,
+                source: nil,
+                meetingFamilyKey: MeetingHistoryResolver.seriesHistoryKey(forExternalIdentifier: "series-merchant-standup")
+            ),
+            SessionIndex(
+                id: "newer",
+                startedAt: startedAt.addingTimeInterval(-120),
+                endedAt: nil,
+                templateSnapshot: nil,
+                title: "Merchant standup",
+                utteranceCount: 5,
+                hasNotes: false,
+                language: nil,
+                meetingApp: nil,
+                engine: nil,
+                tags: nil,
+                source: nil,
+                meetingFamilyKey: MeetingHistoryResolver.seriesHistoryKey(forExternalIdentifier: "series-merchant-standup")
+            ),
+        ]
+
+        let readiness = UpcomingMeetingReadiness.resolve(
+            for: event,
+            settings: settings,
+            sessionHistory: sessionHistory
+        )
+
+        XCTAssertEqual(readiness.historyCount, 2)
+        XCTAssertEqual(readiness.folderPath, "Work/Standups")
+        XCTAssertEqual(readiness.summaryText, "2 previous  •  Folder: Work › Standups")
+    }
+
+    private func makeEvent(
+        id: String,
+        title: String,
+        externalIdentifier: String? = nil
+    ) -> CalendarEvent {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        return CalendarEvent(
+            id: id,
+            title: title,
+            startDate: start,
+            endDate: start.addingTimeInterval(30 * 60),
+            externalIdentifier: externalIdentifier,
+            calendarID: nil,
+            calendarTitle: nil,
+            calendarColorHex: nil,
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: true,
+            meetingURL: nil
+        )
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/IdleHomeDashboardReadinessTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/IdleHomeDashboardReadinessTests.swift
@@ -87,7 +87,7 @@ final class IdleHomeDashboardReadinessTests: XCTestCase {
 
         XCTAssertEqual(readiness.historyCount, 2)
         XCTAssertEqual(readiness.folderPath, "Work/Standups")
-        XCTAssertEqual(readiness.summaryText, "2 previous  •  Folder: Work › Standups")
+        XCTAssertEqual(readiness.summaryText, "2 previous")
     }
 
     private func makeEvent(


### PR DESCRIPTION
Closes #565

## Summary
- add a compact readiness summary line to each upcoming meeting row
- show whether a meeting family has saved history
- show whether a default notes folder is already configured for that meeting family

## Scope note
This first slice intentionally stays cheap and deterministic. It does not add per-row knowledge-base searches or per-row device/auth validation.

## Validation
- swift test --package-path OpenOats --filter IdleHomeDashboardReadinessTests
- swift test --package-path OpenOats --filter UpcomingCalendarGroupingTests
- swift build -c debug --package-path OpenOats
- SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh
