### PR TITLE
Auto-generate post-meeting notes when configured

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -146,6 +146,8 @@ final class LiveSessionController {
     private var observedSystemHasEverCapturedFrames = false
     private var observedMicHasEverCapturedFrames = false
     private var pendingRecoveryDiagnostics: PendingRecoveryDiagnostics?
+    private var pendingAutoNotesSessionID: String?
+    private var autoGeneratingNotesSessionID: String?
 
     init(coordinator: AppCoordinator, container: AppContainer) {
         self.coordinator = coordinator
@@ -261,6 +263,8 @@ final class LiveSessionController {
                             }
                         }
                     }
+
+                    resumePendingAutoNotesIfNeeded(for: status, settings: settings)
                 }
             }
 
@@ -943,8 +947,18 @@ final class LiveSessionController {
         )
         await coordinator.loadHistory()
 
+        let willRunBatchRetranscription = shouldRunBatchRetranscription && coordinator.batchAudioTranscriber != nil
+
+        if let settings {
+            scheduleAutoNotesIfNeeded(
+                for: effectiveIndex,
+                settings: settings,
+                waitForBatch: willRunBatchRetranscription
+            )
+        }
+
         // 9. Kick off batch transcription if enabled
-        if let settings, shouldRunBatchRetranscription, let batchAudioTranscriber = coordinator.batchAudioTranscriber {
+        if let settings, willRunBatchRetranscription, let batchAudioTranscriber = coordinator.batchAudioTranscriber {
             let batchSessionID = sessionID
             let batchModel = settings.batchTranscriptionModel
             let batchLocale = settings.locale
@@ -964,6 +978,128 @@ final class LiveSessionController {
                 )
             }
         }
