### PR TITLE
Make the main window the default meeting review surface

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -75,6 +75,12 @@ final class AppCoordinator {
         set { withMutation(keyPath: \.requestedNotesNavigation) { _requestedNotesNavigation = newValue } }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _requestedHomeNavigation: NotesNavigationRequest?
+    var requestedHomeNavigation: NotesNavigationRequest? {
+        get { access(keyPath: \.requestedHomeNavigation); return _requestedHomeNavigation }
+        set { withMutation(keyPath: \.requestedHomeNavigation) { _requestedHomeNavigation = newValue } }
+    }
+
     var isRecording: Bool {
         if case .recording = state { return true }
         return false
@@ -268,6 +274,35 @@ final class AppCoordinator {
     func consumeRequestedSessionSelection() -> NotesNavigationRequest.Target? {
         defer { requestedNotesNavigation = nil }
         return requestedNotesNavigation?.target
+    }
+
+    func queueHomeSessionSelection(_ sessionID: String?) {
+        if let sessionID {
+            requestedHomeNavigation = NotesNavigationRequest(target: .session(sessionID))
+        } else {
+            requestedHomeNavigation = NotesNavigationRequest(target: .clearSelection)
+        }
+    }
+
+    func queueHomeTranscriptSessionSelection(_ sessionID: String) {
+        requestedHomeNavigation = NotesNavigationRequest(target: .transcriptSession(sessionID))
+    }
+
+    func queueHomeSessionRetranscription(_ sessionID: String) {
+        requestedHomeNavigation = NotesNavigationRequest(target: .retranscribeSession(sessionID))
+    }
+
+    func queueHomeMeetingHistory(_ event: CalendarEvent) {
+        requestedHomeNavigation = NotesNavigationRequest(target: .meetingHistory(event))
+    }
+
+    func queueHomeManualTranscript(_ event: CalendarEvent) {
+        requestedHomeNavigation = NotesNavigationRequest(target: .manualTranscript(event))
+    }
+
+    func consumeRequestedHomeNavigation() -> NotesNavigationRequest.Target? {
+        defer { requestedHomeNavigation = nil }
+        return requestedHomeNavigation?.target
     }
 
     // MARK: - Detection Event Loop

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -80,7 +80,7 @@ public struct OpenOatsRootApp: App {
                 }
                 .keyboardShortcut("l", modifiers: [.command, .shift])
 
-                Button("Past Meetings") {
+                Button("Notes Workspace") {
                     openNotesWindow()
                 }
                 .keyboardShortcut("m", modifiers: [.command, .shift])
@@ -99,7 +99,7 @@ public struct OpenOatsRootApp: App {
             }
         }
 
-        Window("Notes", id: "notes") {
+        Window("Notes Workspace", id: "notes") {
             NotesView(settings: settings)
                 .environment(container)
                 .environment(coordinator)
@@ -130,7 +130,7 @@ extension OpenOatsRootApp {
 
     private func openNotesWindow() {
         openWindow(id: "notes")
-        bringWindowToFront(id: "notes", title: "Notes")
+        bringWindowToFront(id: "notes", title: "Notes Workspace")
     }
 
     private func bringWindowToFront(id: String, title: String) {
@@ -223,9 +223,9 @@ extension OpenOatsRootApp {
             // Check result
             let status = await batchAudioTranscriber.status
             if case .completed = status {
-                coordinator.queueSessionSelection(sessionID)
-                openNotesWindow()
                 await coordinator.loadHistory()
+                coordinator.queueHomeSessionSelection(sessionID)
+                showMainWindow()
             } else if case .failed = status {
                 // Clean up the orphaned session
                 await repo.deleteSession(sessionID: sessionID)

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -42,7 +42,7 @@ struct ContentView: View {
                     HStack(spacing: 4) {
                         Image(systemName: "note.text")
                             .font(.system(size: 11))
-                        Text("Past Meetings")
+                        Text("Notes Workspace")
                             .font(.system(size: 11))
                     }
                     .padding(.horizontal, 6)
@@ -51,8 +51,8 @@ struct ContentView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(.secondary)
-                .help("View past meeting notes")
-                .accessibilityIdentifier("app.pastMeetingsButton")
+                .help("Open the advanced notes workspace")
+                .accessibilityIdentifier("app.notesWorkspaceButton")
 
                 SettingsLink {
                     Image(systemName: "gearshape")
@@ -77,19 +77,16 @@ struct ContentView: View {
                     canRetranscribe: controllerState.lastEndedSessionCanRetranscribe,
                     recoveryIsPending: coordinator.pendingRecoverySessionID == lastSession.id,
                     onOpenTranscript: {
-                        coordinator.queueTranscriptSessionSelection(lastSession.id)
-                        openWindow(id: "notes")
+                        coordinator.queueHomeTranscriptSessionSelection(lastSession.id)
                     },
                     onOpenNotes: {
-                        coordinator.queueSessionSelection(lastSession.id)
-                        openWindow(id: "notes")
+                        coordinator.queueHomeSessionSelection(lastSession.id)
                     },
                     onGenerateNotes: {
-                        openWindow(id: "notes")
+                        coordinator.queueHomeSessionSelection(lastSession.id)
                     },
                     onRetranscribe: {
-                        coordinator.queueSessionRetranscription(lastSession.id)
-                        openWindow(id: "notes")
+                        coordinator.queueHomeSessionRetranscription(lastSession.id)
                     }
                 )
             }

--- a/OpenOats/Sources/OpenOats/Views/HomeTimelineWorkspaceView.swift
+++ b/OpenOats/Sources/OpenOats/Views/HomeTimelineWorkspaceView.swift
@@ -41,6 +41,7 @@ struct HomeTimelineWorkspaceView: View {
             await container.seedIfNeeded(coordinator: coordinator)
             await coordinator.loadHistory()
             await controller.loadHistory()
+            _ = await handleRequestedHomeNavigation(controller: controller)
         }
         .task(id: refreshTaskID(for: accessState)) {
             await refreshCalendarEvents()
@@ -57,6 +58,12 @@ struct HomeTimelineWorkspaceView: View {
         .onChange(of: coordinator.batchStatus) { _, newStatus in
             if case .completed = newStatus {
                 Task { await notesController?.loadHistory() }
+            }
+        }
+        .onChange(of: coordinator.requestedHomeNavigation?.id) {
+            guard let controller = notesController else { return }
+            Task {
+                _ = await handleRequestedHomeNavigation(controller: controller)
             }
         }
         .sheet(
@@ -293,6 +300,59 @@ struct HomeTimelineWorkspaceView: View {
     }
 
     @MainActor
+    private func handleRequestedHomeNavigation(controller: NotesController) async -> Bool {
+        guard let requested = coordinator.consumeRequestedHomeNavigation() else { return false }
+
+        switch requested {
+        case .session(let sessionID):
+            controller.selectSession(sessionID)
+            let selectedSession = coordinator.sessionHistory.first(where: { $0.id == sessionID })
+                ?? controller.state.sessionHistory.first(where: { $0.id == sessionID })
+            detailViewMode = selectedSession?.source == "imported" ? .transcript : .notes
+            selectedEntryID = "session:\(sessionID)"
+            resizeMainWindow(detailVisible: true)
+        case .transcriptSession(let sessionID):
+            controller.selectSession(sessionID)
+            detailViewMode = .transcript
+            selectedEntryID = "session:\(sessionID)"
+            resizeMainWindow(detailVisible: true)
+        case .retranscribeSession(let sessionID):
+            controller.selectSession(sessionID)
+            detailViewMode = .transcript
+            selectedEntryID = "session:\(sessionID)"
+            resizeMainWindow(detailVisible: true)
+            try? await Task.sleep(for: .milliseconds(200))
+            if controller.state.canRetranscribeSelectedSession {
+                container.ensureRecordingServicesInitialized(settings: settings, coordinator: coordinator)
+                controller.rerunBatchTranscription(
+                    model: settings.batchTranscriptionModel,
+                    settings: settings
+                )
+            }
+        case .meetingHistory(let event):
+            controller.showMeetingFamily(for: event)
+            detailViewMode = .notes
+            selectedEntryID = "calendar:\(event.id)"
+            resizeMainWindow(detailVisible: true)
+        case .manualTranscript(let event):
+            detailViewMode = .transcript
+            selectedEntryID = "calendar:\(event.id)"
+            resizeMainWindow(detailVisible: true)
+            let shouldPromptForTranscript = await controller.prepareManualTranscriptSession(for: event)
+            if shouldPromptForTranscript {
+                beginAddTranscript()
+            }
+        case .clearSelection:
+            controller.selectSession(nil)
+            detailViewMode = .notes
+            selectedEntryID = nil
+            resizeMainWindow(detailVisible: false)
+        }
+
+        return true
+    }
+
+    @MainActor
     private func refreshCalendarEvents() async {
         guard settings.calendarIntegrationEnabled, let manager = container.calendarManager else {
             calendarEvents = []
@@ -378,6 +438,11 @@ struct HomeTimelineWorkspaceView: View {
             guard let url = URL(string: urlString) else { continue }
             if NSWorkspace.shared.open(url) { return }
         }
+    }
+
+    private func beginAddTranscript() {
+        manualTranscriptDraft = ""
+        showingAddTranscriptSheet = true
     }
 
     private func resizeMainWindow(detailVisible: Bool) {

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -5,7 +5,6 @@ struct IdleHomeDashboardView: View {
     @Bindable var settings: AppSettings
     @Environment(AppContainer.self) private var container
     @Environment(AppCoordinator.self) private var coordinator
-    @Environment(\.openWindow) private var openWindow
 
     @State private var events: [CalendarEvent] = []
     @State private var earlierTodayEvents: [CalendarEvent] = []
@@ -301,11 +300,10 @@ struct IdleHomeDashboardView: View {
 
     private func openRelatedNotes(for event: CalendarEvent) {
         if event.endDate <= Date() {
-            coordinator.queueManualTranscript(event)
+            coordinator.queueHomeManualTranscript(event)
         } else {
-            coordinator.queueMeetingHistory(event)
+            coordinator.queueHomeMeetingHistory(event)
         }
-        openWindow(id: "notes")
     }
 
     private func beginCreateFolder(for event: CalendarEvent) {

--- a/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
+++ b/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
@@ -639,30 +639,11 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
 
             VStack(alignment: .leading, spacing: 10) {
                 HStack(alignment: .top, spacing: 12) {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text(event.title)
-                            .font(.system(size: 26, weight: .semibold))
-                            .foregroundStyle(.primary)
-
-                        HStack(spacing: 12) {
-                            Text(CalendarEventDisplay.timeRange(for: event))
-                            if let calendarTitle = event.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-                               !calendarTitle.isEmpty {
-                                Text(calendarTitle)
-                            }
-                            meetingFamilyFolderMenu(
-                                controller: controller,
-                                selection: selection,
-                                historyCount: historyCount,
-                                preferredFolderPath: preferredFolderPath,
-                                preferredFolder: preferredFolder,
-                                folders: folders
-                            )
-                            meetingFamilyKnowledgeBaseSignal(state: state)
-                        }
-                        .font(.system(size: 13))
-                        .foregroundStyle(.secondary)
-                    }
+                    Text(event.title)
+                        .font(.system(size: 26, weight: .semibold))
+                        .foregroundStyle(.primary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .layoutPriority(1)
 
                     Spacer(minLength: 0)
 
@@ -696,7 +677,20 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                             .disabled(coordinator.isRecording)
                         }
                     }
+                    .fixedSize(horizontal: true, vertical: false)
                 }
+
+                meetingFamilyOverviewMetadataRow(
+                    leadingText: CalendarEventDisplay.timeRange(for: event),
+                    trailingText: event.calendarTitle,
+                    controller: controller,
+                    state: state,
+                    selection: selection,
+                    historyCount: historyCount,
+                    preferredFolderPath: preferredFolderPath,
+                    preferredFolder: preferredFolder,
+                    folders: folders
+                )
 
                 VStack(alignment: .leading, spacing: 0) {
                     TextEditor(text: prepNotes)
@@ -733,25 +727,18 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                     .font(.system(size: 26, weight: .semibold))
                     .foregroundStyle(.primary)
 
-                HStack(spacing: 12) {
-                    Text("Meeting history")
-                    Text("\(historyCount) saved meeting\(historyCount == 1 ? "" : "s")")
-                    if let calendarTitle = selection.calendarTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
-                       !calendarTitle.isEmpty {
-                        Text(calendarTitle)
-                    }
-                    meetingFamilyFolderMenu(
-                        controller: controller,
-                        selection: selection,
-                        historyCount: historyCount,
-                        preferredFolderPath: preferredFolderPath,
-                        preferredFolder: preferredFolder,
-                        folders: folders
-                    )
-                    meetingFamilyKnowledgeBaseSignal(state: state)
-                }
-                .font(.system(size: 13))
-                .foregroundStyle(.secondary)
+                meetingFamilyOverviewMetadataRow(
+                    leadingText: "Meeting history",
+                    secondaryText: "\(historyCount) saved meeting\(historyCount == 1 ? "" : "s")",
+                    trailingText: selection.calendarTitle,
+                    controller: controller,
+                    state: state,
+                    selection: selection,
+                    historyCount: historyCount,
+                    preferredFolderPath: preferredFolderPath,
+                    preferredFolder: preferredFolder,
+                    folders: folders
+                )
             }
             .padding(18)
             .background(
@@ -763,6 +750,54 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                     .strokeBorder(.quaternary, lineWidth: 1)
             )
         }
+    }
+
+    @ViewBuilder
+    private func meetingFamilyOverviewMetadataRow(
+        leadingText: String,
+        secondaryText: String? = nil,
+        trailingText: String?,
+        controller: NotesController,
+        state: NotesState,
+        selection: MeetingFamilySelection,
+        historyCount: Int,
+        preferredFolderPath: String?,
+        preferredFolder: NotesFolderDefinition?,
+        folders: [NotesFolderDefinition]
+    ) -> some View {
+        FlowLayout(spacing: 10) {
+            Text(leadingText)
+                .lineLimit(1)
+                .fixedSize()
+
+            if let secondaryText,
+               !secondaryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text(secondaryText)
+                    .lineLimit(1)
+                    .fixedSize()
+            }
+
+            if let trailingText = trailingText?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !trailingText.isEmpty {
+                Text(trailingText)
+                    .lineLimit(1)
+                    .fixedSize()
+            }
+
+            meetingFamilyFolderMenu(
+                controller: controller,
+                selection: selection,
+                historyCount: historyCount,
+                preferredFolderPath: preferredFolderPath,
+                preferredFolder: preferredFolder,
+                folders: folders
+            )
+
+            meetingFamilyKnowledgeBaseSignal(state: state)
+        }
+        .font(.system(size: 13))
+        .foregroundStyle(.secondary)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     @ViewBuilder

--- a/OpenOats/Tests/OpenOatsTests/ExternalCommandTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/ExternalCommandTests.swift
@@ -70,6 +70,52 @@ final class ExternalCommandTests: XCTestCase {
         XCTAssertEqual(coordinator.requestedNotesNavigation?.target, .meetingHistory(event))
     }
 
+    func testQueueHomeMeetingHistoryRequestsHistoryTarget() {
+        let coordinator = AppCoordinator()
+        let event = CalendarEvent(
+            id: "evt",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        coordinator.queueHomeMeetingHistory(event)
+
+        XCTAssertEqual(coordinator.requestedHomeNavigation?.target, .meetingHistory(event))
+    }
+
+    func testQueueHomeManualTranscriptRequestsManualTranscriptTarget() {
+        let coordinator = AppCoordinator()
+        let event = CalendarEvent(
+            id: "evt",
+            title: "Payment Ops",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        coordinator.queueHomeManualTranscript(event)
+
+        XCTAssertEqual(coordinator.requestedHomeNavigation?.target, .manualTranscript(event))
+    }
+
+    func testConsumeRequestedHomeNavigationClearsAfterRead() {
+        let coordinator = AppCoordinator()
+
+        coordinator.queueHomeTranscriptSessionSelection("session_abc")
+
+        let consumed = coordinator.consumeRequestedHomeNavigation()
+        XCTAssertEqual(consumed, .transcriptSession("session_abc"))
+        XCTAssertNil(coordinator.requestedHomeNavigation)
+    }
+
     func testQueueExternalStartSessionCanCarryMeetingContextAndScratchpad() {
         let coordinator = AppCoordinator()
         let event = CalendarEvent(
@@ -94,6 +140,12 @@ final class ExternalCommandTests: XCTestCase {
     func testConsumeRequestedSessionSelectionReturnsNilWhenEmpty() {
         let coordinator = AppCoordinator()
         let consumed = coordinator.consumeRequestedSessionSelection()
+        XCTAssertNil(consumed)
+    }
+
+    func testConsumeRequestedHomeNavigationReturnsNilWhenEmpty() {
+        let coordinator = AppCoordinator()
+        let consumed = coordinator.consumeRequestedHomeNavigation()
         XCTAssertNil(consumed)
     }
 }

--- a/UITests/OpenOatsUITests/SmokeTests.swift
+++ b/UITests/OpenOatsUITests/SmokeTests.swift
@@ -11,7 +11,7 @@ final class SmokeTests: XCTestCase {
         let app = launchApp(scenario: "launchSmoke")
 
         XCTAssertTrue(element(in: app, identifier: "app.controlBar.toggle").waitForExistence(timeout: 5))
-        XCTAssertTrue(element(in: app, identifier: "app.pastMeetingsButton").waitForExistence(timeout: 5))
+        XCTAssertTrue(element(in: app, identifier: "app.notesWorkspaceButton").waitForExistence(timeout: 5))
     }
 
     func testSettingsSmokeShowsCorePickers() {
@@ -50,6 +50,24 @@ final class SmokeTests: XCTestCase {
 
         app.typeKey("l", modifierFlags: [.command, .shift])
         XCTAssertTrue(element(in: app, identifier: "app.sessionEndedBanner").waitForExistence(timeout: 5))
+    }
+
+    func testSessionSmokeRoutesGenerateNotesIntoMainWindowDetail() {
+        let app = launchApp(scenario: "sessionSmoke")
+
+        let toggle = element(in: app, identifier: "app.controlBar.toggle")
+        XCTAssertTrue(toggle.waitForExistence(timeout: 5))
+
+        app.typeKey("l", modifierFlags: [.command, .shift])
+        let stop = element(in: app, identifier: "app.controlBar.stop")
+        XCTAssertTrue(stop.waitForExistence(timeout: 5))
+
+        app.typeKey("l", modifierFlags: [.command, .shift])
+        let generateNotes = element(in: app, identifier: "app.generateNotesButton")
+        XCTAssertTrue(generateNotes.waitForExistence(timeout: 5))
+        generateNotes.click()
+
+        XCTAssertTrue(element(in: app, identifier: "home.detailPane").waitForExistence(timeout: 5))
     }
 
     func testNotesSmokeSupportsDeepLinkAndGeneration() async {
@@ -121,7 +139,7 @@ final class SmokeTests: XCTestCase {
     }
 
     private func closeNotesWindowIfPresent(in app: XCUIApplication) {
-        for identifier in ["notes", "Notes"] {
+        for identifier in ["notes", "Notes", "Notes Workspace"] {
             let window = app.windows[identifier]
             guard window.exists else { continue }
             let closeButton = window.buttons.firstMatch


### PR DESCRIPTION
## Summary
- keep the main window as the default review surface for common post-session and meeting-history flows
- rename the dedicated window to Notes Workspace and keep it as an explicit advanced workspace for deep links and organization-heavy tasks
- polish the meeting-family overview layout and extend coordinator/UI coverage for the new routing

## Why
Part of #563. This keeps OpenOats moving toward a single-window review experience without deleting the dedicated Notes workspace before the main window fully proves itself.

## Validation
- swift test --filter "ExternalCommandTests|HomeTimelineGroupingTests|NotesControllerTests"
- scripts/run_ui_smoke.sh
- SKIP_SIGN=1 SKIP_INSTALL=1 scripts/build_swift_app.sh