### PR TITLE
Fix white top and bottom bands in the main window

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -230,6 +230,7 @@ struct ContentView: View {
                 }
             )
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     private var bodyWithModifiers: some View {
@@ -238,7 +239,7 @@ struct ContentView: View {
 
     private var sizedRootContent: some View {
         rootContent
-            .frame(minWidth: 360, maxWidth: 600, minHeight: 400)
+            .frame(minWidth: 360, maxWidth: 600, minHeight: 400, maxHeight: .infinity, alignment: .top)
             .background(.ultraThinMaterial)
     }
 


### PR DESCRIPTION
Closes #585

## Summary
- make the main window content fill the available height instead of only declaring a minimum height
- keep the content top-aligned so taller restored windows do not expose white window background above and below the material content
- fix the latent content-fill bug instead of reverting the `.contentMinSize` window behavior from `#578`

## Why this regressed
The underlying layout bug was already present in `ContentView`, but it became visible after `#578` switched the main window to `.windowResizability(.contentMinSize)`. That change fixed the window collapsing issue, but it also stopped hiding the fact that the content was not filling taller windows.

## Validation
- `swift build -c debug`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`