### PR TITLE
Add a dedicated Calendar settings tab with filtering

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppContainer.swift
+++ b/OpenOats/Sources/OpenOats/App/AppContainer.swift
@@ -241,7 +241,7 @@ final class AppContainer {
     func updateCalendarIntegration(enabled: Bool) {
         if enabled {
             if calendarManager == nil {
-                calendarManager = CalendarManager()
+                setCalendarManager(CalendarManager())
             } else {
                 // Re-read TCC in case the system state changed since the manager was created.
                 calendarManager?.refreshFromSystem()
@@ -252,8 +252,29 @@ final class AppContainer {
                 }
             }
         } else {
-            calendarManager = nil
+            setCalendarManager(nil)
         }
+    }
+
+    /// Recreates the calendar manager so EventKit state is reloaded from scratch.
+    /// Use this when permission or visible calendars may have changed in System Settings
+    /// and a soft status refresh is not sufficient.
+    func reloadCalendarIntegration() {
+        guard calendarManager != nil else {
+            updateCalendarIntegration(enabled: true)
+            return
+        }
+        setCalendarManager(CalendarManager())
+        if calendarManager?.accessState == .notDetermined {
+            Task {
+                _ = await calendarManager?.requestAccess()
+            }
+        }
+    }
+
+    private func setCalendarManager(_ manager: CalendarManager?) {
+        calendarManager = manager
+        detectionController?.calendarManager = manager
     }
 
     func seedIfNeeded(coordinator: AppCoordinator) async {

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -283,7 +283,9 @@ final class LiveSessionController {
         coordinator.suggestionEngine?.clear()
         coordinator.sidecastEngine?.clear()
         let calEvent = calendarEventOverride ?? (settings.calendarIntegrationEnabled
-            ? container.calendarManager?.currentEvent()
+            ? container.calendarManager?.currentEvent(
+                excludingCalendarIDs: settings.excludedCalendarIDs
+            )
             : nil)
         DiagnosticsSupport.record(
             category: "meeting",

--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -401,7 +401,9 @@ final class MeetingDetectionController {
             } else {
                 app = await meetingDetector?.detectedApp
             }
-            let calEvent = calendarManager?.currentEvent()
+            let calEvent = calendarManager?.currentEvent(
+                excludingCalendarIDs: activeSettings?.excludedCalendarIDs ?? []
+            )
 
             let signal: DetectionSignal
             if snapshot?.trigger == .camera {

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -442,7 +442,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
             coordinator.handle(.userStopped, settings: settings)
         } else {
             let calEvent = settings.calendarIntegrationEnabled
-                ? container?.calendarManager?.currentEvent()
+                ? container?.calendarManager?.currentEvent(
+                    excludingCalendarIDs: settings.excludedCalendarIDs
+                )
                 : nil
             coordinator.handle(.userStarted(.manual(calendarEvent: calEvent)), settings: settings)
         }

--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -16,6 +16,13 @@ final class CalendarManager {
         case denied
     }
 
+    struct AvailableCalendar: Sendable, Hashable, Identifiable {
+        let id: String
+        let title: String
+        let sourceTitle: String?
+        let colorHex: String?
+    }
+
     /// Current authorization status, observed at init and after requesting access.
     private(set) var accessState: AccessState
 
@@ -50,9 +57,13 @@ final class CalendarManager {
 
     /// Find the calendar event that best overlaps the given date (typically now).
     /// Returns nil if no event is found or access is not authorized.
-    func currentEvent(at date: Date = Date()) -> CalendarEvent? {
+    func currentEvent(
+        at date: Date = Date(),
+        excludingCalendarIDs: [String] = []
+    ) -> CalendarEvent? {
         guard accessState == .authorized else { return nil }
-        let calendars = eventCalendars()
+        let calendars = eventCalendars(excludingCalendarIDs: Set(excludingCalendarIDs))
+        guard !calendars.isEmpty else { return nil }
 
         // Look for events in a window: started up to 15 min ago through 15 min from now
         let windowStart = date.addingTimeInterval(-15 * 60)
@@ -84,10 +95,12 @@ final class CalendarManager {
     func upcomingEvents(
         from date: Date = Date(),
         within window: TimeInterval = 12 * 60 * 60,
-        limit: Int = 5
+        limit: Int = 5,
+        excludingCalendarIDs: [String] = []
     ) -> [CalendarEvent] {
         guard accessState == .authorized else { return [] }
-        let calendars = eventCalendars()
+        let calendars = eventCalendars(excludingCalendarIDs: Set(excludingCalendarIDs))
+        guard !calendars.isEmpty else { return [] }
 
         let windowEnd = date.addingTimeInterval(window)
         let predicate = store.predicateForEvents(
@@ -105,9 +118,13 @@ final class CalendarManager {
 
     /// Calendar events occurring on the same local day as the given date, ordered by start date.
     /// Returns an empty array if access is not authorized.
-    func events(onSameDayAs date: Date = Date()) -> [CalendarEvent] {
+    func events(
+        onSameDayAs date: Date = Date(),
+        excludingCalendarIDs: [String] = []
+    ) -> [CalendarEvent] {
         guard accessState == .authorized else { return [] }
-        let calendars = eventCalendars()
+        let calendars = eventCalendars(excludingCalendarIDs: Set(excludingCalendarIDs))
+        guard !calendars.isEmpty else { return [] }
         let calendar = Calendar.current
         let startOfDay = calendar.startOfDay(for: date)
         guard let endOfDay = calendar.date(byAdding: .day, value: 1, to: startOfDay) else {
@@ -128,8 +145,31 @@ final class CalendarManager {
 
     // MARK: - Helpers
 
-    private func eventCalendars() -> [EKCalendar] {
+    func availableCalendars() -> [AvailableCalendar] {
+        guard accessState == .authorized else { return [] }
+        return eventCalendars()
+            .map { calendar in
+                AvailableCalendar(
+                    id: calendar.calendarIdentifier,
+                    title: calendar.title,
+                    sourceTitle: calendar.source.title.nilIfBlank,
+                    colorHex: CalendarColorCodec.hexString(from: calendar.cgColor)
+                )
+            }
+            .sorted { lhs, rhs in
+                let lhsSource = lhs.sourceTitle ?? ""
+                let rhsSource = rhs.sourceTitle ?? ""
+                let sourceComparison = lhsSource.localizedCaseInsensitiveCompare(rhsSource)
+                if sourceComparison != .orderedSame {
+                    return sourceComparison == .orderedAscending
+                }
+                return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+            }
+    }
+
+    private func eventCalendars(excludingCalendarIDs: Set<String> = []) -> [EKCalendar] {
         store.calendars(for: .event)
+            .filter { !excludingCalendarIDs.contains($0.calendarIdentifier) }
     }
 
     private static func currentAccessState() -> AccessState {
@@ -141,6 +181,13 @@ final class CalendarManager {
         default:
             return .denied
         }
+    }
+}
+
+private extension String {
+    var nilIfBlank: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -13,6 +13,18 @@ final class SettingsStore {
     private static let enableBatchRetranscriptionLegacyKey = "enableBatchRefinement"
     @ObservationIgnored private var loadedSecretKeys: Set<String> = []
 
+    private static func normalizedIdentifierList(_ values: [String]) -> [String] {
+        var result: [String] = []
+        var seen: Set<String> = []
+        for rawValue in values {
+            let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            guard seen.insert(trimmed).inserted else { continue }
+            result.append(trimmed)
+        }
+        return result
+    }
+
     private func loadSecretIfNeeded(
         key: String,
         currentValue: String,
@@ -718,6 +730,18 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _excludedCalendarIDs: [String]
+    var excludedCalendarIDs: [String] {
+        get { access(keyPath: \.excludedCalendarIDs); return _excludedCalendarIDs }
+        set {
+            withMutation(keyPath: \.excludedCalendarIDs) {
+                let normalized = Self.normalizedIdentifierList(newValue)
+                _excludedCalendarIDs = normalized
+                defaults.set(normalized, forKey: "excludedCalendarIDs")
+            }
+        }
+    }
+
     // MARK: - Privacy Settings
 
     @ObservationIgnored nonisolated(unsafe) private var _hasAcknowledgedRecordingConsent: Bool
@@ -1266,6 +1290,9 @@ final class SettingsStore {
         self._hasShownCameraDetectExplanation = defaults.bool(forKey: "hasShownCameraDetectExplanation")
         self._calendarIntegrationEnabled = defaults.bool(forKey: "calendarIntegrationEnabled")
         self._shareCalendarContextWithCloudNotes = defaults.bool(forKey: "shareCalendarContextWithCloudNotes")
+        self._excludedCalendarIDs = Self.normalizedIdentifierList(
+            defaults.stringArray(forKey: "excludedCalendarIDs") ?? []
+        )
 
         // Privacy Settings
         self._hasAcknowledgedRecordingConsent = defaults.bool(forKey: "hasAcknowledgedRecordingConsent")

--- a/OpenOats/Sources/OpenOats/Views/CalendarSettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/CalendarSettingsView.swift
@@ -1,0 +1,471 @@
+import AppKit
+import SwiftUI
+
+struct CalendarSettingsTab: View {
+    @Bindable var settings: AppSettings
+    @Environment(AppContainer.self) private var container
+
+    @State private var accessState: CalendarManager.AccessState = .notDetermined
+    @State private var availableCalendars: [CalendarManager.AvailableCalendar] = []
+    @State private var refreshTick: Int = 0
+    @State private var isManualRefreshInFlight = false
+    @State private var showReloadSuccess = false
+    @State private var reloadErrorMessage: String?
+
+    private struct CalendarSourceGroup: Identifiable {
+        let title: String
+        let calendars: [CalendarManager.AvailableCalendar]
+
+        var id: String { title }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                accessCard
+
+                if settings.calendarIntegrationEnabled {
+                    switch accessState {
+                    case .authorized:
+                        calendarsCard
+                        cloudSharingCard
+                    case .denied, .notDetermined:
+                        EmptyView()
+                    }
+                }
+            }
+            .padding(20)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .task {
+            syncCalendarIntegration()
+            refreshTick &+= 1
+        }
+        .task(id: refreshTaskID) {
+            await refresh()
+            guard settings.calendarIntegrationEnabled else { return }
+            try? await Task.sleep(for: .seconds(30))
+            refreshTick &+= 1
+        }
+        .onChange(of: settings.calendarIntegrationEnabled) {
+            syncCalendarIntegration()
+            refreshTick &+= 1
+        }
+        .onChange(of: settings.excludedCalendarIDs) {
+            refreshTick &+= 1
+        }
+    }
+
+    private var refreshTaskID: String {
+        "\(settings.calendarIntegrationEnabled)-\(settings.excludedCalendarIDs.joined(separator: ","))-\(refreshTick)"
+    }
+
+    private var selectedCalendarCount: Int {
+        let excluded = Set(settings.excludedCalendarIDs)
+        return availableCalendars.filter { !excluded.contains($0.id) }.count
+    }
+
+    private var calendarSelectionSummary: String {
+        guard !availableCalendars.isEmpty else {
+            return "No calendars available"
+        }
+        if selectedCalendarCount == 0 {
+            return "No calendars selected"
+        }
+        if selectedCalendarCount == availableCalendars.count {
+            return availableCalendars.count == 1
+                ? "1 calendar selected"
+                : "All \(availableCalendars.count) calendars selected"
+        }
+        return "\(selectedCalendarCount) of \(availableCalendars.count) calendars selected"
+    }
+
+    private var calendarGroups: [CalendarSourceGroup] {
+        var groups: [CalendarSourceGroup] = []
+        var currentTitle: String?
+        var currentCalendars: [CalendarManager.AvailableCalendar] = []
+
+        for calendar in availableCalendars {
+            let title = calendar.sourceTitle ?? "Other"
+            if currentTitle == title {
+                currentCalendars.append(calendar)
+            } else {
+                if let currentTitle {
+                    groups.append(CalendarSourceGroup(title: currentTitle, calendars: currentCalendars))
+                }
+                currentTitle = title
+                currentCalendars = [calendar]
+            }
+        }
+
+        if let currentTitle {
+            groups.append(CalendarSourceGroup(title: currentTitle, calendars: currentCalendars))
+        }
+
+        return groups
+    }
+
+    private var accessCard: some View {
+        settingsCard {
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Calendar")
+                        .font(.system(size: 15, weight: .semibold))
+                    Text("Use macOS Calendar to match meetings and title sessions.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if settings.calendarIntegrationEnabled {
+                    refreshButton
+                }
+            }
+
+            Toggle("Use Calendar to identify meetings", isOn: $settings.calendarIntegrationEnabled)
+                .font(.system(size: 12))
+
+            Divider()
+
+            HStack(spacing: 8) {
+                Image(systemName: statusIcon)
+                    .font(.system(size: 12))
+                    .foregroundStyle(statusColor)
+                Text(statusLabel)
+                    .font(.system(size: 12, weight: .medium))
+                Spacer()
+                if accessState == .authorized, !availableCalendars.isEmpty {
+                    Text("\(availableCalendars.count) visible")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            accessDetail
+        }
+    }
+
+    private var cloudSharingCard: some View {
+        settingsCard {
+            Text("Cloud Notes")
+                .font(.system(size: 15, weight: .semibold))
+
+            Toggle("Share calendar details with cloud notes", isOn: $settings.shareCalendarContextWithCloudNotes)
+                .font(.system(size: 12))
+
+            Text("Remote note providers may receive event title, organizer, and invited participant names as text context. Local providers are excluded.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var calendarsCard: some View {
+        settingsCard {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Included Calendars")
+                        .font(.system(size: 15, weight: .semibold))
+                    Text(calendarSelectionSummary)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                HStack(spacing: 8) {
+                    Button("All") {
+                        settings.excludedCalendarIDs = []
+                    }
+                    .font(.system(size: 12))
+                    .disabled(availableCalendars.isEmpty || selectedCalendarCount == availableCalendars.count)
+                    .help("Include all calendars")
+
+                    Button("None") {
+                        settings.excludedCalendarIDs = availableCalendars.map(\.id)
+                    }
+                    .font(.system(size: 12))
+                    .disabled(availableCalendars.isEmpty || selectedCalendarCount == 0)
+                    .help("Exclude all calendars")
+                }
+            }
+
+            Text("Choose which calendars OpenOats can use when matching meetings.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+
+            if availableCalendars.isEmpty {
+                Text("No calendars are currently available from macOS Calendar.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 14) {
+                        ForEach(calendarGroups) { group in
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(group.title)
+                                    .font(.system(size: 10, weight: .semibold))
+                                    .foregroundStyle(.secondary)
+                                    .textCase(.uppercase)
+
+                                ForEach(Array(group.calendars.enumerated()), id: \.element.id) { index, calendar in
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Toggle(isOn: inclusionBinding(for: calendar.id)) {
+                                            HStack(spacing: 8) {
+                                                Circle()
+                                                    .fill(calendarColor(for: calendar))
+                                                    .frame(width: 8, height: 8)
+                                                Text(calendar.title)
+                                                    .font(.system(size: 12, weight: .medium))
+                                                    .lineLimit(1)
+                                                    .truncationMode(.tail)
+                                            }
+                                        }
+                                        .toggleStyle(.checkbox)
+
+                                        if index < group.calendars.count - 1 {
+                                            Divider()
+                                                .padding(.leading, 28)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .frame(minHeight: 220, maxHeight: 320)
+                .background(cardInsetBackground)
+            }
+        }
+    }
+
+    private var refreshButton: some View {
+        Group {
+            if isManualRefreshInFlight {
+                Label {
+                    Text("Reloading…")
+                } icon: {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+                .font(.system(size: 12))
+            } else {
+                Button {
+                    reloadErrorMessage = nil
+                    showReloadSuccess = false
+                    Task {
+                        container.reloadCalendarIntegration()
+                        await refresh(showManualProgress: true)
+                    }
+                } label: {
+                    Label(showReloadSuccess ? "Updated" : "Reload", systemImage: showReloadSuccess ? "checkmark" : "arrow.clockwise")
+                        .font(.system(size: 12))
+                }
+                .buttonStyle(.bordered)
+                .help("Reload calendar access and the visible calendar list")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var accessDetail: some View {
+        switch accessState {
+        case .authorized:
+            if let reloadErrorMessage {
+                Text(reloadErrorMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.orange)
+            }
+        case .denied:
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Calendar access is denied. Grant access in System Settings for OpenOats to see your events.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                Button("Open Privacy Settings…") {
+                    openCalendarPrivacySettings()
+                }
+                .font(.system(size: 12))
+            }
+        case .notDetermined:
+            Text("OpenOats will request Calendar access when this setting is enabled.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var statusIcon: String {
+        switch accessState {
+        case .authorized: return "checkmark.circle.fill"
+        case .denied: return "exclamationmark.triangle.fill"
+        case .notDetermined: return "clock"
+        }
+    }
+
+    private var statusColor: Color {
+        switch accessState {
+        case .authorized: return .green
+        case .denied: return .orange
+        case .notDetermined: return .secondary
+        }
+    }
+
+    private var statusLabel: String {
+        switch accessState {
+        case .authorized: return "Calendar access authorized"
+        case .denied: return "Calendar access denied"
+        case .notDetermined: return "Calendar access not yet requested"
+        }
+    }
+
+    private func inclusionBinding(for calendarID: String) -> Binding<Bool> {
+        Binding(
+            get: { !settings.excludedCalendarIDs.contains(calendarID) },
+            set: { isIncluded in
+                var excluded = Set(settings.excludedCalendarIDs)
+                if isIncluded {
+                    excluded.remove(calendarID)
+                } else {
+                    excluded.insert(calendarID)
+                }
+                settings.excludedCalendarIDs = availableCalendars.map(\.id).filter { excluded.contains($0) }
+            }
+        )
+    }
+
+    @MainActor
+    private func refresh(showManualProgress: Bool = false) async {
+        let refreshStart = ContinuousClock.now
+        if showManualProgress {
+            isManualRefreshInFlight = true
+        }
+        defer {
+            if showManualProgress {
+                Task { @MainActor in
+                    let minimumVisibleDuration = Duration.milliseconds(400)
+                    let elapsed = refreshStart.duration(to: ContinuousClock.now)
+                    if elapsed < minimumVisibleDuration {
+                        try? await Task.sleep(for: minimumVisibleDuration - elapsed)
+                    }
+                    isManualRefreshInFlight = false
+                }
+            }
+        }
+
+        guard settings.calendarIntegrationEnabled else {
+            accessState = .notDetermined
+            availableCalendars = []
+            reloadErrorMessage = nil
+            showReloadSuccess = false
+            return
+        }
+
+        if container.calendarManager == nil {
+            syncCalendarIntegration()
+        }
+
+        guard let manager = container.calendarManager else {
+            accessState = .notDetermined
+            availableCalendars = []
+            reloadErrorMessage = "Could not reload Calendar access."
+            return
+        }
+
+        manager.refreshFromSystem()
+        accessState = manager.accessState
+
+        guard manager.accessState == .authorized else {
+            availableCalendars = []
+            reloadErrorMessage = nil
+            showReloadSuccess = true
+            clearReloadSuccessSoon()
+            return
+        }
+
+        let calendars = manager.availableCalendars()
+        availableCalendars = calendars
+
+        let availableIDs = Set(calendars.map(\.id))
+        let prunedExcludedIDs = settings.excludedCalendarIDs.filter { availableIDs.contains($0) }
+        if prunedExcludedIDs != settings.excludedCalendarIDs {
+            settings.excludedCalendarIDs = prunedExcludedIDs
+        }
+        reloadErrorMessage = nil
+        if showManualProgress {
+            showReloadSuccess = true
+            clearReloadSuccessSoon()
+        }
+    }
+
+    private func syncCalendarIntegration() {
+        container.updateCalendarIntegration(enabled: settings.calendarIntegrationEnabled)
+    }
+
+    private func clearReloadSuccessSoon() {
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(2))
+            guard !isManualRefreshInFlight else { return }
+            showReloadSuccess = false
+        }
+    }
+
+    private func calendarColor(for calendar: CalendarManager.AvailableCalendar) -> Color {
+        guard let hex = calendar.colorHex,
+              let color = Color(calendarHex: hex) else { return .secondary }
+        return color
+    }
+
+    private func settingsCard<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            content()
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(cardBackground)
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(Color(nsColor: .controlBackgroundColor))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.2), lineWidth: 1)
+            )
+    }
+
+    private var cardInsetBackground: some View {
+        RoundedRectangle(cornerRadius: 10)
+            .fill(Color(nsColor: .windowBackgroundColor))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.15), lineWidth: 1)
+            )
+    }
+
+    private func openCalendarPrivacySettings() {
+        let urls = [
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars",
+            "x-apple.systempreferences:com.apple.preference.security?Privacy",
+        ]
+        for urlString in urls {
+            guard let url = URL(string: urlString) else { continue }
+            if NSWorkspace.shared.open(url) { return }
+        }
+    }
+}
+
+private extension Color {
+    init?(calendarHex: String) {
+        let cleaned = calendarHex.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard cleaned.count == 7, cleaned.hasPrefix("#") else { return nil }
+        let redString = String(cleaned.dropFirst().prefix(2))
+        let greenString = String(cleaned.dropFirst(3).prefix(2))
+        let blueString = String(cleaned.dropFirst(5).prefix(2))
+        guard let red = UInt8(redString, radix: 16),
+              let green = UInt8(greenString, radix: 16),
+              let blue = UInt8(blueString, radix: 16) else { return nil }
+        self = Color(
+            red: Double(red) / 255,
+            green: Double(green) / 255,
+            blue: Double(blue) / 255
+        )
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -214,12 +214,19 @@ struct IdleHomeDashboardView: View {
         }
 
         let now = Date()
-        let currentEvent = manager.currentEvent(at: now)
-        let dayEvents = manager.events(onSameDayAs: now)
+        let currentEvent = manager.currentEvent(
+            at: now,
+            excludingCalendarIDs: settings.excludedCalendarIDs
+        )
+        let dayEvents = manager.events(
+            onSameDayAs: now,
+            excludingCalendarIDs: settings.excludedCalendarIDs
+        )
         let upcomingEvents = manager.upcomingEvents(
             from: now,
             within: 7 * 24 * 60 * 60,
-            limit: 24
+            limit: 24,
+            excludingCalendarIDs: settings.excludedCalendarIDs
         )
 
         var combined: [CalendarEvent] = []

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -9,6 +9,7 @@ import Sparkle
 
 private enum SettingsTab: String, CaseIterable {
     case general
+    case calendar
     case transcription
     case intelligence
     case sidecast
@@ -28,6 +29,10 @@ struct SettingsView: View {
             GeneralSettingsTab(settings: settings, updater: updater)
                 .tabItem { Label("General", systemImage: "gear") }
                 .tag(SettingsTab.general)
+
+            CalendarSettingsTab(settings: settings)
+                .tabItem { Label("Calendar", systemImage: "calendar") }
+                .tag(SettingsTab.calendar)
 
             TranscriptionSettingsTab(settings: settings)
                 .tabItem { Label("Transcription", systemImage: "waveform") }
@@ -50,7 +55,7 @@ struct SettingsView: View {
                 .tag(SettingsTab.integrations)
         }
         .accessibilityIdentifier("settings.tabView")
-        .frame(width: 500, height: 600)
+        .frame(width: 640, height: 700)
     }
 }
 
@@ -198,26 +203,6 @@ private struct GeneralSettingsTab: View {
                             .foregroundStyle(.secondary)
                     }
                     .font(.system(size: 12))
-                }
-
-                Section("Calendar") {
-                    Toggle("Use calendar context for meetings", isOn: $settings.calendarIntegrationEnabled)
-                        .font(.system(size: 12))
-
-                    Text("When enabled, OpenOats looks up your calendar for a matching event and uses it to title sessions, show local meeting context, and improve local notes. Calendar access is requested only when you enable this.")
-                        .font(.system(size: 11))
-                        .foregroundStyle(.secondary)
-
-                    if settings.calendarIntegrationEnabled {
-                        Toggle("Include calendar context in cloud-generated notes", isOn: $settings.shareCalendarContextWithCloudNotes)
-                            .font(.system(size: 12))
-
-                        Text("When enabled, matching event titles, organizers, and invited participant names may be sent as text context to remote note providers. This does not apply to local providers like Ollama, MLX, or localhost OpenAI-compatible endpoints.")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
-
-                        CalendarStatusView()
-                    }
                 }
 
                 if !settings.ignoredAppBundleIDs.isEmpty {
@@ -1302,193 +1287,6 @@ private struct GranolaImportButton: View {
             } catch {
                 importState = .failed(error.localizedDescription)
                 isImporting = false
-            }
-        }
-    }
-}
-
-// MARK: - Calendar Status View
-
-/// Displays the current Calendar authorization state, the currently matching event
-/// (if any), and a short list of upcoming events. Scoped to Settings visibility —
-/// does not change session title or finalization behavior.
-private struct CalendarStatusView: View {
-    @Environment(AppContainer.self) private var container
-
-    @State private var accessState: CalendarManager.AccessState = .notDetermined
-    @State private var currentEvent: CalendarEvent?
-    @State private var upcomingEvents: [CalendarEvent] = []
-    @State private var refreshTick: Int = 0
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            statusRow
-
-            switch accessState {
-            case .authorized:
-                authorizedContent
-            case .denied:
-                deniedContent
-            case .notDetermined:
-                Text("OpenOats will ask for Calendar access shortly.")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-            }
-        }
-        .padding(.top, 4)
-        .task(id: refreshTick) {
-            await refresh()
-            // Periodic refresh while the Settings window is open.
-            try? await Task.sleep(for: .seconds(30))
-            refreshTick &+= 1
-        }
-    }
-
-    // MARK: - Subviews
-
-    private var statusRow: some View {
-        HStack(spacing: 6) {
-            Image(systemName: statusIcon)
-                .font(.system(size: 12))
-                .foregroundStyle(statusColor)
-            Text(statusLabel)
-                .font(.system(size: 12, weight: .medium))
-            Spacer()
-        }
-    }
-
-    @ViewBuilder
-    private var authorizedContent: some View {
-        if let event = currentEvent {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Currently matching")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-                Text(event.title)
-                    .font(.system(size: 12, weight: .medium))
-                Text(timeRange(for: event))
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-            }
-            .padding(8)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(Color.accentColor.opacity(0.1))
-            )
-        }
-
-        if upcomingEvents.isEmpty {
-            Text(currentEvent == nil
-                ? "No upcoming events in the next 12 hours."
-                : "No further upcoming events in the next 12 hours.")
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-        } else {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Upcoming")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-                ForEach(upcomingEvents) { event in
-                    HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Text(startTime(for: event))
-                            .font(.system(size: 11, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                            .frame(width: 58, alignment: .leading)
-                        Text(event.title)
-                            .font(.system(size: 12))
-                            .lineLimit(1)
-                            .truncationMode(.tail)
-                        Spacer()
-                    }
-                }
-            }
-        }
-    }
-
-    private var deniedContent: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Calendar access is denied. Grant access in System Settings for OpenOats to see your events.")
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-            Button("Open Privacy Settings…") {
-                openCalendarPrivacySettings()
-            }
-            .font(.system(size: 12))
-        }
-    }
-
-    // MARK: - Helpers
-
-    private var statusIcon: String {
-        switch accessState {
-        case .authorized: return "checkmark.circle.fill"
-        case .denied: return "exclamationmark.triangle.fill"
-        case .notDetermined: return "clock"
-        }
-    }
-
-    private var statusColor: Color {
-        switch accessState {
-        case .authorized: return .green
-        case .denied: return .orange
-        case .notDetermined: return .secondary
-        }
-    }
-
-    private var statusLabel: String {
-        switch accessState {
-        case .authorized: return "Calendar access authorized"
-        case .denied: return "Calendar access denied"
-        case .notDetermined: return "Calendar access not yet requested"
-        }
-    }
-
-    private func timeRange(for event: CalendarEvent) -> String {
-        let formatter = DateFormatter()
-        formatter.timeStyle = .short
-        formatter.dateStyle = .none
-        return "\(formatter.string(from: event.startDate)) – \(formatter.string(from: event.endDate))"
-    }
-
-    private func startTime(for event: CalendarEvent) -> String {
-        let formatter = DateFormatter()
-        formatter.timeStyle = .short
-        formatter.dateStyle = .none
-        return formatter.string(from: event.startDate)
-    }
-
-    @MainActor
-    private func refresh() async {
-        guard let manager = container.calendarManager else {
-            accessState = .notDetermined
-            currentEvent = nil
-            upcomingEvents = []
-            return
-        }
-        accessState = manager.accessState
-        if manager.accessState == .authorized {
-            let now = Date()
-            let current = manager.currentEvent(at: now)
-            currentEvent = current
-            let allUpcoming = manager.upcomingEvents(from: now, limit: 6)
-            upcomingEvents = allUpcoming.filter { $0.id != current?.id }.prefix(5).map { $0 }
-        } else {
-            currentEvent = nil
-            upcomingEvents = []
-        }
-    }
-
-    private func openCalendarPrivacySettings() {
-        let urls = [
-            "x-apple.systempreferences:com.apple.preference.security?Privacy_Calendars",
-            "x-apple.systempreferences:com.apple.preference.security?Privacy",
-        ]
-        for urlString in urls {
-            if let url = URL(string: urlString) {
-                if NSWorkspace.shared.open(url) { return }
             }
         }
     }

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -335,6 +335,23 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(store.shareCalendarContextWithCloudNotes)
     }
 
+    func testDefaultExcludedCalendarIDs() {
+        let store = makeStore()
+        XCTAssertEqual(store.excludedCalendarIDs, [])
+    }
+
+    func testExcludedCalendarIDsRoundTrip() {
+        let store = makeStore()
+        store.excludedCalendarIDs = ["work", "personal"]
+        XCTAssertEqual(store.excludedCalendarIDs, ["work", "personal"])
+    }
+
+    func testExcludedCalendarIDsAreNormalized() {
+        let store = makeStore()
+        store.excludedCalendarIDs = [" work ", "", "personal", "work"]
+        XCTAssertEqual(store.excludedCalendarIDs, ["work", "personal"])
+    }
+
     // MARK: - Privacy Settings Group
 
     func testDefaultHasAcknowledgedRecordingConsent() {


### PR DESCRIPTION
Closes #574

## Summary
- move Calendar out of General into its own Settings tab
- let users include or exclude individual calendars that OpenOats can use
- make reload rebuild CalendarManager / EventKit state so stale visibility bugs are easier to recover from

## UI
- reorganize the tab into a clearer flow: enable Calendar, choose included calendars, optionally share calendar details with cloud notes
- group visible calendars by source/account
- keep reload feedback inside the button instead of adding a separate status row
- tighten wording so local meeting identification and cloud sharing read as different decisions

## Behavior
- persist excluded calendar IDs in settings
- apply the selected calendars to current-event matching, auto-detection, and idle dashboard previews
- prune stale excluded IDs when calendars disappear

## Validation
- `swift build -c debug --package-path OpenOats`
- `swift test --package-path OpenOats --filter SettingsStoreTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`