### PR TITLE
Fix stale Past Meetings refresh and window height collapse on stop

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.74.3"
-  sha256 "4c856c05a54c4015d78d6a76f11270a03ec5083a767f83c24e5fcd7e2356631a"
+  version "1.74.4"
+  sha256 "77c5ee193ba0338df4b3c1d703205e7a6a81b4c5afb8364afc85c02ca1594f16"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -65,7 +65,7 @@ public struct OpenOatsRootApp: App {
                 }
         }
         .windowStyle(.hiddenTitleBar)
-        .windowResizability(.contentSize)
+        .windowResizability(.contentMinSize)
         .defaultSize(width: 320, height: 560)
         .commands {
             CommandGroup(after: .appInfo) {

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -169,6 +169,11 @@ struct NotesView: View {
         .onChange(of: coordinator.sessionHistory.count) {
             Task { await controller.loadHistory() }
         }
+        .onChange(of: coordinator.batchStatus) { _, newStatus in
+            if case .completed = newStatus {
+                Task { await controller.loadHistory() }
+            }
+        }
         .onChange(of: coordinator.requestedNotesNavigation?.id) {
             Task {
                 _ = await handleRequestedNotesNavigation(controller: controller)


### PR DESCRIPTION
## Summary

- **#577**: NotesView now observes `coordinator.batchStatus` so the Past Meetings list refreshes when batch transcription completes. Previously, only `sessionHistory.count` was observed, which doesn't change after batch completion (the session was already added when recording stopped).
- **#576**: Main window uses `.contentMinSize` instead of `.contentSize` so user-set height is preserved when recording stops and the content layout shrinks.
- Bumps Homebrew cask to v1.74.4.

Closes #577
Closes #576