### PR TITLE
Add date-based subfolders for meeting notes

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Manages live recording sessions, transcription lifecycle, and session finalization.
+// ABOUTME: Bridges observable app state with repositories, audio capture, and settings changes.
 import Foundation
 import Observation
 import CoreAudio
@@ -133,6 +135,7 @@ final class LiveSessionController {
     private var observedIsGenerating = false
     private var observedKBFolderPath: String?
     private var observedNotesFolderPath = ""
+    private var observedMeetingTranscriptDateFolderFormat: MeetingTranscriptDateFolderFormat?
     private var observedEmbeddingProvider: EmbeddingProvider?
     private var observedVoyageApiKey: String?
     private var observedTranscriptionModel: TranscriptionModel = .parakeetV2
@@ -595,12 +598,20 @@ final class LiveSessionController {
 
         // Configure notes folder for mirroring (prefer security-scoped bookmark)
         if let settings {
+            let dateSubfolderFormat = Self.dateSubfolderFormat(for: settings)
             if let resolvedURL = settings.resolveNotesFolderBookmark() {
-                await coordinator.sessionRepository.setNotesFolderPath(resolvedURL, securityScoped: true)
+                await coordinator.sessionRepository.setNotesFolderPath(
+                    resolvedURL,
+                    securityScoped: true,
+                    dateSubfolderFormat: dateSubfolderFormat
+                )
                 coordinator.audioRecorder?.updateDirectory(resolvedURL, securityScoped: true)
             } else {
                 let notesURL = URL(fileURLWithPath: settings.notesFolderPath)
-                await coordinator.sessionRepository.setNotesFolderPath(notesURL)
+                await coordinator.sessionRepository.setNotesFolderPath(
+                    notesURL,
+                    dateSubfolderFormat: dateSubfolderFormat
+                )
                 coordinator.audioRecorder?.updateDirectory(notesURL)
             }
         }
@@ -966,6 +977,10 @@ final class LiveSessionController {
         )
     }
 
+    private static func dateSubfolderFormat(for settings: AppSettings) -> MeetingTranscriptDateFolderFormat? {
+        settings.saveMeetingTranscriptsInDateSubfolders ? settings.meetingTranscriptDateFolderFormat : nil
+    }
+
     static func transcriptIssue(for input: RecordingHealthInput) -> SessionTranscriptIssue? {
         guard input.utteranceCount == 0 else { return nil }
 
@@ -1277,17 +1292,27 @@ final class LiveSessionController {
             }
         }
 
-        if settings.notesFolderPath != observedNotesFolderPath {
+        let dateSubfolderFormat = Self.dateSubfolderFormat(for: settings)
+        if settings.notesFolderPath != observedNotesFolderPath
+            || dateSubfolderFormat != observedMeetingTranscriptDateFolderFormat {
             observedNotesFolderPath = settings.notesFolderPath
+            observedMeetingTranscriptDateFolderFormat = dateSubfolderFormat
             if let resolvedURL = settings.resolveNotesFolderBookmark() {
                 Task {
-                    await coordinator.sessionRepository.setNotesFolderPath(resolvedURL, securityScoped: true)
+                    await coordinator.sessionRepository.setNotesFolderPath(
+                        resolvedURL,
+                        securityScoped: true,
+                        dateSubfolderFormat: dateSubfolderFormat
+                    )
                 }
                 coordinator.audioRecorder?.updateDirectory(resolvedURL, securityScoped: true)
             } else {
                 let url = URL(fileURLWithPath: settings.notesFolderPath)
                 Task {
-                    await coordinator.sessionRepository.setNotesFolderPath(url)
+                    await coordinator.sessionRepository.setNotesFolderPath(
+                        url,
+                        dateSubfolderFormat: dateSubfolderFormat
+                    )
                 }
                 coordinator.audioRecorder?.updateDirectory(url)
             }

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -1,5 +1,3 @@
-// ABOUTME: Manages live recording sessions, transcription lifecycle, and session finalization.
-// ABOUTME: Bridges observable app state with repositories, audio capture, and settings changes.
 import Foundation
 import Observation
 import CoreAudio

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Stores user preferences and secrets behind observable app settings.
+// ABOUTME: Persists non-secret values in UserDefaults and sensitive values in the keychain.
 import AppKit
 import CoreAudio
 import Foundation
@@ -884,6 +886,34 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _saveMeetingTranscriptsInDateSubfolders: Bool
+    var saveMeetingTranscriptsInDateSubfolders: Bool {
+        get {
+            access(keyPath: \.saveMeetingTranscriptsInDateSubfolders)
+            return _saveMeetingTranscriptsInDateSubfolders
+        }
+        set {
+            withMutation(keyPath: \.saveMeetingTranscriptsInDateSubfolders) {
+                _saveMeetingTranscriptsInDateSubfolders = newValue
+                defaults.set(newValue, forKey: "saveMeetingTranscriptsInDateSubfolders")
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _meetingTranscriptDateFolderFormat: MeetingTranscriptDateFolderFormat
+    var meetingTranscriptDateFolderFormat: MeetingTranscriptDateFolderFormat {
+        get {
+            access(keyPath: \.meetingTranscriptDateFolderFormat)
+            return _meetingTranscriptDateFolderFormat
+        }
+        set {
+            withMutation(keyPath: \.meetingTranscriptDateFolderFormat) {
+                _meetingTranscriptDateFolderFormat = newValue
+                defaults.set(newValue.rawValue, forKey: "meetingTranscriptDateFolderFormat")
+            }
+        }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _notesFolders: [NotesFolderDefinition]
     var notesFolders: [NotesFolderDefinition] {
         get { access(keyPath: \.notesFolders); return _notesFolders }
@@ -1278,6 +1308,10 @@ final class SettingsStore {
         }
         let defaultNotesPath = storage.defaultNotesDirectory.path
         self._notesFolderPath = defaults.string(forKey: "notesFolderPath") ?? defaultNotesPath
+        self._saveMeetingTranscriptsInDateSubfolders = defaults.bool(forKey: "saveMeetingTranscriptsInDateSubfolders")
+        self._meetingTranscriptDateFolderFormat = defaults
+            .string(forKey: "meetingTranscriptDateFolderFormat")
+            .flatMap(MeetingTranscriptDateFolderFormat.init(rawValue:)) ?? .iso
         self._notesFolders = Self.decodeNotesFolders(defaults.data(forKey: "notesFolders")) ?? []
         self._meetingPrepNotesByKey = Self.decodeMeetingPrepNotes(defaults.data(forKey: "meetingPrepNotesByKey")) ?? [:]
         self._meetingHistoryAliasesByKey = Self.decodeMeetingHistoryAliases(

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -1,5 +1,3 @@
-// ABOUTME: Stores user preferences and secrets behind observable app settings.
-// ABOUTME: Persists non-secret values in UserDefaults and sensitive values in the keychain.
 import AppKit
 import CoreAudio
 import Foundation

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -1,4 +1,38 @@
+// ABOUTME: Defines app settings value types and display metadata shared by the UI.
+// ABOUTME: Keeps persisted preference enums close to the code that reads UserDefaults.
 import Foundation
+
+enum MeetingTranscriptDateFolderFormat: String, CaseIterable, Identifiable, Codable, Sendable {
+    case us
+    case uk
+    case iso
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .us: "US (MM-DD-YYYY)"
+        case .uk: "UK (DD-MM-YYYY)"
+        case .iso: "ISO (YYYY-MM-DD)"
+        }
+    }
+
+    func folderName(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = dateFormat
+        return formatter.string(from: date)
+    }
+
+    private var dateFormat: String {
+        switch self {
+        case .us: "MM-dd-yyyy"
+        case .uk: "dd-MM-yyyy"
+        case .iso: "yyyy-MM-dd"
+        }
+    }
+}
 
 enum NotesFolderColor: String, CaseIterable, Identifiable, Codable {
     case gray

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -1,5 +1,3 @@
-// ABOUTME: Defines app settings value types and display metadata shared by the UI.
-// ABOUTME: Keeps persisted preference enums close to the code that reads UserDefaults.
 import Foundation
 
 enum MeetingTranscriptDateFolderFormat: String, CaseIterable, Identifiable, Codable, Sendable {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Persists meeting sessions, transcripts, generated notes, and exported mirrors.
+// ABOUTME: Coordinates the app's canonical session store with user-selected notes folders.
 import Foundation
 import UniformTypeIdentifiers
 
@@ -197,6 +199,7 @@ actor SessionRepository {
 
     /// User-facing notes folder for mirroring (e.g. ~/Documents/OpenOats).
     private var notesFolderPath: URL?
+    private var meetingTranscriptDateFolderFormat: MeetingTranscriptDateFolderFormat?
 
     /// Whether `notesFolderPath` is a security-scoped URL that requires
     /// `startAccessingSecurityScopedResource()` before file I/O.
@@ -233,9 +236,14 @@ actor SessionRepository {
     /// - Parameters:
     ///   - url: The folder URL (may be a security-scoped URL resolved from a bookmark).
     ///   - securityScoped: Pass `true` when the URL was resolved from a security-scoped bookmark.
-    func setNotesFolderPath(_ url: URL?, securityScoped: Bool = false) {
+    func setNotesFolderPath(
+        _ url: URL?,
+        securityScoped: Bool = false,
+        dateSubfolderFormat: MeetingTranscriptDateFolderFormat? = nil
+    ) {
         notesFolderPath = url
         notesFolderIsSecurityScoped = securityScoped
+        meetingTranscriptDateFolderFormat = dateSubfolderFormat
     }
 
     /// Register a callback invoked once per session when a write error occurs.
@@ -1894,6 +1902,7 @@ actor SessionRepository {
         guard let outputDir = notesFolderPath else { return }
         let sessDir = sessionsDirectory
         let isSecurityScoped = notesFolderIsSecurityScoped
+        let dateSubfolderFormat = meetingTranscriptDateFolderFormat
         let meta = loadSessionMetadataFile(sessionID: sessionID)
         Task.detached(priority: .background) {
             SessionRepository.performMirror(
@@ -1902,6 +1911,7 @@ actor SessionRepository {
                 notesMarkdown: notesMarkdown,
                 outputDir: outputDir,
                 isSecurityScoped: isSecurityScoped,
+                dateSubfolderFormat: dateSubfolderFormat,
                 sessionsDirectory: sessDir
             )
         }
@@ -1913,6 +1923,7 @@ actor SessionRepository {
         notesMarkdown: String?,
         outputDir: URL,
         isSecurityScoped: Bool,
+        dateSubfolderFormat: MeetingTranscriptDateFolderFormat?,
         sessionsDirectory: URL
     ) {
         // Acquire security-scoped access if the URL was resolved from a bookmark
@@ -1952,7 +1963,7 @@ actor SessionRepository {
             metadata: .init(from: index),
             records: records,
             notesMarkdown: resolvedMarkdown,
-            outputDirectory: outputDir,
+            outputDirectory: mirrorDirectory(outputDir, format: dateSubfolderFormat, startedAt: index.startedAt),
             preferPackage: !referencedAssetPaths.isEmpty
         )
 
@@ -1965,6 +1976,15 @@ actor SessionRepository {
                 into: packageDirectoryURL
             )
         }
+    }
+
+    private nonisolated static func mirrorDirectory(
+        _ outputDir: URL,
+        format: MeetingTranscriptDateFolderFormat?,
+        startedAt: Date
+    ) -> URL {
+        guard let format else { return outputDir }
+        return outputDir.appendingPathComponent(format.folderName(for: startedAt), isDirectory: true)
     }
 
     private nonisolated static func referencedMirrorAssetPaths(in markdown: String) -> Set<String> {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -1,5 +1,3 @@
-// ABOUTME: Persists meeting sessions, transcripts, generated notes, and exported mirrors.
-// ABOUTME: Coordinates the app's canonical session store with user-selected notes folders.
 import Foundation
 import UniformTypeIdentifiers
 

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -1,5 +1,3 @@
-// ABOUTME: Renders the app settings window and binds controls to persisted preferences.
-// ABOUTME: Groups capture, transcription, intelligence, template, and integration options.
 import AppKit
 import SwiftUI
 import CoreAudio

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -90,12 +90,14 @@ private struct GeneralSettingsTab: View {
                         }
                     }
 
-                    HStack {
-                        Toggle(
-                            "Save meeting transcripts into subfolders.",
-                            isOn: $settings.saveMeetingTranscriptsInDateSubfolders
-                        )
-                        .font(.system(size: 12))
+                    HStack(alignment: .center) {
+                        Toggle("", isOn: $settings.saveMeetingTranscriptsInDateSubfolders)
+                            .labelsHidden()
+                            .accessibilityLabel("Save meeting transcripts into subfolders")
+
+                        Text("Save meeting transcripts into subfolders.")
+                            .font(.system(size: 12))
+                            .fixedSize(horizontal: false, vertical: true)
 
                         Spacer()
 

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Renders the app settings window and binds controls to persisted preferences.
+// ABOUTME: Groups capture, transcription, intelligence, template, and integration options.
 import AppKit
 import SwiftUI
 import CoreAudio
@@ -86,6 +88,26 @@ private struct GeneralSettingsTab: View {
                         Button("Choose...") {
                             chooseNotesFolder()
                         }
+                    }
+
+                    HStack {
+                        Toggle(
+                            "Save meeting transcripts into subfolders.",
+                            isOn: $settings.saveMeetingTranscriptsInDateSubfolders
+                        )
+                        .font(.system(size: 12))
+
+                        Spacer()
+
+                        Picker("", selection: $settings.meetingTranscriptDateFolderFormat) {
+                            ForEach(MeetingTranscriptDateFolderFormat.allCases) { format in
+                                Text(format.displayName).tag(format)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .frame(width: 175)
+                        .disabled(!settings.saveMeetingTranscriptsInDateSubfolders)
                     }
                 }
 

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Exercises the session repository persistence and exported meeting mirror files.
+// ABOUTME: Uses temporary directories to verify on-disk session artifacts without app state.
 import XCTest
 @testable import OpenOatsKit
 
@@ -23,6 +25,17 @@ final class SessionRepositoryTests: XCTestCase {
             isOnlineMeeting: true,
             meetingURL: URL(string: "https://meet.example.com/customer-sync")
         )
+    }
+
+    private func localDate(year: Int, month: Int, day: Int, hour: Int = 10) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = .current
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        return components.date!
     }
 
     override func setUp() async throws {
@@ -375,6 +388,57 @@ final class SessionRepositoryTests: XCTestCase {
         }
         
         XCTAssertTrue(didMirror, "Background mirror task did not complete in time")
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
+    func testSaveNotesMirrorsIntoISODateSubfolder() async throws {
+        let exportDir = rootDir.appendingPathComponent("exported_notes_by_date", isDirectory: true)
+        try FileManager.default.createDirectory(at: exportDir, withIntermediateDirectories: true)
+
+        await repo.setNotesFolderPath(exportDir, dateSubfolderFormat: .iso)
+
+        let startedAt = localDate(year: 2026, month: 5, day: 2)
+        let sessionID = "test_mirror_date_folder_session"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: startedAt)],
+            startedAt: startedAt,
+            title: "Date Folder Meeting"
+        )
+
+        let template = TemplateSnapshot(
+            id: UUID(), name: "Mirror", icon: "star", systemPrompt: "Be helpful"
+        )
+        let notes = GeneratedNotes(
+            template: template,
+            generatedAt: startedAt,
+            markdown: "# Date Folder Notes\n\nContent here."
+        )
+
+        await repo.saveNotes(sessionID: sessionID, notes: notes)
+
+        let dateFolder = exportDir.appendingPathComponent("2026-05-02", isDirectory: true)
+        var didMirror = false
+        for _ in 0..<20 {
+            try? await Task.sleep(for: .milliseconds(100))
+            let contents = try? FileManager.default.contentsOfDirectory(
+                at: dateFolder,
+                includingPropertiesForKeys: nil
+            )
+            if contents?.contains(where: { $0.lastPathComponent.contains("date-folder-meeting") && $0.pathExtension == "md" }) ?? false {
+                didMirror = true
+                break
+            }
+        }
+
+        XCTAssertTrue(didMirror, "Background mirror task did not write into the date subfolder")
+
+        let topLevelContents = try FileManager.default.contentsOfDirectory(
+            at: exportDir,
+            includingPropertiesForKeys: nil
+        )
+        XCTAssertFalse(topLevelContents.contains(where: { $0.pathExtension == "md" }))
 
         await repo.deleteSession(sessionID: sessionID)
     }

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -1,5 +1,3 @@
-// ABOUTME: Exercises the session repository persistence and exported meeting mirror files.
-// ABOUTME: Uses temporary directories to verify on-disk session artifacts without app state.
 import XCTest
 @testable import OpenOatsKit
 

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -1,5 +1,3 @@
-// ABOUTME: Verifies SettingsStore defaults, persistence, and user-facing preferences.
-// ABOUTME: Uses isolated UserDefaults suites so settings tests do not affect local app data.
 import XCTest
 @testable import OpenOatsKit
 

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -1,3 +1,5 @@
+// ABOUTME: Verifies SettingsStore defaults, persistence, and user-facing preferences.
+// ABOUTME: Uses isolated UserDefaults suites so settings tests do not affect local app data.
 import XCTest
 @testable import OpenOatsKit
 
@@ -28,6 +30,17 @@ final class SettingsStoreTests: XCTestCase {
             runMigrations: false
         )
         return SettingsStore(storage: storage)
+    }
+
+    private func localDate(year: Int, month: Int, day: Int, hour: Int = 10) -> Date {
+        var components = DateComponents()
+        components.calendar = Calendar(identifier: .gregorian)
+        components.timeZone = .current
+        components.year = year
+        components.month = month
+        components.day = day
+        components.hour = hour
+        return components.date!
     }
 
     // MARK: - AI Settings Group
@@ -227,6 +240,33 @@ final class SettingsStoreTests: XCTestCase {
 
         store.diagnosticLoggingEnabled = true
         XCTAssertTrue(store.diagnosticLoggingEnabled)
+    }
+
+    func testDefaultMeetingTranscriptDateSubfoldersSettings() {
+        let store = makeStore()
+        XCTAssertFalse(store.saveMeetingTranscriptsInDateSubfolders)
+        XCTAssertEqual(store.meetingTranscriptDateFolderFormat, .iso)
+    }
+
+    func testMeetingTranscriptDateSubfoldersSettingsRoundTrip() {
+        let suiteName = "com.openoats.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let store = makeStore(defaults: defaults)
+        store.saveMeetingTranscriptsInDateSubfolders = true
+        store.meetingTranscriptDateFolderFormat = .uk
+
+        let reopened = makeStore(defaults: defaults)
+        XCTAssertTrue(reopened.saveMeetingTranscriptsInDateSubfolders)
+        XCTAssertEqual(reopened.meetingTranscriptDateFolderFormat, .uk)
+    }
+
+    func testMeetingTranscriptDateFolderFormatFolderNames() {
+        let date = localDate(year: 2026, month: 5, day: 2)
+        XCTAssertEqual(MeetingTranscriptDateFolderFormat.us.folderName(for: date), "05-02-2026")
+        XCTAssertEqual(MeetingTranscriptDateFolderFormat.uk.folderName(for: date), "02-05-2026")
+        XCTAssertEqual(MeetingTranscriptDateFolderFormat.iso.folderName(for: date), "2026-05-02")
     }
 
     func testDefaultBatchTranscriptionModel() {


### PR DESCRIPTION
## Summary

OpenOats already makes it very easy to save meeting notes directly into an Obsidian vault. For users coming from Granola, though, it is standard practice to keep those imported meeting notes organized into date-based subfolders. Until now, OpenOats could save directly to the target folder, but could not automatically organize those exported meeting notes by date.

This tiny change makes that behavior configurable in Settings > General > Meeting Notes. Users can enable date-based subfolders and choose US (MM-DD-YYYY), UK (DD-MM-YYYY), or ISO (YYYY-MM-DD) folder names.

## Changes

- Adds persisted settings for date-based meeting transcript subfolders.
- Adds a checkbox and date-format picker under Meeting Notes settings.
- Mirrors exported meeting markdown into the selected date subfolder when enabled.
- Keeps the existing flat-folder behavior as the default.
- Adds settings and repository tests for the new behavior.

## Validation

- `swift build`
- Manual app test: enabled ISO date subfolders and confirmed exported meeting markdown was written under the expected date folder.

Note: `swift test --filter ...` is blocked in my local environment because Command Line Tools cannot resolve `XCTest` (`no such module XCTest`).