+    }
+
+    private func scheduleAutoNotesIfNeeded(
+        for session: SessionIndex,
+        settings: AppSettings,
+        waitForBatch: Bool
+    ) {
+        guard settings.canAutoGeneratePostMeetingNotes else {
+            pendingAutoNotesSessionID = nil
+            return
+        }
+
+        if waitForBatch {
+            pendingAutoNotesSessionID = session.id
+            return
+        }
+
+        guard session.utteranceCount > 0 else { return }
+        startAutoNotesGeneration(sessionID: session.id, settings: settings)
+    }
+
+    private func resumePendingAutoNotesIfNeeded(
+        for status: BatchAudioTranscriber.Status,
+        settings: AppSettings
+    ) {
+        guard let pendingSessionID = pendingAutoNotesSessionID else { return }
+
+        switch status {
+        case .completed(let sessionID) where sessionID == pendingSessionID:
+            pendingAutoNotesSessionID = nil
+            startAutoNotesGeneration(sessionID: sessionID, settings: settings)
+        case .failed, .cancelled:
+            pendingAutoNotesSessionID = nil
+            startAutoNotesGeneration(sessionID: pendingSessionID, settings: settings)
+        default:
+            break
+        }
+    }
+
+    private func startAutoNotesGeneration(sessionID: String, settings: AppSettings) {
+        guard settings.canAutoGeneratePostMeetingNotes else { return }
+        guard autoGeneratingNotesSessionID != sessionID else { return }
+
+        autoGeneratingNotesSessionID = sessionID
+        Task { [weak self] in
+            await self?.generatePostMeetingNotes(sessionID: sessionID, settings: settings)
+        }
+    }
+
+    private func generatePostMeetingNotes(sessionID: String, settings: AppSettings) async {
+        defer {
+            if autoGeneratingNotesSessionID == sessionID {
+                autoGeneratingNotesSessionID = nil
+            }
+        }
+
+        let sessionDetail = await coordinator.sessionRepository.loadSession(id: sessionID)
+        let session = sessionDetail.index
+        guard !session.hasNotes else { return }
+        guard session.utteranceCount > 0 else { return }
+
+        let sessionData = await coordinator.sessionRepository.loadSessionData(sessionID: sessionID)
+        guard !sessionData.transcript.isEmpty else { return }
+        let customGuidance = await coordinator.sessionRepository.loadCustomNotesGuidance(sessionID: sessionID)
+
+        let template = resolvedNotesTemplate(for: session)
+        let scratchpad = await coordinator.sessionRepository.loadScratchpad(sessionID: sessionID)
+
+        do {
+            let generatedMarkdown = try await coordinator.notesEngine.generateMarkdownDetached(
+                transcript: sessionData.transcript,
+                template: template,
+                settings: settings,
+                calendarEvent: sessionData.calendarEvent,
+                scratchpad: scratchpad.isEmpty ? nil : scratchpad,
+                customGuidance: customGuidance
+            )
+
+            let notes = GeneratedNotes(
+                template: coordinator.templateStore.snapshot(of: template),
+                generatedAt: Date(),
+                markdown: GeneratedNotes.normalizedMarkdown(
+                    generatedMarkdown,
+                    title: session.title,
+                    date: session.startedAt
+                )
+            )
+
+            await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
+            await coordinator.loadHistory()
+
+            if coordinator.lastEndedSession?.id == sessionID {
+                coordinator.lastEndedSession = await coordinator.sessionRepository.loadSession(id: sessionID).index
+            }
+
+            syncProjectedState(settings: settings)
+            DiagnosticsSupport.record(
+                category: "meeting",
+                message: "Auto-generated post-meeting notes for \(sessionID)"
+            )
+        } catch {
+            DiagnosticsSupport.record(
+                category: "meeting",
+                message: "Auto-generated post-meeting notes failed for \(sessionID): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func resolvedNotesTemplate(for session: SessionIndex) -> MeetingTemplate {
+        if let snapshot = session.templateSnapshot {
+            return coordinator.templateStore.template(for: snapshot.id)
+                ?? MeetingTemplate(
+                    id: snapshot.id,
+                    name: snapshot.name,
+                    icon: snapshot.icon,
+                    systemPrompt: snapshot.systemPrompt,
+                    isBuiltIn: false
+                )
+        }
+
+        return coordinator.templateStore.template(for: TemplateStore.genericID)
+            ?? TemplateStore.builtInTemplates.first!
     }
 
     static func audioRetentionPlan(settings: AppSettings, utteranceCount: Int?) -> AudioRetentionPlan {

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -241,6 +241,25 @@ final class NotesController {
         }
     }
 
+    func handleSessionHistoryChanged() async {
+        let selectedSessionID = state.selectedSessionID
+        let selectedSessionHasLoadedNotes = state.loadedNotes != nil
+
+        await loadHistory()
+
+        guard let selectedSessionID else { return }
+        guard let session = state.sessionHistory.first(where: { $0.id == selectedSessionID }) else {
+            if state.selectedSessionID == selectedSessionID {
+                selectSession(nil)
+            }
+            return
+        }
+
+        if session.hasNotes != selectedSessionHasLoadedNotes {
+            selectSession(selectedSessionID)
+        }
+    }
+
     /// React to a deep-link session selection request.
     /// Returns true if a request was consumed (caller may want to switch to notes tab).
     func handleRequestedSessionSelection() -> Bool {
@@ -570,7 +589,7 @@ final class NotesController {
         if !coordinator.notesEngine.generatedMarkdown.isEmpty {
             let generatedMarkdown = coordinator.notesEngine.generatedMarkdown
             let session = state.sessionHistory.first { $0.id == sessionID }
-            let markdown = Self.normalizedNotesMarkdown(
+            let markdown = GeneratedNotes.normalizedMarkdown(
                 generatedMarkdown,
                 title: session?.title,
                 date: session?.startedAt ?? Date()
@@ -1290,37 +1309,6 @@ final class NotesController {
         if let selection = state.selectedMeetingFamily {
             presentMeetingHistory(for: selection)
         }
-    }
-
-    static func normalizedNotesMarkdown(_ markdown: String, title: String?, date: Date) -> String {
-        let trimmed = markdown.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            return notesHeading(title: title, date: date)
-        }
-
-        let firstLine = trimmed
-            .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true)
-            .first?
-            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if firstLine.hasPrefix("# ") {
-            return trimmed
-        }
-
-        return notesHeading(title: title, date: date) + trimmed
-    }
-
-    /// Builds a markdown heading for generated notes when the model does not provide one.
-    static func notesHeading(title: String?, date: Date) -> String {
-        let displayTitle: String
-        if let title, !title.isEmpty {
-            displayTitle = title
-        } else {
-            let formatter = DateFormatter()
-            formatter.dateStyle = .medium
-            formatter.timeStyle = .short
-            displayTitle = formatter.string(from: date)
-        }
-        return "# Meeting Notes: \(displayTitle)\n\n"
     }
 
     private func matchingMeetingHistorySessions(for selection: MeetingFamilySelection) -> [SessionIndex] {

--- a/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
@@ -5,6 +5,17 @@ import Observation
 @Observable
 @MainActor
 final class NotesEngine {
+    enum GenerationError: LocalizedError {
+        case failed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .failed(let message):
+                return message
+            }
+        }
+    }
+
     enum Mode {
         case live
         case scripted(markdown: String)
@@ -35,6 +46,25 @@ final class NotesEngine {
 
     init(mode: Mode = .live) {
         self.mode = mode
+    }
+
+    func generateMarkdownDetached(
+        transcript: [SessionRecord],
+        template: MeetingTemplate,
+        settings: AppSettings,
+        calendarEvent: CalendarEvent? = nil,
+        scratchpad: String? = nil,
+        customGuidance: String? = nil
+    ) async throws -> String {
+        let detachedEngine = NotesEngine(mode: mode)
+        return try await detachedEngine.awaitGeneratedMarkdown(
+            transcript: transcript,
+            template: template,
+            settings: settings,
+            calendarEvent: calendarEvent,
+            scratchpad: scratchpad,
+            customGuidance: customGuidance
+        )
     }
 
     /// Starts streaming note generation from the LLM, updating `generatedMarkdown` in real time.
@@ -172,6 +202,36 @@ final class NotesEngine {
         currentTask?.cancel()
         currentTask = nil
         isGenerating = false
+    }
+
+    private func awaitGeneratedMarkdown(
+        transcript: [SessionRecord],
+        template: MeetingTemplate,
+        settings: AppSettings,
+        calendarEvent: CalendarEvent? = nil,
+        scratchpad: String? = nil,
+        customGuidance: String? = nil
+    ) async throws -> String {
+        try await withCheckedThrowingContinuation { continuation in
+            generate(
+                transcript: transcript,
+                template: template,
+                settings: settings,
+                calendarEvent: calendarEvent,
+                scratchpad: scratchpad,
+                customGuidance: customGuidance
+            ) { [weak self] in
+                guard let self else {
+                    continuation.resume(throwing: GenerationError.failed("Notes generation ended unexpectedly"))
+                    return
+                }
+                if let error = self.error {
+                    continuation.resume(throwing: GenerationError.failed(error))
+                } else {
+                    continuation.resume(returning: self.generatedMarkdown)
+                }
+            }
+        }
     }
 
     nonisolated static func buildUserContent(

--- a/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
@@ -7,14 +7,35 @@ actor OpenRouterClient {
     /// Builds a chat completions URL from a user-provided base URL, stripping
     /// any trailing `/v1` or `/v1/chat/completions` to avoid double-pathing.
     static func chatCompletionsURL(from rawBase: String) -> URL? {
-        var base = rawBase.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        // Strip paths that users commonly include so we don't get /v1/v1/...
+        let trimmed = rawBase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmed),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = components.host,
+              !host.isEmpty else {
+            return nil
+        }
+
+        var path = components.path
+        while path.hasSuffix("/") {
+            path.removeLast()
+        }
+
         for suffix in ["/v1/chat/completions", "/v1"] {
-            if base.hasSuffix(suffix) {
-                base = String(base.dropLast(suffix.count))
+            if path.hasSuffix(suffix) {
+                path.removeLast(suffix.count)
+                break
             }
         }
-        return URL(string: base + "/v1/chat/completions")
+
+        if path.isEmpty {
+            components.path = "/v1/chat/completions"
+        } else {
+            components.path = path + "/v1/chat/completions"
+        }
+        components.query = nil
+        components.fragment = nil
+        return components.url
     }
 
     static func isLocalHost(_ url: URL) -> Bool {

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -340,6 +340,36 @@ struct GeneratedNotes: Codable, Sendable {
     let template: TemplateSnapshot
     let generatedAt: Date
     let markdown: String
+
+    static func normalizedMarkdown(_ markdown: String, title: String?, date: Date) -> String {
+        let trimmed = markdown.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return notesHeading(title: title, date: date)
+        }
+
+        let firstLine = trimmed
+            .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: true)
+            .first?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if firstLine.hasPrefix("# ") {
+            return trimmed
+        }
+
+        return notesHeading(title: title, date: date) + trimmed
+    }
+
+    static func notesHeading(title: String?, date: Date) -> String {
+        let displayTitle: String
+        if let title, !title.isEmpty {
+            displayTitle = title
+        } else {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .short
+            displayTitle = formatter.string(from: date)
+        }
+        return "# Meeting Notes: \(displayTitle)\n\n"
+    }
 }
 
 struct NoteAttachment: Codable, Sendable, Equatable, Identifiable {

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -1382,15 +1382,41 @@ final class SettingsStore {
         transcriptionModel.displayName
     }
 
+    /// The model ID to use for notes generation, respecting the active LLM provider.
+    var activeNotesModel: String {
+        switch llmProvider {
+        case .openRouter:
+            selectedModel
+        case .ollama:
+            ollamaLLMModel
+        case .mlx:
+            mlxModel
+        case .openAICompatible:
+            openAILLMModel
+        }
+    }
+
+    /// Returns true when notes generation has enough provider-specific configuration
+    /// to run automatically after a meeting ends without a guaranteed setup failure.
+    var canAutoGeneratePostMeetingNotes: Bool {
+        let model = activeNotesModel.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !model.isEmpty else { return false }
+
+        switch llmProvider {
+        case .openRouter:
+            return !openRouterApiKey.isEmpty
+        case .ollama:
+            return OpenRouterClient.chatCompletionsURL(from: ollamaBaseURL) != nil
+        case .mlx:
+            return OpenRouterClient.chatCompletionsURL(from: mlxBaseURL) != nil
+        case .openAICompatible:
+            return OpenRouterClient.chatCompletionsURL(from: openAILLMBaseURL) != nil
+        }
+    }
+
     /// The model name to display in the UI, respecting the active LLM provider.
     var activeModelDisplay: String {
-        let raw: String
-        switch llmProvider {
-        case .openRouter: raw = selectedModel
-        case .ollama: raw = ollamaLLMModel
-        case .mlx: raw = mlxModel
-        case .openAICompatible: raw = openAILLMModel
-        }
+        let raw = activeNotesModel
         return raw.split(separator: "/").last.map(String.init) ?? raw
     }
 

--- a/OpenOats/Sources/OpenOats/Views/HomeTimelineWorkspaceView.swift
+++ b/OpenOats/Sources/OpenOats/Views/HomeTimelineWorkspaceView.swift
@@ -52,8 +52,8 @@ struct HomeTimelineWorkspaceView: View {
         .onChange(of: settings.calendarIntegrationEnabled) {
             refreshTick &+= 1
         }
-        .onChange(of: coordinator.sessionHistory.count) {
-            Task { await notesController?.loadHistory() }
+        .onChange(of: coordinator.sessionHistory) {
+            Task { await notesController?.handleSessionHistoryChanged() }
         }
         .onChange(of: coordinator.batchStatus) { _, newStatus in
             if case .completed = newStatus {

--- a/OpenOats/Sources/OpenOats/Views/NotesView.swift
+++ b/OpenOats/Sources/OpenOats/Views/NotesView.swift
@@ -104,8 +104,8 @@ struct NotesView: View {
         .onChange(of: coordinator.lastEndedSession?.id) {
             Task { await controller.handleLastEndedSessionChanged() }
         }
-        .onChange(of: coordinator.sessionHistory.count) {
-            Task { await controller.loadHistory() }
+        .onChange(of: coordinator.sessionHistory) {
+            Task { await controller.handleSessionHistoryChanged() }
         }
         .onChange(of: coordinator.batchStatus) { _, newStatus in
             if case .completed = newStatus {

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -697,6 +697,107 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertEqual(mergedDetail.calendarEvent?.id, event.id)
     }
 
+    func testFinalizeCurrentSessionAutoGeneratesNotesWhenConfigured() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        settings.llmProvider = .ollama
+        settings.ollamaBaseURL = "http://localhost:11434"
+        settings.ollamaLLMModel = "qwen3:8b"
+        settings.enableBatchRetranscription = false
+
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings,
+            scripted: [Utterance(text: "Follow up on merchant fees", speaker: .you)]
+        )
+
+        controller.startSession(settings: settings)
+
+        var sessionID: String?
+        for _ in 0..<20 {
+            sessionID = await coordinator.sessionRepository.getCurrentSessionID()
+            if sessionID != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        guard let sessionID else {
+            return XCTFail("Expected session ID after starting session")
+        }
+
+        let recordedUtterance = Utterance(
+            text: "Follow up on merchant fees",
+            speaker: .you,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        await coordinator.sessionRepository.appendLiveUtterance(
+            sessionID: sessionID,
+            utterance: recordedUtterance
+        )
+
+        controller.stopSession(settings: settings)
+        await controller.finalizeCurrentSession(settings: settings)
+
+        var savedNotes: GeneratedNotes?
+        for _ in 0..<20 {
+            savedNotes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
+            if savedNotes != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        XCTAssertNotNil(savedNotes)
+        XCTAssertTrue(savedNotes?.markdown.contains("Test") ?? false)
+        XCTAssertEqual(coordinator.lastEndedSession?.id, sessionID)
+        XCTAssertTrue(coordinator.lastEndedSession?.hasNotes == true)
+    }
+
+    func testFinalizeCurrentSessionSkipsAutoNotesWhenProviderIsNotConfigured() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        settings.llmProvider = .openRouter
+        settings.selectedModel = "google/gemini-3-flash-preview"
+        settings.openRouterApiKey = ""
+        settings.enableBatchRetranscription = false
+
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings,
+            scripted: [Utterance(text: "Follow up on merchant fees", speaker: .you)]
+        )
+
+        controller.startSession(settings: settings)
+
+        var sessionID: String?
+        for _ in 0..<20 {
+            sessionID = await coordinator.sessionRepository.getCurrentSessionID()
+            if sessionID != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        guard let sessionID else {
+            return XCTFail("Expected session ID after starting session")
+        }
+
+        let recordedUtterance = Utterance(
+            text: "Follow up on merchant fees",
+            speaker: .you,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        await coordinator.sessionRepository.appendLiveUtterance(
+            sessionID: sessionID,
+            utterance: recordedUtterance
+        )
+
+        controller.stopSession(settings: settings)
+        await controller.finalizeCurrentSession(settings: settings)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        let savedNotes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
+        XCTAssertNil(savedNotes)
+        XCTAssertFalse(coordinator.lastEndedSession?.hasNotes == true)
+    }
+
     func testAudioRetentionPlanKeepsRecoveryAudioForCloudLiveTranscription() {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -1323,7 +1323,7 @@ final class NotesControllerTests: XCTestCase {
     }
 
     func testNormalizedNotesMarkdownPrependsFallbackHeadingWhenMissing() {
-        let markdown = NotesController.normalizedNotesMarkdown(
+        let markdown = GeneratedNotes.normalizedMarkdown(
             "## Summary\nHello",
             title: "Standup",
             date: Date(timeIntervalSince1970: 1_700_000_000)
@@ -1333,7 +1333,7 @@ final class NotesControllerTests: XCTestCase {
     }
 
     func testNormalizedNotesMarkdownFallsBackToDateForMissingTitle() {
-        let markdown = NotesController.normalizedNotesMarkdown(
+        let markdown = GeneratedNotes.normalizedMarkdown(
             "## Summary\nHello",
             title: "",
             date: Date(timeIntervalSince1970: 1_700_000_000)
@@ -1344,7 +1344,7 @@ final class NotesControllerTests: XCTestCase {
     }
 
     func testNormalizedNotesMarkdownPreservesExistingHeading() {
-        let markdown = NotesController.normalizedNotesMarkdown(
+        let markdown = GeneratedNotes.normalizedMarkdown(
             "# Test Notes\n\n## Summary\nHello",
             title: "Standup",
             date: Date(timeIntervalSince1970: 1_700_000_000)

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -71,6 +71,35 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.selectedModel, "anthropic/claude-4-sonnet")
     }
 
+    func testAutoPostMeetingNotesRequiresOpenRouterKey() {
+        let store = makeStore()
+        store.llmProvider = .openRouter
+        store.selectedModel = "google/gemini-3-flash-preview"
+
+        XCTAssertFalse(store.canAutoGeneratePostMeetingNotes)
+
+        store.openRouterApiKey = "sk-or-v1-test"
+        XCTAssertTrue(store.canAutoGeneratePostMeetingNotes)
+    }
+
+    func testAutoPostMeetingNotesAcceptsValidLocalProviderConfiguration() {
+        let store = makeStore()
+        store.llmProvider = .ollama
+        store.ollamaBaseURL = "http://localhost:11434"
+        store.ollamaLLMModel = "qwen3:8b"
+
+        XCTAssertTrue(store.canAutoGeneratePostMeetingNotes)
+    }
+
+    func testAutoPostMeetingNotesRejectsInvalidLocalProviderURL() {
+        let store = makeStore()
+        store.llmProvider = .mlx
+        store.mlxBaseURL = "not a url"
+        store.mlxModel = "mlx-community/Llama-3.2-3B-Instruct-4bit"
+
+        XCTAssertFalse(store.canAutoGeneratePostMeetingNotes)
+    }
+
     func testDefaultEmbeddingProvider() {
         let store = makeStore()
         XCTAssertEqual(store.embeddingProvider, .voyageAI)

--- a/UITests/OpenOatsUITests/SmokeTests.swift
+++ b/UITests/OpenOatsUITests/SmokeTests.swift
@@ -83,9 +83,10 @@ final class SmokeTests: XCTestCase {
 
     func testHomeTimelineSelectsSavedSessionAndCollapsesDetail() {
         let app = launchApp(scenario: "notesSmoke")
-        closeNotesWindowIfPresent(in: app)
         app.activate()
-        XCTAssertTrue(app.windows["main"].waitForExistence(timeout: 2))
+        let mainWindow = app.windows["main"]
+        XCTAssertTrue(mainWindow.waitForExistence(timeout: 2))
+        focus(window: mainWindow)
 
         let savedSession = element(in: app, identifier: "home.timeline.session.session_ui_test_notes")
         XCTAssertTrue(savedSession.waitForExistence(timeout: 5))
@@ -101,9 +102,10 @@ final class SmokeTests: XCTestCase {
 
     func testHomeTimelineSupportsRenamingFromDetailManageMenu() {
         let app = launchApp(scenario: "notesSmoke")
-        closeNotesWindowIfPresent(in: app)
         app.activate()
-        XCTAssertTrue(app.windows["main"].waitForExistence(timeout: 2))
+        let mainWindow = app.windows["main"]
+        XCTAssertTrue(mainWindow.waitForExistence(timeout: 2))
+        focus(window: mainWindow)
 
         let savedSession = element(in: app, identifier: "home.timeline.session.session_ui_test_notes")
         XCTAssertTrue(savedSession.waitForExistence(timeout: 5))
@@ -168,16 +170,8 @@ final class SmokeTests: XCTestCase {
         app.descendants(matching: .any).matching(identifier: identifier).firstMatch
     }
 
-    private func closeNotesWindowIfPresent(in app: XCUIApplication) {
-        for identifier in ["notes", "Notes", "Notes Workspace"] {
-            let window = app.windows[identifier]
-            guard window.exists else { continue }
-            let closeButton = window.buttons.firstMatch
-            if closeButton.exists {
-                closeButton.click()
-            }
-            return
-        }
+    private func focus(window: XCUIElement) {
+        window.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.05)).click()
     }
 
     private func openDeepLink(_ url: URL) async {


### PR DESCRIPTION
Closes #603

## What changed
- trigger automatic note generation after meeting finalization when notes generation is actually configured for the active provider
- wait for batch retranscription when that path is truly active before generating notes
- run background auto-generation through a detached notes engine so it does not clobber a manual generation already running in the detail pane
- refresh the main-window detail pane and the Notes Workspace when background-generated notes land
- add focused provider-gating and lifecycle coverage, plus harden the two home-timeline smoke tests around restored secondary windows

## Why
The current flow requires a manual `Generate Notes` action even when the user has already configured notes generation. That is the behavior gap in #603.

The implementation uses a stricter gate than "a model string exists" because `OpenRouter` ships with a default model name even when no API key is present. Treating that as configured would create post-meeting failures after every meeting.

## User impact
- stopping a meeting can now produce notes automatically without an extra click
- batch-improved transcripts still win when batch retranscription is enabled and available
- existing manual note generation remains intact for users who want to regenerate or edit from the detail pane

## Validation
- `swift test --filter "LiveSessionControllerTests|SettingsStoreTests|NotesControllerTests|NotesEngineTests"`
- `scripts/run_ui_smoke.sh`
- `SKIP_SIGN=1 SKIP_INSTALL=1 scripts/build_swift_app.sh`
