### PR TITLE
Retry system audio tap format read for Sequoia 15.7.x race

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.74.8"
-  sha256 "31774583b2a76ff9419bfcd263fb5c190220a895865be1c650971c4d71aeb643"
+  version "1.74.9"
+  sha256 "a059c2d7427cec12efe356faa2a18a906f3e77aa7e136c7aa36a2540ef913754"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.74.9"
-  sha256 "a059c2d7427cec12efe356faa2a18a906f3e77aa7e136c7aa36a2540ef913754"
+  version "1.74.10"
+  sha256 "836c7a967233348097ed535af644309c5083c70e7f5a980b83cdb9cc7b2e16ca"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
@@ -73,7 +73,6 @@ final class SystemAudioCapture: @unchecked Sendable {
         tapDescription.isMono = true
         tapDescription.isExclusive = true
         tapDescription.deviceUID = outputUID
-        tapDescription.stream = 0
 
         var tapID = AudioObjectID(kAudioObjectUnknown)
         var status = AudioHardwareCreateProcessTap(tapDescription, &tapID)
@@ -86,20 +85,12 @@ final class SystemAudioCapture: @unchecked Sendable {
         let aggregateDescription: [String: Any] = [
             kAudioAggregateDeviceNameKey: "OpenOats System Audio",
             kAudioAggregateDeviceUIDKey: aggregateUID,
-            kAudioAggregateDeviceMainSubDeviceKey: outputUID,
             kAudioAggregateDeviceIsPrivateKey: true,
-            kAudioAggregateDeviceIsStackedKey: false,
             kAudioAggregateDeviceTapAutoStartKey: true,
-            kAudioAggregateDeviceSubDeviceListKey: [
-                [
-                    kAudioSubDeviceUIDKey: outputUID,
-                    kAudioSubDeviceInputChannelsKey: []
-                ]
-            ],
             kAudioAggregateDeviceTapListKey: [
                 [
-                    kAudioSubTapDriftCompensationKey: true,
-                    kAudioSubTapUIDKey: tapUUID.uuidString
+                    kAudioSubTapUIDKey: tapUUID.uuidString,
+                    kAudioSubTapDriftCompensationKey: true
                 ]
             ]
         ]

--- a/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
+++ b/OpenOats/Sources/OpenOats/Audio/SystemAudioCapture.swift
@@ -365,19 +365,24 @@ final class SystemAudioCapture: @unchecked Sendable {
         var streamDescription = AudioStreamBasicDescription()
         var dataSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
 
-        let status = AudioObjectGetPropertyData(
-            tapID,
-            &address,
-            0,
-            nil,
-            &dataSize,
-            &streamDescription
-        )
-
-        guard status == noErr else {
-            throw CaptureError.tapFormatUnavailable(status)
+        // Retry on kAudioHardwareBadObjectError — Sequoia 15.7.x has a race where
+        // the tap's AudioObjectID isn't resolvable for a few tens of milliseconds
+        // after AudioHardwareCreateProcessTap returns.
+        var status: OSStatus = noErr
+        for _ in 0..<10 {
+            status = AudioObjectGetPropertyData(
+                tapID,
+                &address,
+                0,
+                nil,
+                &dataSize,
+                &streamDescription
+            )
+            if status == noErr { return streamDescription }
+            if status != kAudioHardwareBadObjectError { break }
+            usleep(50_000)
         }
-        return streamDescription
+        throw CaptureError.tapFormatUnavailable(status)
     }
 
     enum CaptureError: LocalizedError {


### PR DESCRIPTION
## Summary

- Fixes #596 — system audio capture fails 100% on macOS Sequoia 15.7.x due to a race in `coreaudiod` where the tap's `AudioObjectID` isn't resolvable for a few tens of milliseconds after `AudioHardwareCreateProcessTap` returns
- Adds a retry loop (up to 10 attempts, 50ms apart) on `kAudioHardwareBadObjectError` in `tapStreamDescription(for:)` before giving up
- Bumps Homebrew cask to v1.74.10

## Test plan

- [ ] Build succeeds (verified locally)
- [ ] On macOS Sequoia 15.7.x: system audio capture should now succeed after retry instead of failing silently
- [ ] On macOS Tahoe: no behavioral change (first attempt succeeds, retry never fires)
- [ ] Verify non-transient errors still fail immediately without retry