### PR TITLE
Fix system audio capture on USB output devices

### DIFF
--- a/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
@@ -73,7 +73,6 @@ final class SystemAudioCapture: @unchecked Sendable {
         tapDescription.isMono = true
         tapDescription.isExclusive = true
         tapDescription.deviceUID = outputUID
-        tapDescription.stream = 0
 
         var tapID = AudioObjectID(kAudioObjectUnknown)
         var status = AudioHardwareCreateProcessTap(tapDescription, &tapID)
@@ -86,20 +85,12 @@ final class SystemAudioCapture: @unchecked Sendable {
         let aggregateDescription: [String: Any] = [
             kAudioAggregateDeviceNameKey: "OpenOats System Audio",
             kAudioAggregateDeviceUIDKey: aggregateUID,
-            kAudioAggregateDeviceMainSubDeviceKey: outputUID,
             kAudioAggregateDeviceIsPrivateKey: true,
-            kAudioAggregateDeviceIsStackedKey: false,
             kAudioAggregateDeviceTapAutoStartKey: true,
-            kAudioAggregateDeviceSubDeviceListKey: [
-                [
-                    kAudioSubDeviceUIDKey: outputUID,
-                    kAudioSubDeviceInputChannelsKey: []
-                ]
-            ],
             kAudioAggregateDeviceTapListKey: [
                 [
-                    kAudioSubTapDriftCompensationKey: true,
-                    kAudioSubTapUIDKey: tapUUID.uuidString
+                    kAudioSubTapUIDKey: tapUUID.uuidString,
+                    kAudioSubTapDriftCompensationKey: true
                 ]
             ]
         ]


### PR DESCRIPTION
## Summary

- Remove hardcoded `tapDescription.stream = 0` so the process tap captures from all output streams (fixes USB interfaces whose playback stream isn't at index 0)
- Switch to a tap-only aggregate device by dropping subdevice configuration keys that caused the IO proc to never fire on USB hardware
- Tap remains device-pinned via `tapDescription.deviceUID`, so capture is still scoped correctly

Based on the analysis and fix from @andrewphahn in #590. Closes #590.

## Test plan

- [x] `swift build` compiles cleanly
- [ ] CI: validate-swift, package-smoke, ui-smoke