### PR TITLE
Fix false positive system audio banner and Open Settings button (#580)

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.74.5"
-  sha256 "13b38f43a9cd9de544dbe47547ace62f86fa4eba520112c7c0074dd003202fa5"
+  version "1.74.6"
+  sha256 "a63e0b9defbf07b0094512166f07f1d45df54b2b52c048a5ffd824925925f961"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -143,6 +143,8 @@ final class LiveSessionController {
     /// preventing the auto-dismiss → re-poll cycle from re-triggering the notification.
     private var lastNotifiedBatchSessionID: String?
     private var observedPeakAudioLevelSinceStart: Float = 0
+    private var observedSystemHasEverCapturedFrames = false
+    private var observedMicHasEverCapturedFrames = false
     private var pendingRecoveryDiagnostics: PendingRecoveryDiagnostics?
 
     init(coordinator: AppCoordinator, container: AppContainer) {
@@ -1370,13 +1372,19 @@ final class LiveSessionController {
             observedPeakAudioLevelSinceStart = max(observedPeakAudioLevelSinceStart, currentState.audioLevel)
             if case .recording(let metadata) = currentState.sessionPhase {
                 let captureHealth = coordinator.transcriptionEngine?.captureHealthSnapshot
+                if captureHealth?.systemHasCapturedFrames == true {
+                    observedSystemHasEverCapturedFrames = true
+                }
+                if captureHealth?.micHasCapturedFrames == true {
+                    observedMicHasEverCapturedFrames = true
+                }
                 let input = RecordingHealthInput(
                     elapsed: max(0, Date().timeIntervalSince(metadata.startedAt)),
                     transcriptionModel: settings.transcriptionModel,
                     utteranceCount: utteranceCount,
                     peakAudioLevel: observedPeakAudioLevelSinceStart,
-                    micHasCapturedFrames: captureHealth?.micHasCapturedFrames ?? false,
-                    systemHasCapturedFrames: captureHealth?.systemHasCapturedFrames ?? false,
+                    micHasCapturedFrames: observedMicHasEverCapturedFrames,
+                    systemHasCapturedFrames: observedSystemHasEverCapturedFrames,
                     micCaptureError: captureHealth?.micCaptureError,
                     isMicMuted: currentState.isMicMuted,
                     isRecordingPaused: currentState.isRecordingPaused,
@@ -1388,6 +1396,8 @@ final class LiveSessionController {
             }
         } else {
             observedPeakAudioLevelSinceStart = 0
+            observedSystemHasEverCapturedFrames = false
+            observedMicHasEverCapturedFrames = false
             set(\.recordingHealthNotice, nil)
         }
 

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -395,6 +395,7 @@ struct ContentView: View {
     }
 
     private func openSettingsWindow() {
+        NSApp.activate()
         NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
     }
 


### PR DESCRIPTION
## Summary

- **False positive banner**: The "No system audio — Check output device" warning could appear during an active recording even when system audio was being captured and transcribed correctly. Root cause: output device changes mid-recording restart the system audio capture, transiently resetting `hasCapturedFrames`. The health poll could fire during this window and show the warning. Fixed by latching capture-detected flags across the session in `LiveSessionController`, following the existing `observedPeakAudioLevelSinceStart` pattern.
- **Dead Open Settings button**: The "Open Settings" button on recording health banners did nothing when the app wasn't frontmost (user is in their meeting app). Fixed by activating the app before sending the `showSettingsWindow:` action.
- **Homebrew cask**: Bumps to v1.74.6.

## Test plan

- [x] `swift build` compiles cleanly
- [x] `LiveSessionControllerTests` — all 40 tests pass
- [ ] `validate-swift` CI check
- [ ] `package-smoke` CI check

Closes #580