### PR TITLE
Fix KB indexing resilience: partial success, empty chunks, URL normalization, provider errors

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.74.3"
-  sha256 "4c856c05a54c4015d78d6a76f11270a03ec5083a767f83c24e5fcd7e2356631a"
+  version "1.74.4"
+  sha256 "77c5ee193ba0338df4b3c1d703205e7a6a81b4c5afb8364afc85c02ca1594f16"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -65,7 +65,7 @@ public struct OpenOatsRootApp: App {
                 }
         }
         .windowStyle(.hiddenTitleBar)
-        .windowResizability(.contentSize)
+        .windowResizability(.contentMinSize)
         .defaultSize(width: 320, height: 560)
         .commands {
             CommandGroup(after: .appInfo) {

--- a/OpenOats/Sources/OpenOats/Intelligence/KnowledgeBase.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/KnowledgeBase.swift
@@ -253,17 +253,26 @@ final class KnowledgeBase {
         // Embed new/changed files in batches
         if !filesToEmbed.isEmpty {
             let allTextsToEmbed = filesToEmbed.flatMap { entry in
-                entry.chunks.map { chunk in
+                entry.chunks.compactMap { chunk -> String? in
+                    let trimmed = chunk.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { return nil }
                     var prefix = entry.relativePath
                     if !chunk.header.isEmpty { prefix += " > \(chunk.header)" }
-                    return "\(prefix)\n\(chunk.text)"
+                    return "\(prefix)\n\(trimmed)"
                 }
+            }
+
+            guard !allTextsToEmbed.isEmpty else {
+                finishIndexing(chunks: allChunks, fileCount: scanResult.fileCount)
+                return
             }
 
             indexingStatus = .embedding(completed: 0, total: allTextsToEmbed.count, activeRange: nil)
 
             let result = await embedInBatches(texts: allTextsToEmbed)
-            guard let embeddings = result.embeddings else {
+            let embeddings = result.embeddings
+
+            if embeddings.allSatisfy({ $0 == nil }) {
                 failIndexing(
                     message: result.error ?? "Embedding failed before any chunks were indexed.",
                     availableChunks: allChunks,
@@ -273,25 +282,37 @@ final class KnowledgeBase {
             }
 
             var offset = 0
+            var failedChunkCount = 0
             for entry in filesToEmbed {
                 var fileChunks: [KBChunk] = []
                 for chunk in entry.chunks {
-                    let embedding = embeddings[offset]
-                    let fileName = entry.key.components(separatedBy: ":").first ?? ""
-                    let kbChunk = KBChunk(
-                        text: chunk.text,
-                        sourceFile: fileName,
-                        headerContext: chunk.header,
-                        embedding: Self.normalizeEmbedding(embedding),
-                        relativePath: entry.relativePath,
-                        folderBreadcrumb: entry.folderBreadcrumb,
-                        documentTitle: entry.documentTitle
-                    )
-                    fileChunks.append(kbChunk)
+                    let trimmed = chunk.text.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { continue }
+                    if let embedding = embeddings[offset] {
+                        let fileName = entry.key.components(separatedBy: ":").first ?? ""
+                        let kbChunk = KBChunk(
+                            text: chunk.text,
+                            sourceFile: fileName,
+                            headerContext: chunk.header,
+                            embedding: Self.normalizeEmbedding(embedding),
+                            relativePath: entry.relativePath,
+                            folderBreadcrumb: entry.folderBreadcrumb,
+                            documentTitle: entry.documentTitle
+                        )
+                        fileChunks.append(kbChunk)
+                    } else {
+                        failedChunkCount += 1
+                    }
                     offset += 1
                 }
-                cache.entries[entry.key] = fileChunks
+                if !fileChunks.isEmpty {
+                    cache.entries[entry.key] = fileChunks
+                }
                 allChunks.append(contentsOf: fileChunks)
+            }
+
+            if failedChunkCount > 0 {
+                Log.knowledgeBase.warning("KB indexing: \(failedChunkCount) chunks failed to embed, continuing with partial results")
             }
 
             // Prune stale cache entries using pre-computed keys
@@ -729,36 +750,34 @@ final class KnowledgeBase {
         }
     }
 
-    private func embedInBatches(texts: [String]) async -> (embeddings: [[Float]]?, error: String?) {
+    private func embedInBatches(texts: [String]) async -> (embeddings: [[Float]?], error: String?) {
         let batchSize = 32
         let batches = stride(from: 0, to: texts.count, by: batchSize).map { start in
             Array(texts[start..<min(start + batchSize, texts.count)])
         }
 
-        // Ollama is local with no rate limits — fire all batches concurrently.
-        // Cloud providers (Voyage, OpenAI-compatible) are rate-limited, keep sequential.
         if settings.embeddingProvider == .ollama {
-            return await embedBatchesConcurrently(batches, total: texts.count)
+            return await embedBatchesConcurrently(batches, total: texts.count, batchSize: batchSize)
         } else {
-            return await embedBatchesSequentially(batches, total: texts.count)
+            return await embedBatchesSequentially(batches, total: texts.count, batchSize: batchSize)
         }
     }
 
-    private func embedBatchesConcurrently(_ batches: [[String]], total: Int) async -> (embeddings: [[Float]]?, error: String?) {
+    private func embedBatchesConcurrently(_ batches: [[String]], total: Int, batchSize: Int) async -> (embeddings: [[Float]?], error: String?) {
         if total > 0 {
-            indexingStatus = .embedding(completed: 0, total: total, activeRange: 1...min(32, total))
+            indexingStatus = .embedding(completed: 0, total: total, activeRange: 1...min(batchSize, total))
         }
-        typealias Indexed = (order: Int, embeddings: [[Float]]?)
+        typealias Indexed = (order: Int, embeddings: [[Float]]?, batchCount: Int)
         let results: [Indexed] = await withTaskGroup(of: Indexed.self) { group in
             for (i, batch) in batches.enumerated() {
                 group.addTask {
                     for attempt in 0..<2 {
                         if attempt > 0 { try? await Task.sleep(for: .seconds(1)) }
                         if let embs = try? await self.embedTexts(batch, inputType: "document") {
-                            return (i, embs)
+                            return (i, embs, batch.count)
                         }
                     }
-                    return (i, nil)
+                    return (i, nil, batch.count)
                 }
             }
             var collected: [Indexed] = []
@@ -772,26 +791,37 @@ final class KnowledgeBase {
             }
             return collected.sorted { $0.order < $1.order }
         }
-        guard !results.contains(where: { $0.embeddings == nil }) else {
-            return (nil, "One or more embedding batches failed")
+
+        var ordered: [[Float]?] = []
+        var lastError: String?
+        for result in results {
+            if let embs = result.embeddings {
+                ordered.append(contentsOf: embs.map { Optional($0) })
+            } else {
+                ordered.append(contentsOf: Array(repeating: nil as [Float]?, count: result.batchCount))
+                lastError = "One or more embedding batches failed"
+            }
         }
-        return (results.flatMap { $0.embeddings! }, nil)
+        return (ordered, lastError)
     }
 
-    private func embedBatchesSequentially(_ batches: [[String]], total: Int) async -> (embeddings: [[Float]]?, error: String?) {
-        var allEmbeddings: [[Float]] = []
+    private func embedBatchesSequentially(_ batches: [[String]], total: Int, batchSize: Int) async -> (embeddings: [[Float]?], error: String?) {
+        var allEmbeddings: [[Float]?] = []
         var offset = 0
+        var lastError: String?
         for batch in batches {
             let rangeStart = offset + 1
             let rangeEnd = offset + batch.count
             indexingStatus = .embedding(completed: offset, total: total, activeRange: rangeStart...rangeEnd)
             var retried = false
+            var succeeded = false
             while true {
                 do {
                     let embeddings = try await embedTexts(batch, inputType: "document")
-                    allEmbeddings.append(contentsOf: embeddings)
+                    allEmbeddings.append(contentsOf: embeddings.map { Optional($0) })
                     offset += embeddings.count
                     indexingStatus = .embedding(completed: min(offset, total), total: total, activeRange: nil)
+                    succeeded = true
                     break
                 } catch {
                     if !retried {
@@ -799,11 +829,16 @@ final class KnowledgeBase {
                         try? await Task.sleep(for: .seconds(1))
                         continue
                     }
-                    return (nil, error.localizedDescription)
+                    lastError = error.localizedDescription
+                    break
                 }
             }
+            if !succeeded {
+                allEmbeddings.append(contentsOf: Array(repeating: nil as [Float]?, count: batch.count))
+                offset += batch.count
+            }
         }
-        return (allEmbeddings, nil)
+        return (allEmbeddings, lastError)
     }
 
     // MARK: - Vector Math

--- a/OpenOats/Sources/OpenOats/Intelligence/OllamaEmbedClient.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/OllamaEmbedClient.swift
@@ -1,24 +1,26 @@
 import Foundation
 
-/// Client for Ollama's OpenAI-compatible embeddings endpoint.
+/// Client for Ollama and OpenAI-compatible embeddings endpoints.
 actor OllamaEmbedClient {
-    enum OllamaEmbedError: Error, LocalizedError {
-        case httpError(Int, String)
-        case invalidURL
-        case emptyResponse
+    enum EmbedClientError: Error, LocalizedError {
+        case httpError(Int, String, provider: String)
+        case invalidURL(provider: String)
+        case emptyResponse(provider: String)
 
         var errorDescription: String? {
             switch self {
-            case .httpError(let code, let msg): "Ollama embed error (HTTP \(code)): \(msg)"
-            case .invalidURL: "Invalid Ollama base URL"
-            case .emptyResponse: "Empty response from Ollama embeddings"
+            case .httpError(let code, let msg, let provider): "\(provider) embed error (HTTP \(code)): \(msg)"
+            case .invalidURL(let provider): "Invalid \(provider) base URL"
+            case .emptyResponse(let provider): "Empty response from \(provider) embeddings"
             }
         }
     }
 
     func embed(texts: [String], baseURL: String, model: String, apiKey: String? = nil) async throws -> [[Float]] {
-        guard let url = URL(string: baseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/v1/embeddings") else {
-            throw OllamaEmbedError.invalidURL
+        let providerName = apiKey != nil ? "OpenAI Compatible" : "Ollama"
+        let normalized = Self.normalizeBaseURL(baseURL)
+        guard let url = URL(string: normalized + "/v1/embeddings") else {
+            throw EmbedClientError.invalidURL(provider: providerName)
         }
 
         let body = EmbedRequest(model: model, input: texts)
@@ -34,20 +36,30 @@ actor OllamaEmbedClient {
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let http = response as? HTTPURLResponse else {
-            throw OllamaEmbedError.httpError(-1, "No HTTP response")
+            throw EmbedClientError.httpError(-1, "No HTTP response", provider: providerName)
         }
 
         guard (200...299).contains(http.statusCode) else {
             let msg = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw OllamaEmbedError.httpError(http.statusCode, msg)
+            throw EmbedClientError.httpError(http.statusCode, msg, provider: providerName)
         }
 
         let decoded = try JSONDecoder().decode(EmbedResponse.self, from: data)
-        guard !decoded.data.isEmpty else { throw OllamaEmbedError.emptyResponse }
+        guard !decoded.data.isEmpty else { throw EmbedClientError.emptyResponse(provider: providerName) }
 
         return decoded.data
             .sorted { $0.index < $1.index }
             .map { $0.embedding }
+    }
+
+    /// Strips trailing slashes and a trailing `/v1` path segment so callers
+    /// can enter either `http://localhost:11434` or `http://localhost:11434/v1`.
+    static func normalizeBaseURL(_ raw: String) -> String {
+        var url = raw.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        if url.hasSuffix("/v1") {
+            url = String(url.dropLast(3))
+        }
+        return url
     }
 
     // MARK: - Request/Response Types

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -169,6 +169,11 @@ struct NotesView: View {
         .onChange(of: coordinator.sessionHistory.count) {
             Task { await controller.loadHistory() }
         }
+        .onChange(of: coordinator.batchStatus) { _, newStatus in
+            if case .completed = newStatus {
+                Task { await controller.loadHistory() }
+            }
+        }
         .onChange(of: coordinator.requestedNotesNavigation?.id) {
             Task {
                 _ = await handleRequestedNotesNavigation(controller: controller)


### PR DESCRIPTION
Closes #579

## Summary

- **Partial success on batch failures**: Instead of aborting the entire indexing run when a single embedding batch fails, continue with remaining batches and index all successfully embedded chunks. Only fail if every batch fails.
- **Empty chunk filtering**: Skip whitespace-only chunks before sending them to the embedding API, preventing spurious HTTP 400 errors from providers that reject empty inputs.
- **Base URL normalization**: Strip trailing `/v1` from the embedding base URL before appending `/v1/embeddings`, fixing the path-doubling issue (`/v1/v1/embeddings`) reported when users enter `https://api.openai.com/v1` as their base URL.
- **Provider-aware error messages**: Error messages now show the actual provider name ("Ollama" or "OpenAI Compatible") instead of always saying "Ollama".

## Test plan

- [x] Full test suite passes (633 tests, 0 failures)
- [x] Release build compiles cleanly
- [ ] Verify with Ollama: indexing a KB folder with mixed file sizes completes partially when some chunks exceed context length
- [ ] Verify with OpenAI-compatible provider: base URL `https://api.openai.com/v1` no longer produces 404s
- [ ] Verify error banner shows correct provider name