### PR TITLE
Bump Homebrew cask to v1.74.7

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.74.6"
-  sha256 "a63e0b9defbf07b0094512166f07f1d45df54b2b52c048a5ffd824925925f961"
+  version "1.74.7"
+  sha256 "ad83690d55be7a0e99efdf5f6129c64848a61ef4a2cc99c7773c57840ad921d1"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
## Summary
- Update Homebrew cask version from 1.74.6 to 1.74.7
- Update sha256 checksum for the new DMG

Housekeeping change — catches up the cask to the latest release.