### PR TITLE
Fix re-transcribe crash by copying SPM resource bundles

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.74.10"
-  sha256 "836c7a967233348097ed535af644309c5083c70e7f5a980b83cdb9cc7b2e16ca"
+  version "1.74.11"
+  sha256 "0d9f1758d531448bed69f471256559c8e4d1bf77f23eb450ba3d7e20f96bd7a7"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/scripts/build_swift_app.sh
+++ b/scripts/build_swift_app.sh
@@ -76,6 +76,20 @@ else
   echo "Warning: Sparkle.framework not found in build artifacts"
 fi
 
+# Copy SPM resource bundles (needed by swift-transformers for tokenizer fallback configs)
+ARCH=$(uname -m)
+BUNDLE_DIR="$SWIFT_DIR/.build/${ARCH}-apple-macosx/release"
+COPIED_BUNDLES=0
+for bundle in "$BUNDLE_DIR"/*.bundle; do
+  if [[ -d "$bundle" ]]; then
+    cp -R "$bundle" "$APP_DIR/Contents/Resources/"
+    COPIED_BUNDLES=$((COPIED_BUNDLES + 1))
+  fi
+done
+if [[ $COPIED_BUNDLES -gt 0 ]]; then
+  echo "Copied $COPIED_BUNDLES SPM resource bundle(s)"
+fi
+
 # Add PkgInfo
 echo -n "APPL????" > "$APP_DIR/Contents/PkgInfo"
 


### PR DESCRIPTION
Closes #598

## Summary

- The build script was not copying SPM resource bundles into the `.app` bundle. When WhisperKit's tokenizer loading fell back to `Bundle.module` (via `LanguageModelConfigurationFromHub.fallbackTokenizerConfig`), the missing `swift-transformers_Hub.bundle` caused an assertion failure crash (`EXC_BREAKPOINT / SIGTRAP`).
- Adds a step in `build_swift_app.sh` to copy all `*.bundle` directories from the SPM release build output into `Contents/Resources/`.
- Also bumps Homebrew cask to v1.74.11.