### PR TITLE
Restore live scratchpad editor visibility

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -676,7 +676,7 @@ private struct PostSessionBanner: View {
 private struct ScratchpadSection: View {
     @Binding var text: String
     let onPasteAssetProviders: ([NSItemProvider]) -> Void
-    @AppStorage("isScratchpadExpanded") private var isExpanded = true
+    @State private var isExpanded = true
 
     private let pasteAssetTypes: [UTType] = [.png, .jpeg, .tiff, .image, .fileURL]
 
@@ -689,6 +689,7 @@ private struct ScratchpadSection: View {
                 .padding(4)
                 .background(Color(nsColor: .textBackgroundColor).opacity(0.5))
                 .clipShape(RoundedRectangle(cornerRadius: 6))
+                .accessibilityIdentifier("app.scratchpadEditor")
                 .onPasteCommand(of: pasteAssetTypes) { providers in
                     onPasteAssetProviders(providers)
                 }

--- a/UITests/OpenOatsUITests/SmokeTests.swift
+++ b/UITests/OpenOatsUITests/SmokeTests.swift
@@ -52,6 +52,16 @@ final class SmokeTests: XCTestCase {
         XCTAssertTrue(element(in: app, identifier: "app.sessionEndedBanner").waitForExistence(timeout: 5))
     }
 
+    func testSessionSmokeShowsScratchpadEditorByDefault() {
+        let app = launchApp(scenario: "sessionSmoke")
+
+        let toggle = element(in: app, identifier: "app.controlBar.toggle")
+        XCTAssertTrue(toggle.waitForExistence(timeout: 5))
+
+        app.typeKey("l", modifierFlags: [.command, .shift])
+        XCTAssertTrue(element(in: app, identifier: "app.scratchpadEditor").waitForExistence(timeout: 5))
+    }
+
     func testSessionSmokeRoutesGenerateNotesIntoMainWindowDetail() {
         let app = launchApp(scenario: "sessionSmoke")
 


### PR DESCRIPTION
Closes #613

## What changed
- stop persisting the live scratchpad disclosure state in `ContentView`
- make the live `My Notes` scratchpad expansion state session-local again
- add an accessibility identifier for the scratchpad editor surface
- add UI smoke coverage that asserts the scratchpad editor is visible by default after starting a live session

## Why
The live scratchpad editor could look like it disappeared during an active meeting even though the `My Notes` section header was still present.

The root cause was persisted disclosure state via `@AppStorage("isScratchpadExpanded")`. If the section had been collapsed previously, that hidden state survived across later sessions and app launches.

## User impact
- the live `My Notes` editor is visible by default again when a meeting is running
- users can still collapse it during the current session
- the change does not alter the reusable meeting-detail notes flows

## Validation
- `scripts/run_ui_smoke.sh`
- `SKIP_SIGN=1 SKIP_INSTALL=1 scripts/build_swift_app.sh`
