### PR TITLE
Fix intent card tap target to cover entire tile

### DIFF
--- a/OpenOats/Sources/OpenOats/Wizard/IntentStepView.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/IntentStepView.swift
@@ -122,6 +122,7 @@ struct IntentStepView: View {
                         .font(.system(size: 16))
                 }
             }
+            .contentShape(Rectangle())
             .padding(14)
             .background(
                 RoundedRectangle(cornerRadius: 10)


### PR DESCRIPTION
## Summary
- The intent selection cards on the onboarding wizard's first step only responded to clicks on the text/icon content, not empty space within the tile
- Added `.contentShape(Rectangle())` to the card's `HStack` so the full tile area is clickable

## Test plan
- [x] Build the app and launch the setup wizard
- [x] Click on empty space inside each intent card (between icon and text, or to the right of the checkmark)
- [x] Verify the card gets selected on any click within the tile boundary


🤖 Generated with [Claude Code](https://claude.com/claude-code)