### PR TITLE
Bump Homebrew cask to v1.75.0

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.74.11"
-  sha256 "0d9f1758d531448bed69f471256559c8e4d1bf77f23eb450ba3d7e20f96bd7a7"
+  version "1.75.0"
+  sha256 "3fb98150ade526fb1421bf3701e0c50a5581de2408f3c897b7e2342a922df6ff"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Bumps the Homebrew cask from v1.74.11 to v1.75.0 to match the latest GitHub release.

- Version: 1.74.11 → 1.75.0
- sha256 verified against the v1.75.0 DMG asset

Automated bump as part of the in-flight release maintenance cycle.