### PR TITLE
Add post-update What's New sheet

### DIFF
--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -20,6 +20,7 @@ public struct OpenOatsRootApp: App {
     @State private var settings: AppSettings
     @State private var coordinator: AppCoordinator
     @State private var container: AppContainer
+    @State private var whatsNewController: WhatsNewController
     private let updaterController: AppUpdaterController
     private let defaults: UserDefaults
 
@@ -28,6 +29,7 @@ public struct OpenOatsRootApp: App {
         self._settings = State(initialValue: context.settings)
         self._coordinator = State(initialValue: context.coordinator)
         self._container = State(initialValue: context.container)
+        self._whatsNewController = State(initialValue: WhatsNewController(defaults: context.container.defaults))
         self.updaterController = context.updaterController
         self.defaults = context.container.defaults
         AppLaunchBootstrap.context = .init(
@@ -57,6 +59,9 @@ public struct OpenOatsRootApp: App {
                     DiagnosticsSupport.record(category: "app", message: "Main window appeared")
                     settings.applyScreenShareVisibility()
                 }
+                .task {
+                    await whatsNewController.presentPostUpdateReleaseNotesIfNeeded()
+                }
                 .onOpenURL { url in
                     guard let command = OpenOatsDeepLink.parse(url) else { return }
                     // Restore visibility when app is in background mode (LSUIElement)
@@ -70,6 +75,20 @@ public struct OpenOatsRootApp: App {
                         openNotesWindow()
                     default:
                         coordinator.queueExternalCommand(command)
+                    }
+                }
+                .sheet(
+                    item: Binding(
+                        get: { whatsNewController.presentedRelease },
+                        set: { release in
+                            if release == nil {
+                                whatsNewController.markPresentedReleaseSeen()
+                            }
+                        }
+                    )
+                ) { release in
+                    WhatsNewView(release: release) {
+                        whatsNewController.markPresentedReleaseSeen()
                     }
                 }
         }

--- a/OpenOats/Sources/OpenOats/App/WhatsNewController.swift
+++ b/OpenOats/Sources/OpenOats/App/WhatsNewController.swift
@@ -1,0 +1,157 @@
+import AppKit
+import Foundation
+import Observation
+
+struct WhatsNewRelease: Identifiable, Equatable {
+    var id: String { version }
+
+    let version: String
+    let title: String
+    let body: String
+    let htmlURL: URL
+}
+
+enum WhatsNewReleaseClient {
+    enum ClientError: Error {
+        case invalidURL
+        case invalidResponse
+    }
+
+    private struct GitHubRelease: Decodable {
+        let tagName: String
+        let name: String?
+        let body: String?
+        let htmlURL: URL
+
+        enum CodingKeys: String, CodingKey {
+            case tagName = "tag_name"
+            case name
+            case body
+            case htmlURL = "html_url"
+        }
+    }
+
+    static func fetch(version: String) async throws -> WhatsNewRelease {
+        guard let url = URL(string: "https://api.github.com/repos/yazinsai/OpenOats/releases/tags/v\(version)") else {
+            throw ClientError.invalidURL
+        }
+
+        let (data, response) = try await URLSession.shared.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            throw ClientError.invalidResponse
+        }
+
+        let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
+        return WhatsNewRelease(
+            version: normalizedTag(release.tagName) ?? version,
+            title: release.name?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+                ? release.name!
+                : "OpenOats \(version)",
+            body: release.body?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+                ? release.body!
+                : "No release notes were published for this version.",
+            htmlURL: release.htmlURL
+        )
+    }
+
+    private static func normalizedTag(_ tag: String) -> String? {
+        let trimmed = tag.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("v") else { return trimmed.isEmpty ? nil : trimmed }
+        let version = String(trimmed.dropFirst())
+        return version.isEmpty ? nil : version
+    }
+}
+
+@Observable
+@MainActor
+final class WhatsNewController {
+    static let lastSeenVersionKey = "lastSeenReleaseNotesVersion"
+
+    private let defaults: UserDefaults
+    private let currentVersionProvider: () -> String?
+    private let fetchRelease: (String) async throws -> WhatsNewRelease
+    private var checkedThisLaunch = false
+
+    var presentedRelease: WhatsNewRelease?
+
+    init(
+        defaults: UserDefaults = .standard,
+        currentVersionProvider: @escaping () -> String? = {
+            Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        },
+        fetchRelease: @escaping (String) async throws -> WhatsNewRelease = WhatsNewReleaseClient.fetch(version:)
+    ) {
+        self.defaults = defaults
+        self.currentVersionProvider = currentVersionProvider
+        self.fetchRelease = fetchRelease
+    }
+
+    func presentPostUpdateReleaseNotesIfNeeded() async {
+        guard !checkedThisLaunch else { return }
+        checkedThisLaunch = true
+
+        guard let currentVersion = normalizedVersion(currentVersionProvider()) else { return }
+        guard let lastSeenVersion = defaults.string(forKey: Self.lastSeenVersionKey) else {
+            defaults.set(currentVersion, forKey: Self.lastSeenVersionKey)
+            return
+        }
+        guard Self.shouldShow(currentVersion: currentVersion, lastSeenVersion: lastSeenVersion) else { return }
+
+        do {
+            presentedRelease = try await fetchRelease(currentVersion)
+        } catch {
+            DiagnosticsSupport.record(
+                category: "app",
+                message: "Unable to load release notes for \(currentVersion): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    func markPresentedReleaseSeen() {
+        guard let release = presentedRelease else { return }
+        defaults.set(release.version, forKey: Self.lastSeenVersionKey)
+        presentedRelease = nil
+    }
+
+    static func shouldShow(currentVersion: String, lastSeenVersion: String) -> Bool {
+        guard let current = SemanticVersion(currentVersion),
+              let lastSeen = SemanticVersion(lastSeenVersion) else {
+            return false
+        }
+        return current > lastSeen
+    }
+
+    private func normalizedVersion(_ version: String?) -> String? {
+        guard let version else { return nil }
+        let trimmed = version.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return trimmed.hasPrefix("v") ? String(trimmed.dropFirst()) : trimmed
+    }
+}
+
+private struct SemanticVersion: Comparable {
+    let major: Int
+    let minor: Int
+    let patch: Int
+
+    init?(_ rawVersion: String) {
+        let normalized = rawVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        let components = normalized.split(separator: ".", omittingEmptySubsequences: false)
+        guard components.count == 3,
+              let major = Int(components[0]),
+              let minor = Int(components[1]),
+              let patch = Int(components[2]) else {
+            return nil
+        }
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        return lhs.patch < rhs.patch
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/WhatsNewView.swift
+++ b/OpenOats/Sources/OpenOats/Views/WhatsNewView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+struct WhatsNewView: View {
+    let release: WhatsNewRelease
+    let onClose: () -> Void
+
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("What's New in OpenOats \(release.version)")
+                    .font(.system(size: 24, weight: .semibold))
+                Text(release.title)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+            }
+
+            ScrollView {
+                Text(markdownText)
+                    .font(.system(size: 13))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+                    .padding(.vertical, 2)
+            }
+            .frame(minHeight: 260, maxHeight: 420)
+            .padding(12)
+            .background(Color(nsColor: .textBackgroundColor).opacity(0.45))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            HStack {
+                Button("View Full Release Notes") {
+                    openURL(release.htmlURL)
+                    onClose()
+                }
+                .buttonStyle(.link)
+
+                Spacer()
+
+                Button("Got It") {
+                    onClose()
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(24)
+        .frame(width: 620)
+    }
+
+    private var markdownText: AttributedString {
+        (try? AttributedString(markdown: release.body, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
+            ?? AttributedString(release.body)
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/WhatsNewControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/WhatsNewControllerTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import XCTest
+@testable import OpenOatsKit
+
+@MainActor
+final class WhatsNewControllerTests: XCTestCase {
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "com.openoats.tests.whatsnew.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func makeRelease(version: String = "1.78.0") -> WhatsNewRelease {
+        WhatsNewRelease(
+            version: version,
+            title: "OpenOats \(version)",
+            body: "## Fixed\n- Notes render correctly.",
+            htmlURL: URL(string: "https://github.com/yazinsai/OpenOats/releases/tag/v\(version)")!
+        )
+    }
+
+    func testShouldShowOnlyForNewerSemanticVersion() {
+        XCTAssertTrue(WhatsNewController.shouldShow(currentVersion: "1.78.0", lastSeenVersion: "1.77.0"))
+        XCTAssertTrue(WhatsNewController.shouldShow(currentVersion: "1.78.1", lastSeenVersion: "1.78.0"))
+        XCTAssertFalse(WhatsNewController.shouldShow(currentVersion: "1.77.0", lastSeenVersion: "1.77.0"))
+        XCTAssertFalse(WhatsNewController.shouldShow(currentVersion: "1.76.9", lastSeenVersion: "1.77.0"))
+    }
+
+    func testShouldShowFailsClosedForMalformedVersions() {
+        XCTAssertFalse(WhatsNewController.shouldShow(currentVersion: "1.78", lastSeenVersion: "1.77.0"))
+        XCTAssertFalse(WhatsNewController.shouldShow(currentVersion: "1.78.0-beta", lastSeenVersion: "1.77.0"))
+        XCTAssertFalse(WhatsNewController.shouldShow(currentVersion: "1.78.0", lastSeenVersion: "latest"))
+    }
+
+    func testFirstInstallStoresCurrentVersionWithoutShowingRelease() async {
+        let defaults = makeDefaults()
+        var fetchCount = 0
+        let controller = WhatsNewController(
+            defaults: defaults,
+            currentVersionProvider: { "1.78.0" },
+            fetchRelease: { version in
+                fetchCount += 1
+                return self.makeRelease(version: version)
+            }
+        )
+
+        await controller.presentPostUpdateReleaseNotesIfNeeded()
+
+        XCTAssertNil(controller.presentedRelease)
+        XCTAssertEqual(fetchCount, 0)
+        XCTAssertEqual(defaults.string(forKey: WhatsNewController.lastSeenVersionKey), "1.78.0")
+    }
+
+    func testUpdateFetchesReleaseAndMarksSeenOnDismiss() async {
+        let defaults = makeDefaults()
+        defaults.set("1.77.0", forKey: WhatsNewController.lastSeenVersionKey)
+        let controller = WhatsNewController(
+            defaults: defaults,
+            currentVersionProvider: { "1.78.0" },
+            fetchRelease: { version in self.makeRelease(version: version) }
+        )
+
+        await controller.presentPostUpdateReleaseNotesIfNeeded()
+
+        XCTAssertEqual(controller.presentedRelease?.version, "1.78.0")
+        XCTAssertEqual(defaults.string(forKey: WhatsNewController.lastSeenVersionKey), "1.77.0")
+
+        controller.markPresentedReleaseSeen()
+
+        XCTAssertNil(controller.presentedRelease)
+        XCTAssertEqual(defaults.string(forKey: WhatsNewController.lastSeenVersionKey), "1.78.0")
+    }
+
+    func testFailedFetchDoesNotMarkVersionSeen() async {
+        struct TestError: Error {}
+
+        let defaults = makeDefaults()
+        defaults.set("1.77.0", forKey: WhatsNewController.lastSeenVersionKey)
+        let controller = WhatsNewController(
+            defaults: defaults,
+            currentVersionProvider: { "1.78.0" },
+            fetchRelease: { _ in throw TestError() }
+        )
+
+        await controller.presentPostUpdateReleaseNotesIfNeeded()
+
+        XCTAssertNil(controller.presentedRelease)
+        XCTAssertEqual(defaults.string(forKey: WhatsNewController.lastSeenVersionKey), "1.77.0")
+    }
+
+    func testCheckRunsOnlyOncePerLaunch() async {
+        let defaults = makeDefaults()
+        defaults.set("1.77.0", forKey: WhatsNewController.lastSeenVersionKey)
+        var fetchCount = 0
+        let controller = WhatsNewController(
+            defaults: defaults,
+            currentVersionProvider: { "1.78.0" },
+            fetchRelease: { version in
+                fetchCount += 1
+                return self.makeRelease(version: version)
+            }
+        )
+
+        await controller.presentPostUpdateReleaseNotesIfNeeded()
+        await controller.presentPostUpdateReleaseNotesIfNeeded()
+
+        XCTAssertEqual(fetchCount, 1)
+    }
+}


### PR DESCRIPTION
## Summary
- Add a post-update release notes gate that suppresses first install, compares semantic app versions, and fetches the current GitHub Release by tag.
- Show a lightweight SwiftUI What's New sheet with markdown release notes and a link to the full GitHub release.
- Add unit coverage for first-install behavior, update detection, malformed versions, failed fetch retry, and once-per-launch checking.

Fixes #600

## Test plan
- `swift test --filter WhatsNewControllerTests`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`

Made with [Cursor](https://cursor.com)