### PR TITLE
Initialize the menu bar controller at app launch

### DIFF
--- a/OpenOats/Sources/OpenOats/App/MenuBarController.swift
+++ b/OpenOats/Sources/OpenOats/App/MenuBarController.swift
@@ -10,6 +10,7 @@ final class MenuBarController {
     private let settings: AppSettings
     private let onToggleMeeting: () -> Void
     private var iconUpdateTask: Task<Void, Never>?
+    private var hasConfiguredButton = false
 
     var onShowMainWindow: (() -> Void)?
     var onQuitApp: (() -> Void)?
@@ -54,12 +55,7 @@ final class MenuBarController {
         )
         popover.contentViewController = NSHostingController(rootView: popoverView)
 
-        if let button = statusItem.button {
-            button.image = Self.makeConcentricCirclesIcon(filled: false)
-            button.image?.isTemplate = true
-            button.target = self
-            button.action = #selector(togglePopover(_:))
-        }
+        refreshStatusItem()
 
         startIconObservation()
     }
@@ -93,8 +89,28 @@ final class MenuBarController {
     }
 
     private func updateIcon() {
+        refreshStatusItem()
         statusItem.button?.image = Self.makeConcentricCirclesIcon(filled: coordinator.isRecording)
         statusItem.button?.image?.isTemplate = true
+    }
+
+    func refreshStatusItem() {
+        guard let button = statusItem.button else {
+            DiagnosticsSupport.record(category: "menu", message: "Status item button unavailable")
+            return
+        }
+
+        if !hasConfiguredButton {
+            button.target = self
+            button.action = #selector(togglePopover(_:))
+            hasConfiguredButton = true
+            DiagnosticsSupport.record(category: "menu", message: "Status item button configured")
+        }
+
+        if button.image == nil {
+            button.image = Self.makeConcentricCirclesIcon(filled: coordinator.isRecording)
+            button.image?.isTemplate = true
+        }
     }
 
     private static func makeConcentricCirclesIcon(filled: Bool) -> NSImage {

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -21,6 +21,12 @@ public struct OpenOatsRootApp: App {
         self._container = State(initialValue: context.container)
         self.updaterController = context.updaterController
         self.defaults = context.container.defaults
+        AppLaunchBootstrap.context = .init(
+            settings: context.settings,
+            coordinator: context.coordinator,
+            container: context.container,
+            defaults: context.container.defaults
+        )
         DiagnosticsSupport.record(category: "app", message: "App initialized")
     }
 
@@ -31,19 +37,15 @@ public struct OpenOatsRootApp: App {
                 .environment(coordinator)
                 .defaultAppStorage(defaults)
                 .onAppear {
-                    appDelegate.coordinator = coordinator
-                    appDelegate.settings = settings
-                    appDelegate.defaults = defaults
-                    appDelegate.container = container
+                    appDelegate.configure(
+                        coordinator: coordinator,
+                        settings: settings,
+                        defaults: defaults,
+                        container: container,
+                        showMainWindow: { [self] in showMainWindow() },
+                        checkForUpdates: { updaterController.checkForUpdatesFromMenuBar() }
+                    )
                     DiagnosticsSupport.record(category: "app", message: "Main window appeared")
-                    if case .live = container.mode {
-                        appDelegate.setupMenuBarIfNeeded(
-                            coordinator: coordinator,
-                            settings: settings,
-                            showMainWindow: { [self] in showMainWindow() },
-                            checkForUpdates: { updaterController.checkForUpdatesFromMenuBar() }
-                        )
-                    }
                     settings.applyScreenShareVisibility()
                 }
                 .onOpenURL { url in
@@ -230,6 +232,18 @@ extension Notification.Name {
 }
 
 @MainActor
+private enum AppLaunchBootstrap {
+    struct Context {
+        let settings: AppSettings
+        let coordinator: AppCoordinator
+        let container: AppContainer
+        let defaults: UserDefaults
+    }
+
+    static var context: Context?
+}
+
+@MainActor
 final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private var windowObserver: Any?
     private var menuBarController: MenuBarController?
@@ -238,28 +252,67 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     var settings: AppSettings?
     var container: AppContainer?
     var defaults: UserDefaults = .standard
+    var showMainWindowAction: (() -> Void)?
+    var checkForUpdatesAction: (() -> Void)?
 
-    func setupMenuBarIfNeeded(
+    func configure(
         coordinator: AppCoordinator,
         settings: AppSettings,
-        showMainWindow: @escaping () -> Void,
-        checkForUpdates: @escaping () -> Void
+        defaults: UserDefaults,
+        container: AppContainer,
+        showMainWindow: (() -> Void)? = nil,
+        checkForUpdates: (() -> Void)? = nil
     ) {
-        guard menuBarController == nil else { return }
+        self.coordinator = coordinator
+        self.settings = settings
+        self.defaults = defaults
+        self.container = container
+        if let showMainWindow {
+            showMainWindowAction = showMainWindow
+        }
+        if let checkForUpdates {
+            checkForUpdatesAction = checkForUpdates
+        }
+        if case .live = container.mode {
+            DiagnosticsSupport.record(
+                category: "menu",
+                message: "Configuring menu bar controller from app delegate activationPolicy=\(activationPolicyDescription())"
+            )
+            setupMenuBarIfNeeded(coordinator: coordinator, settings: settings)
+        }
+    }
+
+    func setupMenuBarIfNeeded(coordinator: AppCoordinator, settings: AppSettings) {
+        if let menuBarController {
+            menuBarController.refreshStatusItem()
+            return
+        }
 
         let controller = MenuBarController(
             coordinator: coordinator,
             settings: settings,
-            onCheckForUpdates: checkForUpdates,
+            onCheckForUpdates: { [weak self] in
+                self?.checkForUpdatesAction?()
+            },
             onToggleMeeting: { [weak self] in
                 self?.toggleMeeting()
             }
         )
-        controller.onShowMainWindow = showMainWindow
+        controller.onShowMainWindow = { [weak self] in
+            if let action = self?.showMainWindowAction {
+                action()
+            } else {
+                self?.fallbackShowMainWindow()
+            }
+        }
         controller.onQuitApp = { [weak self] in
             self?.handleQuit()
         }
         menuBarController = controller
+        DiagnosticsSupport.record(
+            category: "menu",
+            message: "Menu bar controller created activationPolicy=\(activationPolicyDescription())"
+        )
     }
 
     private var isUITest: Bool {
@@ -272,6 +325,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         if !isUITest {
             NSApp.setActivationPolicy(.regular)
+        }
+
+        if let context = AppLaunchBootstrap.context {
+            DiagnosticsSupport.record(
+                category: "menu",
+                message: "Consuming launch bootstrap activationPolicy=\(activationPolicyDescription())"
+            )
+            configure(
+                coordinator: context.coordinator,
+                settings: context.settings,
+                defaults: context.defaults,
+                container: context.container
+            )
+            AppLaunchBootstrap.context = nil
         }
 
         let hidden = defaults.object(forKey: "hideFromScreenShare") == nil
@@ -306,6 +373,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         }
 
         registerGlobalHotkey()
+    }
+
+    func applicationDidBecomeActive(_ notification: Notification) {
+        DiagnosticsSupport.record(
+            category: "menu",
+            message: "Application became active activationPolicy=\(activationPolicyDescription())"
+        )
+        if let coordinator, let settings, let container, case .live = container.mode {
+            setupMenuBarIfNeeded(coordinator: coordinator, settings: settings)
+        } else {
+            menuBarController?.refreshStatusItem()
+        }
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -392,6 +471,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
                 trigger: nil
             )
             try? await center.add(request)
+        }
+    }
+
+    private func fallbackShowMainWindow() {
+        NSApp.setActivationPolicy(.regular)
+        NSApp.activate(ignoringOtherApps: true)
+        if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == OpenOatsRootApp.mainWindowID }) {
+            window.makeKeyAndOrderFront(nil)
+        }
+    }
+
+    private func activationPolicyDescription() -> String {
+        switch NSApp.activationPolicy() {
+        case .regular:
+            return "regular"
+        case .accessory:
+            return "accessory"
+        case .prohibited:
+            return "prohibited"
+        @unknown default:
+            return "unknown"
         }
     }
 


### PR DESCRIPTION
Closes #571

## Summary
- initialize the menu bar controller during app launch instead of relying on the main window appearance path
- refresh the status item button when the app becomes active instead of assuming it is only available during controller init
- add diagnostics breadcrumbs around menu-bar setup so future launch-path regressions are easier to prove

## Validation
- `swift build -c debug --package-path OpenOats`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`

## Notes
- this keeps `hideFromScreenShare` scoped to window sharing only
- this does not redesign the broader regular/accessory activation-policy model in this PR