### PR TITLE
Bump Homebrew cask to v1.74.9

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.74.8"
-  sha256 "31774583b2a76ff9419bfcd263fb5c190220a895865be1c650971c4d71aeb643"
+  version "1.74.9"
+  sha256 "a059c2d7427cec12efe356faa2a18a906f3e77aa7e136c7aa36a2540ef913754"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
@@ -73,7 +73,6 @@ final class SystemAudioCapture: @unchecked Sendable {
         tapDescription.isMono = true
         tapDescription.isExclusive = true
         tapDescription.deviceUID = outputUID
-        tapDescription.stream = 0
 
         var tapID = AudioObjectID(kAudioObjectUnknown)
         var status = AudioHardwareCreateProcessTap(tapDescription, &tapID)
@@ -86,20 +85,12 @@ final class SystemAudioCapture: @unchecked Sendable {
         let aggregateDescription: [String: Any] = [
             kAudioAggregateDeviceNameKey: "OpenOats System Audio",
             kAudioAggregateDeviceUIDKey: aggregateUID,
-            kAudioAggregateDeviceMainSubDeviceKey: outputUID,
             kAudioAggregateDeviceIsPrivateKey: true,
-            kAudioAggregateDeviceIsStackedKey: false,
             kAudioAggregateDeviceTapAutoStartKey: true,
-            kAudioAggregateDeviceSubDeviceListKey: [
-                [
-                    kAudioSubDeviceUIDKey: outputUID,
-                    kAudioSubDeviceInputChannelsKey: []
-                ]
-            ],
             kAudioAggregateDeviceTapListKey: [
                 [
-                    kAudioSubTapDriftCompensationKey: true,
-                    kAudioSubTapUIDKey: tapUUID.uuidString
+                    kAudioSubTapUIDKey: tapUUID.uuidString,
+                    kAudioSubTapDriftCompensationKey: true
                 ]
             ]
         ]


### PR DESCRIPTION
## Summary
- Update Homebrew cask version from 1.74.8 to 1.74.9
- SHA256 from automation branch `automation/homebrew-cask-1.74.9`