### PR TITLE
Add a true default notes template fallback

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -1043,7 +1043,11 @@ final class LiveSessionController {
         guard !sessionData.transcript.isEmpty else { return }
         let customGuidance = await coordinator.sessionRepository.loadCustomNotesGuidance(sessionID: sessionID)
 
-        let template = resolvedNotesTemplate(for: session)
+        let template = resolvedNotesTemplate(
+            for: session,
+            calendarEvent: sessionData.calendarEvent,
+            settings: settings
+        )
         let scratchpad = await coordinator.sessionRepository.loadScratchpad(sessionID: sessionID)
 
         do {
@@ -1086,20 +1090,18 @@ final class LiveSessionController {
         }
     }
 
-    private func resolvedNotesTemplate(for session: SessionIndex) -> MeetingTemplate {
-        if let snapshot = session.templateSnapshot {
-            return coordinator.templateStore.template(for: snapshot.id)
-                ?? MeetingTemplate(
-                    id: snapshot.id,
-                    name: snapshot.name,
-                    icon: snapshot.icon,
-                    systemPrompt: snapshot.systemPrompt,
-                    isBuiltIn: false
-                )
-        }
-
-        return coordinator.templateStore.template(for: TemplateStore.genericID)
-            ?? TemplateStore.builtInTemplates.first!
+    private func resolvedNotesTemplate(
+        for session: SessionIndex,
+        calendarEvent: CalendarEvent?,
+        settings: AppSettings
+    ) -> MeetingTemplate {
+        NotesTemplateResolver.resolve(
+            templateStore: coordinator.templateStore,
+            settings: settings,
+            sessionTemplateSnapshot: session.templateSnapshot,
+            meetingFamilyEvent: calendarEvent,
+            meetingFamilyKey: session.meetingFamilyKey
+        ) ?? TemplateStore.builtInTemplates.first!
     }
 
     static func audioRetentionPlan(settings: AppSettings, utteranceCount: Int?) -> AudioRetentionPlan {

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -362,7 +362,7 @@ final class NotesController {
             let session = state.sessionHistory.first { $0.id == sessionID }
             let familySelection = session.map { Self.meetingFamilySelection(for: $0, calendarEvent: data.calendarEvent) }
             state.selectedTemplate = selectedTemplate(
-                forSessionTemplateID: session?.templateSnapshot?.id,
+                sessionTemplateSnapshot: session?.templateSnapshot,
                 meetingFamilySelection: familySelection
             )
 
@@ -409,7 +409,7 @@ final class NotesController {
         state.showingOriginal = false
         state.customNotesGuidance = ""
         state.selectedTemplate = selectedTemplate(
-            forSessionTemplateID: nil,
+            sessionTemplateSnapshot: nil,
             meetingFamilySelection: selection
         )
         coordinator.batchTextCleaner.cancel()
@@ -1212,36 +1212,16 @@ final class NotesController {
     // MARK: - Private
 
     private func selectedTemplate(
-        forSessionTemplateID sessionTemplateID: UUID?,
+        sessionTemplateSnapshot: TemplateSnapshot?,
         meetingFamilySelection: MeetingFamilySelection?
     ) -> MeetingTemplate? {
-        if let sessionTemplateID,
-           sessionTemplateID != TemplateStore.genericID,
-           let template = coordinator.templateStore.template(for: sessionTemplateID) {
-            return template
-        }
-
-        let preferredID: UUID?
-        if let upcomingEvent = meetingFamilySelection?.upcomingEvent {
-            preferredID = settings?.meetingFamilyPreferences(for: upcomingEvent)?.templateID
-        } else if let meetingFamilyKey = meetingFamilySelection?.key {
-            preferredID = settings?.meetingFamilyPreferences(forHistoryKey: meetingFamilyKey)?.templateID
-        } else {
-            preferredID = nil
-        }
-
-        if let preferredID,
-           let template = coordinator.templateStore.template(for: preferredID) {
-            return template
-        }
-
-        if let sessionTemplateID,
-           let template = coordinator.templateStore.template(for: sessionTemplateID) {
-            return template
-        }
-
-        return coordinator.templateStore.template(for: TemplateStore.genericID)
-            ?? TemplateStore.builtInTemplates.first
+        NotesTemplateResolver.resolve(
+            templateStore: coordinator.templateStore,
+            settings: settings,
+            sessionTemplateSnapshot: sessionTemplateSnapshot,
+            meetingFamilyEvent: meetingFamilySelection?.upcomingEvent,
+            meetingFamilyKey: meetingFamilySelection?.key
+        )
     }
 
     private func persistCurrentManualNotesDraftIfNeeded() {

--- a/OpenOats/Sources/OpenOats/App/NotesTemplateResolver.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesTemplateResolver.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+@MainActor
+enum NotesTemplateResolver {
+    static func resolve(
+        templateStore: TemplateStore,
+        settings: AppSettings?,
+        sessionTemplateSnapshot: TemplateSnapshot?,
+        meetingFamilyEvent: CalendarEvent? = nil,
+        meetingFamilyKey: String? = nil
+    ) -> MeetingTemplate? {
+        if let explicitSessionTemplate = explicitSessionTemplate(
+            from: sessionTemplateSnapshot,
+            templateStore: templateStore
+        ) {
+            return explicitSessionTemplate
+        }
+
+        if let settings {
+            if let preferredID = meetingFamilyEvent.flatMap({ settings.meetingFamilyPreferences(for: $0)?.templateID }),
+               let template = templateStore.template(for: preferredID) {
+                return template
+            }
+
+            if let meetingFamilyKey,
+               let preferredID = settings.meetingFamilyPreferences(forHistoryKey: meetingFamilyKey)?.templateID,
+               let template = templateStore.template(for: preferredID) {
+                return template
+            }
+
+            if let defaultTemplateID = settings.defaultNotesTemplateID,
+               let template = templateStore.template(for: defaultTemplateID) {
+                return template
+            }
+        }
+
+        if let sessionTemplate = sessionTemplate(from: sessionTemplateSnapshot, templateStore: templateStore) {
+            return sessionTemplate
+        }
+
+        return templateStore.template(for: TemplateStore.genericID)
+            ?? TemplateStore.builtInTemplates.first
+    }
+
+    private static func explicitSessionTemplate(
+        from snapshot: TemplateSnapshot?,
+        templateStore: TemplateStore
+    ) -> MeetingTemplate? {
+        guard let snapshot, snapshot.id != TemplateStore.genericID else { return nil }
+        return sessionTemplate(from: snapshot, templateStore: templateStore)
+    }
+
+    private static func sessionTemplate(
+        from snapshot: TemplateSnapshot?,
+        templateStore: TemplateStore
+    ) -> MeetingTemplate? {
+        guard let snapshot else { return nil }
+        return templateStore.template(for: snapshot.id)
+            ?? MeetingTemplate(
+                id: snapshot.id,
+                name: snapshot.name,
+                icon: snapshot.icon,
+                systemPrompt: snapshot.systemPrompt,
+                isBuiltIn: false
+            )
+    }
+}

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -25,6 +25,11 @@ final class SettingsStore {
         return result
     }
 
+    private static func normalizeDefaultNotesTemplateID(_ value: UUID?) -> UUID? {
+        guard value != TemplateStore.genericID else { return nil }
+        return value
+    }
+
     private func loadSecretIfNeeded(
         key: String,
         currentValue: String,
@@ -254,6 +259,22 @@ final class SettingsStore {
             withMutation(keyPath: \.selectedModel) {
                 _selectedModel = newValue
                 defaults.set(newValue, forKey: "selectedModel")
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _defaultNotesTemplateID: UUID?
+    var defaultNotesTemplateID: UUID? {
+        get { access(keyPath: \.defaultNotesTemplateID); return _defaultNotesTemplateID }
+        set {
+            withMutation(keyPath: \.defaultNotesTemplateID) {
+                let normalized = Self.normalizeDefaultNotesTemplateID(newValue)
+                _defaultNotesTemplateID = normalized
+                if let normalized {
+                    defaults.set(normalized.uuidString, forKey: "defaultNotesTemplateID")
+                } else {
+                    defaults.removeObject(forKey: "defaultNotesTemplateID")
+                }
             }
         }
     }
@@ -1200,6 +1221,9 @@ final class SettingsStore {
         self._openAIEmbedApiKey = ""
         self._openAIEmbedModel = defaults.string(forKey: "openAIEmbedModel") ?? "text-embedding-3-small"
         self._selectedModel = defaults.string(forKey: "selectedModel") ?? "google/gemini-3-flash-preview"
+        self._defaultNotesTemplateID = Self.normalizeDefaultNotesTemplateID(
+            defaults.string(forKey: "defaultNotesTemplateID").flatMap(UUID.init(uuidString:))
+        )
         self._embeddingProvider = EmbeddingProvider(rawValue: defaults.string(forKey: "embeddingProvider") ?? "") ?? .voyageAI
         self._voyageApiKey = ""
         self._suggestionVerbosity = SuggestionVerbosity(

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -46,7 +46,7 @@ struct SettingsView: View {
                 .tabItem { Label("Sidecast", systemImage: "person.3.sequence") }
                 .tag(SettingsTab.sidecast)
 
-            TemplatesSettingsTab()
+            TemplatesSettingsTab(settings: settings)
                 .tabItem { Label("Templates", systemImage: "doc.text") }
                 .tag(SettingsTab.templates)
 
@@ -845,6 +845,7 @@ private struct TemplatesSettingsTab: View {
         case name
     }
 
+    @Bindable var settings: AppSettings
     @Environment(AppCoordinator.self) private var coordinator
     @State private var templates: [MeetingTemplate] = []
     @State private var isAddingTemplate = false
@@ -858,6 +859,27 @@ private struct TemplatesSettingsTab: View {
         ScrollView {
             Form {
                 Section("Meeting Templates") {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Default template")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        Picker("Default template", selection: defaultTemplateSelection) {
+                            Text("Generic").tag(Optional<UUID>.none)
+                            ForEach(templatesForPicker) { template in
+                                Text(template.name).tag(Optional(template.id))
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                        .frame(maxWidth: 260, alignment: .leading)
+
+                        Text("Used when a session has no explicit template and the meeting family does not have its own default.")
+                            .font(.system(size: 10))
+                            .foregroundStyle(.tertiary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .padding(.vertical, 2)
+
                     ForEach(templates) { template in
                         HStack {
                             Image(systemName: template.icon)
@@ -876,6 +898,7 @@ private struct TemplatesSettingsTab: View {
                                 .font(.system(size: 11))
                                 .buttonStyle(.plain)
                                 .foregroundStyle(.blue)
+                                .disabled(!isBuiltInTemplateModified(template))
                             } else {
                                 Button {
                                     beginEditing(template)
@@ -896,6 +919,11 @@ private struct TemplatesSettingsTab: View {
                             }
                         }
                     }
+
+                    Text("Built-in templates are shipped defaults. Reset only applies if a built-in template was changed outside this view.")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                        .fixedSize(horizontal: false, vertical: true)
 
                     if isAddingTemplate || editingTemplateID != nil {
                         VStack(alignment: .leading, spacing: 10) {
@@ -995,7 +1023,7 @@ private struct TemplatesSettingsTab: View {
         }
         .onAppear {
             Task { @MainActor in
-                templates = coordinator.templateStore.templates
+                refreshTemplates()
             }
         }
     }
@@ -1012,24 +1040,44 @@ private struct TemplatesSettingsTab: View {
         !trimmedTemplateName.isEmpty && !trimmedTemplatePrompt.isEmpty
     }
 
+    private var defaultTemplateSelection: Binding<UUID?> {
+        Binding(
+            get: {
+                guard let templateID = settings.defaultNotesTemplateID,
+                      coordinator.templateStore.template(for: templateID) != nil else {
+                    return nil
+                }
+                return templateID
+            },
+            set: { settings.defaultNotesTemplateID = $0 }
+        )
+    }
+
+    private var templatesForPicker: [MeetingTemplate] {
+        templates.filter { $0.id != TemplateStore.genericID }
+    }
+
     private func addTemplate(_ template: MeetingTemplate) {
         Task { @MainActor in
             coordinator.templateStore.add(template)
-            templates = coordinator.templateStore.templates
+            refreshTemplates()
         }
     }
 
     private func resetTemplate(id: UUID) {
         Task { @MainActor in
             coordinator.templateStore.resetBuiltIn(id: id)
-            templates = coordinator.templateStore.templates
+            refreshTemplates()
         }
     }
 
     private func deleteTemplate(id: UUID) {
         Task { @MainActor in
             coordinator.templateStore.delete(id: id)
-            templates = coordinator.templateStore.templates
+            if settings.defaultNotesTemplateID == id {
+                settings.defaultNotesTemplateID = nil
+            }
+            refreshTemplates()
         }
     }
 
@@ -1047,7 +1095,22 @@ private struct TemplatesSettingsTab: View {
     private func updateTemplate(_ template: MeetingTemplate) {
         Task { @MainActor in
             coordinator.templateStore.update(template)
-            templates = coordinator.templateStore.templates
+            refreshTemplates()
+        }
+    }
+
+    private func isBuiltInTemplateModified(_ template: MeetingTemplate) -> Bool {
+        guard let builtIn = TemplateStore.builtInTemplates.first(where: { $0.id == template.id }) else {
+            return false
+        }
+        return template != builtIn
+    }
+
+    private func refreshTemplates() {
+        templates = coordinator.templateStore.templates
+        if let templateID = settings.defaultNotesTemplateID,
+           coordinator.templateStore.template(for: templateID) == nil {
+            settings.defaultNotesTemplateID = nil
         }
     }
 

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -751,6 +751,141 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertTrue(coordinator.lastEndedSession?.hasNotes == true)
     }
 
+    func testFinalizeCurrentSessionAutoGeneratesNotesUsingGlobalDefaultTemplateFallback() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        settings.llmProvider = .ollama
+        settings.ollamaBaseURL = "http://localhost:11434"
+        settings.ollamaLLMModel = "qwen3:8b"
+        settings.enableBatchRetranscription = false
+
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings,
+            scripted: [Utterance(text: "Follow up on merchant fees", speaker: .you)]
+        )
+
+        let customTemplate = MeetingTemplate(
+            id: UUID(),
+            name: "Board Update",
+            icon: "briefcase",
+            systemPrompt: "Summarize in board format.",
+            isBuiltIn: false
+        )
+        coordinator.templateStore.add(customTemplate)
+        settings.defaultNotesTemplateID = customTemplate.id
+
+        controller.startSession(settings: settings)
+
+        var sessionID: String?
+        for _ in 0..<20 {
+            sessionID = await coordinator.sessionRepository.getCurrentSessionID()
+            if sessionID != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        guard let sessionID else {
+            return XCTFail("Expected session ID after starting session")
+        }
+
+        let recordedUtterance = Utterance(
+            text: "Follow up on merchant fees",
+            speaker: .you,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        await coordinator.sessionRepository.appendLiveUtterance(
+            sessionID: sessionID,
+            utterance: recordedUtterance
+        )
+
+        controller.stopSession(settings: settings)
+        await controller.finalizeCurrentSession(settings: settings)
+
+        var savedNotes: GeneratedNotes?
+        for _ in 0..<20 {
+            savedNotes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
+            if savedNotes != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        XCTAssertEqual(savedNotes?.template.id, customTemplate.id)
+    }
+
+    func testFinalizeCurrentSessionAutoGeneratesNotesPreferringMeetingFamilyTemplate() async {
+        let dirs = makeTempDirs()
+        let settings = makeSettings(notesDirectory: dirs.notes)
+        settings.llmProvider = .ollama
+        settings.ollamaBaseURL = "http://localhost:11434"
+        settings.ollamaLLMModel = "qwen3:8b"
+        settings.enableBatchRetranscription = false
+
+        let (controller, coordinator) = makeController(
+            root: dirs.root,
+            notesDirectory: dirs.notes,
+            settings: settings,
+            scripted: [Utterance(text: "Follow up on merchant fees", speaker: .you)]
+        )
+
+        let customTemplate = MeetingTemplate(
+            id: UUID(),
+            name: "Board Update",
+            icon: "briefcase",
+            systemPrompt: "Summarize in board format.",
+            isBuiltIn: false
+        )
+        coordinator.templateStore.add(customTemplate)
+        settings.defaultNotesTemplateID = customTemplate.id
+
+        let event = CalendarEvent(
+            id: "evt_meeting_family_auto_notes",
+            title: "Daily Standup",
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(900),
+            externalIdentifier: "series-standup",
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+        settings.setMeetingFamilyTemplatePreference(TemplateStore.standUpID, for: event)
+
+        controller.startSession(settings: settings, calendarEventOverride: event)
+
+        var sessionID: String?
+        for _ in 0..<20 {
+            sessionID = await coordinator.sessionRepository.getCurrentSessionID()
+            if sessionID != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        guard let sessionID else {
+            return XCTFail("Expected session ID after starting session")
+        }
+
+        let recordedUtterance = Utterance(
+            text: "Follow up on merchant fees",
+            speaker: .you,
+            timestamp: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        await coordinator.sessionRepository.appendLiveUtterance(
+            sessionID: sessionID,
+            utterance: recordedUtterance
+        )
+
+        controller.stopSession(settings: settings)
+        await controller.finalizeCurrentSession(settings: settings)
+
+        var savedNotes: GeneratedNotes?
+        for _ in 0..<20 {
+            savedNotes = await coordinator.sessionRepository.loadNotes(sessionID: sessionID)
+            if savedNotes != nil { break }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+
+        XCTAssertEqual(savedNotes?.template.id, TemplateStore.standUpID)
+    }
+
     func testFinalizeCurrentSessionSkipsAutoNotesWhenProviderIsNotConfigured() async {
         let dirs = makeTempDirs()
         let settings = makeSettings(notesDirectory: dirs.notes)

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -838,6 +838,69 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertFalse(markdown.contains("# Meeting Notes: Q4 Planning\n\n# Test Notes"))
     }
 
+    func testShowMeetingHistoryUsesGlobalDefaultTemplateFallback() {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+
+        let customTemplate = MeetingTemplate(
+            id: UUID(),
+            name: "Board Update",
+            icon: "briefcase",
+            systemPrompt: "Summarize in board format.",
+            isBuiltIn: false
+        )
+        coordinator.templateStore.add(customTemplate)
+        settings.defaultNotesTemplateID = customTemplate.id
+
+        let event = CalendarEvent(
+            id: "evt_global_default",
+            title: "Product Review",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+
+        controller.showMeetingHistory(for: event)
+
+        XCTAssertEqual(controller.state.selectedTemplate?.id, customTemplate.id)
+    }
+
+    func testShowMeetingHistoryPrefersMeetingFamilyTemplateOverGlobalDefault() {
+        let (root, notes) = makeTempDirs()
+        let settings = makeSettings(notesDirectory: notes)
+        let (controller, coordinator) = makeController(root: root, settings: settings)
+
+        let customTemplate = MeetingTemplate(
+            id: UUID(),
+            name: "Board Update",
+            icon: "briefcase",
+            systemPrompt: "Summarize in board format.",
+            isBuiltIn: false
+        )
+        coordinator.templateStore.add(customTemplate)
+        settings.defaultNotesTemplateID = customTemplate.id
+
+        let event = CalendarEvent(
+            id: "evt_meeting_family_default",
+            title: "Daily Standup",
+            startDate: Date(timeIntervalSince1970: 1_700_000_000),
+            endDate: Date(timeIntervalSince1970: 1_700_000_900),
+            organizer: nil,
+            participants: [],
+            isOnlineMeeting: false,
+            meetingURL: nil
+        )
+        settings.setMeetingFamilyTemplatePreference(TemplateStore.standUpID, for: event)
+
+        controller.showMeetingHistory(for: event)
+
+        XCTAssertEqual(controller.state.selectedTemplate?.id, TemplateStore.standUpID)
+    }
+
     func testShowMeetingHistoryLoadsMatchingSessionsAndNotePreviews() async {
         let (root, _) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -71,6 +71,26 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.selectedModel, "anthropic/claude-4-sonnet")
     }
 
+    func testDefaultNotesTemplateIDRoundTripAndNormalizesGenericToNil() {
+        let suiteName = "com.openoats.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let store = makeStore(defaults: defaults)
+        let customTemplateID = UUID()
+        store.defaultNotesTemplateID = customTemplateID
+        XCTAssertEqual(store.defaultNotesTemplateID, customTemplateID)
+
+        let reopened = makeStore(defaults: defaults)
+        XCTAssertEqual(reopened.defaultNotesTemplateID, customTemplateID)
+
+        reopened.defaultNotesTemplateID = TemplateStore.genericID
+        XCTAssertNil(reopened.defaultNotesTemplateID)
+
+        let reopenedAgain = makeStore(defaults: defaults)
+        XCTAssertNil(reopenedAgain.defaultNotesTemplateID)
+    }
+
     func testAutoPostMeetingNotesRequiresOpenRouterKey() {
         let store = makeStore()
         store.llmProvider = .openRouter


### PR DESCRIPTION
## Summary
- add a persisted global default notes template setting and shared template-resolution helper
- make manual note generation and post-meeting auto-generation use the same precedence rule
- expose the global default in Templates settings and clarify built-in reset behavior

Closes #621.

## Testing
- swift test --filter "SettingsStoreTests|NotesControllerTests|LiveSessionControllerTests"
- scripts/run_ui_smoke.sh
- SKIP_SIGN=1 SKIP_INSTALL=1 scripts/build_swift_app.sh
