### PR TITLE
Fix banner "Open Settings" button

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -12,6 +12,7 @@ struct ContentView: View {
     @Environment(AppContainer.self) private var container
     @Environment(AppCoordinator.self) private var coordinator
     @Environment(\.openWindow) private var openWindow
+    @Environment(\.openSettings) private var openSettings
     @State private var overlayManager = OverlayManager()
     @State private var miniBarManager = MiniBarManager()
     @State private var liveSessionController: LiveSessionController?
@@ -407,7 +408,7 @@ struct ContentView: View {
 
     private func openSettingsWindow() {
         NSApp.activate()
-        NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        openSettings()
     }
 
     private func openMicrophonePrivacySettings() {


### PR DESCRIPTION
## Summary
- The "Open Settings" button on the no-sound / no-device banners did nothing when clicked.
- Root cause: `ContentView.openSettingsWindow()` used `NSApp.sendAction(Selector("showSettingsWindow:"), to: nil, from: nil)`, which is flaky in SwiftUI apps on macOS 14+ (especially with the app's `.accessory` activation policy) and silently dropped the action. The gear button in the same view already uses `SettingsLink` and works.
- Switched to `@Environment(\.openSettings)` — the same plumbing `SettingsLink` uses — so every banner action ("Open Settings" for missing mic, missing output device, no audio detected, etc.) now opens the in-app Settings window reliably.

## Test plan
- [ ] Start a recording with no microphone or no system audio so the no-sound banner appears.
- [ ] Click **Open Settings** on the banner → verify the in-app Settings window opens.
- [ ] Repeat for the other banners that surface this button (mic unavailable, output device unavailable, API key missing, etc.).
- [ ] Confirm the existing gear-icon `SettingsLink` still works (no regression).