### PR TITLE
Fix notes cleanup refresh and markdown fences

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.76.0"
-  sha256 "ada68514c25ff86e95e7f19e83fc328c52645e1678ae818ce6b9ccac9de2b25d"
+  version "1.77.0"
+  sha256 "6c648e33c886efdd43f58b09568be11044cc22740c8062781e69e35e2a509768"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -913,6 +913,7 @@ final class NotesController {
                 state.loadedTranscript = []
                 state.loadedCalendarEvent = nil
             }
+            await coordinator.loadHistory()
             await loadHistory()
         }
     }
@@ -928,6 +929,7 @@ final class NotesController {
                 state.loadedTranscript = []
                 state.loadedCalendarEvent = nil
             }
+            await coordinator.loadHistory()
             await loadHistory()
         }
     }

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -342,7 +342,7 @@ struct GeneratedNotes: Codable, Sendable {
     let markdown: String
 
     static func normalizedMarkdown(_ markdown: String, title: String?, date: Date) -> String {
-        let trimmed = markdown.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = strippingWholeResponseMarkdownFence(from: markdown)
         guard !trimmed.isEmpty else {
             return notesHeading(title: title, date: date)
         }
@@ -356,6 +356,25 @@ struct GeneratedNotes: Codable, Sendable {
         }
 
         return notesHeading(title: title, date: date) + trimmed
+    }
+
+    static func strippingWholeResponseMarkdownFence(from markdown: String) -> String {
+        let trimmed = markdown.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("```") else { return trimmed }
+
+        let lines = trimmed.components(separatedBy: .newlines)
+        guard lines.count >= 2 else { return trimmed }
+
+        let openingFence = lines[0].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard openingFence == "```" || openingFence.lowercased() == "```markdown" else {
+            return trimmed
+        }
+
+        let closingFence = lines[lines.count - 1].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard closingFence == "```" else { return trimmed }
+
+        let inner = lines.dropFirst().dropLast().joined(separator: "\n")
+        return inner.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     static func notesHeading(title: String?, date: Date) -> String {

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -720,6 +720,39 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertNil(controller.state.loadedNotes)
     }
 
+    func testDeleteSessionRefreshesSharedCoordinatorHistory() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_delete_shared_history"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID)
+        await controller.loadHistory()
+        XCTAssertTrue(coordinator.sessionHistory.contains { $0.id == sessionID })
+
+        controller.deleteSession(sessionID: sessionID)
+        try? await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertFalse(coordinator.sessionHistory.contains { $0.id == sessionID })
+        XCTAssertFalse(controller.state.sessionHistory.contains { $0.id == sessionID })
+    }
+
+    func testDeleteSessionsRefreshesSharedCoordinatorHistory() async {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+
+        await seedSession(coordinator: coordinator, sessionID: "session_delete_bulk_one")
+        await seedSession(coordinator: coordinator, sessionID: "session_delete_bulk_two")
+        await controller.loadHistory()
+        XCTAssertTrue(coordinator.sessionHistory.contains { $0.id == "session_delete_bulk_one" })
+        XCTAssertTrue(coordinator.sessionHistory.contains { $0.id == "session_delete_bulk_two" })
+
+        controller.deleteSessions(sessionIDs: ["session_delete_bulk_one", "session_delete_bulk_two"])
+        try? await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertFalse(coordinator.sessionHistory.contains { $0.id == "session_delete_bulk_one" })
+        XCTAssertFalse(coordinator.sessionHistory.contains { $0.id == "session_delete_bulk_two" })
+    }
+
     func testOpenNotesSelectsCorrectSession() async {
         let (root, _) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)
@@ -1351,6 +1384,37 @@ final class NotesControllerTests: XCTestCase {
         )
 
         XCTAssertEqual(markdown, "# Test Notes\n\n## Summary\nHello")
+    }
+
+    func testNormalizedNotesMarkdownStripsWholeMarkdownFence() {
+        let markdown = GeneratedNotes.normalizedMarkdown(
+            """
+            ```markdown
+            ## Summary
+            Hello
+            ```
+            """,
+            title: "Standup",
+            date: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        XCTAssertEqual(markdown, "# Meeting Notes: Standup\n\n## Summary\nHello")
+    }
+
+    func testNormalizedNotesMarkdownPreservesPartialCodeFence() {
+        let markdown = GeneratedNotes.normalizedMarkdown(
+            """
+            ## Summary
+
+            ```swift
+            let example = true
+            ```
+            """,
+            title: "Standup",
+            date: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+
+        XCTAssertTrue(markdown.contains("```swift"))
     }
 
     func testOriginalTranscriptToggle() async {


### PR DESCRIPTION
## Summary
- Refresh shared coordinator history when deleting sessions from Notes Workspace so the main Meetings timeline drops deleted notes immediately.
- Strip whole-response markdown/code fences from generated notes before heading normalization, while preserving real code fences inside notes.
- Bump the Homebrew cask from v1.76.0 to v1.77.0 with the verified DMG sha256.

Fixes #609
Fixes #617

## Test plan
- `swift test --filter NotesControllerTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`

Made with [Cursor](https://cursor.com)