### PR TITLE
Add native OpenAI and Anthropic providers

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.77.0"
-  sha256 "6c648e33c886efdd43f58b09568be11044cc22740c8062781e69e35e2a509768"
+  version "1.78.0"
+  sha256 "91c8ca3916842524eec78c085dfd538899b4185169b9061d80ae926167f1d3b5"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -1309,12 +1309,7 @@ final class LiveSessionController {
             coordinator.sessionHistory.first { $0.id == lastSession.id }?.hasNotes
         } ?? false
 
-        let activeModelRaw = switch settings.llmProvider {
-        case .openRouter: settings.selectedModel
-        case .ollama: settings.ollamaLLMModel
-        case .mlx: settings.mlxModel
-        case .openAICompatible: settings.openAILLMModel
-        }
+        let activeModelRaw = settings.activeNotesModel
 
         let sidebarSuggestions: [Suggestion]
         let sidebarGenerating: Bool

--- a/OpenOats/Sources/OpenOats/Intelligence/BatchTextCleaner.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/BatchTextCleaner.swift
@@ -59,12 +59,34 @@ final class BatchTextCleaner {
         let apiKey: String?
         let baseURL: URL?
         let model: String
+        let transport: OpenRouterClient.CompletionTransport
 
         switch settings.llmProvider {
         case .openRouter:
-            apiKey = settings.openRouterApiKey.isEmpty ? nil : settings.openRouterApiKey
+            apiKey = settings.activeLLMApiKey
             baseURL = nil
             model = "openai/gpt-4o-mini"
+            transport = settings.activeLLMTransport
+        case .openAI:
+            apiKey = settings.activeLLMApiKey
+            guard let url = settings.activeLLMBaseURL else {
+                error = "Invalid OpenAI URL: \(settings.openAIBaseURL)"
+                isCleaningUp = false
+                return records
+            }
+            baseURL = url
+            model = settings.openAIModel
+            transport = settings.activeLLMTransport
+        case .anthropic:
+            apiKey = settings.activeLLMApiKey
+            guard let url = settings.activeLLMBaseURL else {
+                error = "Invalid Anthropic URL: \(settings.anthropicBaseURL)"
+                isCleaningUp = false
+                return records
+            }
+            baseURL = url
+            model = settings.anthropicModel
+            transport = settings.activeLLMTransport
         case .ollama:
             apiKey = nil
             guard let ollamaURL = OpenRouterClient.chatCompletionsURL(from: settings.ollamaBaseURL) else {
@@ -74,6 +96,7 @@ final class BatchTextCleaner {
             }
             baseURL = ollamaURL
             model = settings.ollamaLLMModel
+            transport = settings.activeLLMTransport
         case .mlx:
             apiKey = nil
             guard let mlxURL = OpenRouterClient.chatCompletionsURL(from: settings.mlxBaseURL) else {
@@ -83,8 +106,9 @@ final class BatchTextCleaner {
             }
             baseURL = mlxURL
             model = settings.mlxModel
+            transport = settings.activeLLMTransport
         case .openAICompatible:
-            apiKey = settings.openAILLMApiKey.isEmpty ? nil : settings.openAILLMApiKey
+            apiKey = settings.activeLLMApiKey
             guard let openAIURL = OpenRouterClient.chatCompletionsURL(from: settings.openAILLMBaseURL) else {
                 error = "Invalid OpenAI Compatible URL: \(settings.openAILLMBaseURL)"
                 isCleaningUp = false
@@ -92,12 +116,13 @@ final class BatchTextCleaner {
             }
             baseURL = openAIURL
             model = settings.openAILLMModel
+            transport = settings.activeLLMTransport
         }
 
         let chunks = Self.chunkRecords(records)
         totalChunks = chunks.count
 
-        let task = Task { [weak self, client, apiKey, baseURL, model] () -> [SessionRecord] in
+        let task = Task { [weak self, client, apiKey, baseURL, model, transport] () -> [SessionRecord] in
             // Process chunks concurrently (up to 3 at a time) off the main actor.
             let results: [(index: Int, records: [SessionRecord]?)] = await withTaskGroup(
                 of: (Int, [SessionRecord]?).self,
@@ -123,7 +148,8 @@ final class BatchTextCleaner {
                             client: client,
                             apiKey: apiKey,
                             model: model,
-                            baseURL: baseURL
+                            baseURL: baseURL,
+                            transport: transport
                         )
                         return (chunkIndex, cleaned)
                     }
@@ -226,7 +252,8 @@ final class BatchTextCleaner {
         client: OpenRouterClient,
         apiKey: String?,
         model: String,
-        baseURL: URL?
+        baseURL: URL?,
+        transport: OpenRouterClient.CompletionTransport
     ) async -> [SessionRecord]? {
         let lines = records.map { record in
             let label = record.speaker.displayLabel
@@ -247,7 +274,8 @@ final class BatchTextCleaner {
                 model: model,
                 messages: messages,
                 maxTokens: 4096,
-                baseURL: baseURL
+                baseURL: baseURL,
+                transport: transport
             )
 
             return parseResponse(response, originalRecords: records)

--- a/OpenOats/Sources/OpenOats/Intelligence/LiveTranscriptCleaner.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/LiveTranscriptCleaner.swift
@@ -93,10 +93,17 @@ actor LiveTranscriptCleaner {
         let apiKey: String?
         let baseURL: URL?
         let model: String
+        let transport: OpenRouterClient.CompletionTransport
 
         // Read settings on MainActor
         let provider = await MainActor.run { settings.llmProvider }
         let openRouterKey = await MainActor.run { settings.openRouterApiKey }
+        let openAIKey = await MainActor.run { settings.openAIApiKey }
+        let openAIURL = await MainActor.run { settings.openAIBaseURL }
+        let openAIModel = await MainActor.run { settings.openAIModel }
+        let anthropicKey = await MainActor.run { settings.anthropicApiKey }
+        let anthropicURL = await MainActor.run { settings.anthropicBaseURL }
+        let anthropicModel = await MainActor.run { settings.anthropicModel }
         let ollamaURL = await MainActor.run { settings.ollamaBaseURL }
         let ollamaModel = await MainActor.run { settings.ollamaLLMModel }
         let mlxURL = await MainActor.run { settings.mlxBaseURL }
@@ -110,6 +117,25 @@ actor LiveTranscriptCleaner {
             apiKey = openRouterKey.isEmpty ? nil : openRouterKey
             baseURL = nil
             model = cleanupModel
+            transport = .chatCompletions
+        case .openAI:
+            apiKey = openAIKey.isEmpty ? nil : openAIKey
+            guard let url = OpenRouterClient.chatCompletionsURL(from: openAIURL) else {
+                await markFailed(utterance.id)
+                return
+            }
+            baseURL = url
+            model = openAIModel
+            transport = .chatCompletions
+        case .anthropic:
+            apiKey = anthropicKey.isEmpty ? nil : anthropicKey
+            guard let url = OpenRouterClient.anthropicMessagesURL(from: anthropicURL) else {
+                await markFailed(utterance.id)
+                return
+            }
+            baseURL = url
+            model = anthropicModel
+            transport = .anthropicMessages
         case .ollama:
             apiKey = nil
             guard let url = OpenRouterClient.chatCompletionsURL(from: ollamaURL) else {
@@ -118,6 +144,7 @@ actor LiveTranscriptCleaner {
             }
             baseURL = url
             model = ollamaModel
+            transport = .chatCompletions
         case .mlx:
             apiKey = nil
             guard let url = OpenRouterClient.chatCompletionsURL(from: mlxURL) else {
@@ -126,6 +153,7 @@ actor LiveTranscriptCleaner {
             }
             baseURL = url
             model = mlxModelName
+            transport = .chatCompletions
         case .openAICompatible:
             apiKey = openAILLMKey.isEmpty ? nil : openAILLMKey
             guard let url = OpenRouterClient.chatCompletionsURL(from: openAILLMURL) else {
@@ -134,6 +162,7 @@ actor LiveTranscriptCleaner {
             }
             baseURL = url
             model = openAILLMModelName
+            transport = .chatCompletions
         }
 
         let messages: [OpenRouterClient.Message] = [
@@ -147,7 +176,8 @@ actor LiveTranscriptCleaner {
                 model: model,
                 messages: messages,
                 maxTokens: 512,
-                baseURL: baseURL
+                baseURL: baseURL,
+                transport: transport
             )
 
             let trimmed = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
@@ -110,12 +110,36 @@ final class NotesEngine {
         let apiKey: String?
         let baseURL: URL?
         let model: String
+        let transport: OpenRouterClient.CompletionTransport
 
         switch settings.llmProvider {
         case .openRouter:
-            apiKey = settings.openRouterApiKey.isEmpty ? nil : settings.openRouterApiKey
+            apiKey = settings.activeLLMApiKey
             baseURL = nil
             model = settings.selectedModel
+            transport = settings.activeLLMTransport
+        case .openAI:
+            apiKey = settings.activeLLMApiKey
+            guard let openAIURL = settings.activeLLMBaseURL else {
+                error = "Invalid OpenAI URL: \(settings.openAIBaseURL)"
+                isGenerating = false
+                onFinished()
+                return
+            }
+            baseURL = openAIURL
+            model = settings.openAIModel
+            transport = settings.activeLLMTransport
+        case .anthropic:
+            apiKey = settings.activeLLMApiKey
+            guard let anthropicURL = settings.activeLLMBaseURL else {
+                error = "Invalid Anthropic URL: \(settings.anthropicBaseURL)"
+                isGenerating = false
+                onFinished()
+                return
+            }
+            baseURL = anthropicURL
+            model = settings.anthropicModel
+            transport = settings.activeLLMTransport
         case .ollama:
             apiKey = nil
             guard let ollamaURL = OpenRouterClient.chatCompletionsURL(from: settings.ollamaBaseURL) else {
@@ -126,6 +150,7 @@ final class NotesEngine {
             }
             baseURL = ollamaURL
             model = settings.ollamaLLMModel
+            transport = settings.activeLLMTransport
         case .mlx:
             apiKey = nil
             guard let mlxURL = OpenRouterClient.chatCompletionsURL(from: settings.mlxBaseURL) else {
@@ -136,8 +161,9 @@ final class NotesEngine {
             }
             baseURL = mlxURL
             model = settings.mlxModel
+            transport = settings.activeLLMTransport
         case .openAICompatible:
-            apiKey = settings.openAILLMApiKey.isEmpty ? nil : settings.openAILLMApiKey
+            apiKey = settings.activeLLMApiKey
             guard let openAIURL = OpenRouterClient.chatCompletionsURL(from: settings.openAILLMBaseURL) else {
                 error = "Invalid OpenAI Compatible URL: \(settings.openAILLMBaseURL)"
                 isGenerating = false
@@ -146,6 +172,7 @@ final class NotesEngine {
             }
             baseURL = openAIURL
             model = settings.openAILLMModel
+            transport = settings.activeLLMTransport
         }
 
         let includeCalendarContext = Self.shouldIncludeCalendarContext(
@@ -175,7 +202,8 @@ final class NotesEngine {
                     model: model,
                     messages: messages,
                     maxTokens: 4096,
-                    baseURL: baseURL
+                    baseURL: baseURL,
+                    transport: transport
                 )
                 guard let stream else {
                     self?.isGenerating = false
@@ -288,7 +316,7 @@ final class NotesEngine {
         switch provider {
         case .ollama, .mlx:
             return true
-        case .openRouter:
+        case .openRouter, .openAI, .anthropic:
             return allowCloudCalendarContext
         case .openAICompatible:
             if let baseURL, OpenRouterClient.isLocalHost(baseURL) {

--- a/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
@@ -3,6 +3,12 @@ import Foundation
 /// Streaming OpenAI-compatible client for OpenRouter API (and Ollama via OpenAI-compatible endpoint).
 actor OpenRouterClient {
     private static let defaultBaseURL = URL(string: "https://openrouter.ai/api/v1/chat/completions")!
+    private static let anthropicVersion = "2023-06-01"
+
+    enum CompletionTransport: Equatable, Sendable {
+        case chatCompletions
+        case anthropicMessages
+    }
 
     /// Builds a chat completions URL from a user-provided base URL, stripping
     /// any trailing `/v1` or `/v1/chat/completions` to avoid double-pathing.
@@ -33,6 +39,36 @@ actor OpenRouterClient {
         } else {
             components.path = path + "/v1/chat/completions"
         }
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
+
+    /// Builds an Anthropic Messages URL from a user-provided base URL, stripping
+    /// trailing `/v1` or `/v1/messages` before appending the canonical path.
+    static func anthropicMessagesURL(from rawBase: String) -> URL? {
+        let trimmed = rawBase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmed),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = components.host,
+              !host.isEmpty else {
+            return nil
+        }
+
+        var path = components.path
+        while path.hasSuffix("/") {
+            path.removeLast()
+        }
+
+        for suffix in ["/v1/messages", "/v1"] {
+            if path.hasSuffix(suffix) {
+                path.removeLast(suffix.count)
+                break
+            }
+        }
+
+        components.path = path.isEmpty ? "/v1/messages" : path + "/v1/messages"
         components.query = nil
         components.fragment = nil
         return components.url
@@ -91,9 +127,20 @@ actor OpenRouterClient {
         model: String,
         messages: [Message],
         maxTokens: Int = 1024,
-        baseURL: URL? = nil
+        baseURL: URL? = nil,
+        transport: CompletionTransport = .chatCompletions
     ) -> AsyncThrowingStream<String, Error> {
-        AsyncThrowingStream { continuation in
+        if transport == .anthropicMessages {
+            return streamAnthropicCompletion(
+                apiKey: apiKey,
+                model: model,
+                messages: messages,
+                maxTokens: maxTokens,
+                baseURL: baseURL
+            )
+        }
+
+        return AsyncThrowingStream<String, Error> { continuation in
             let task = Task {
                 do {
                     let targetURL = baseURL ?? Self.defaultBaseURL
@@ -168,8 +215,20 @@ actor OpenRouterClient {
         maxTokens: Int = 512,
         temperature: Double? = nil,
         baseURL: URL? = nil,
-        webSearch: Bool = false
+        webSearch: Bool = false,
+        transport: CompletionTransport = .chatCompletions
     ) async throws -> String {
+        if transport == .anthropicMessages {
+            return try await completeAnthropic(
+                apiKey: apiKey,
+                model: model,
+                messages: messages,
+                maxTokens: maxTokens,
+                temperature: temperature,
+                baseURL: baseURL
+            )
+        }
+
         let targetURL = baseURL ?? Self.defaultBaseURL
         if let preflightError = Self.preflightError(for: targetURL, apiKey: apiKey) {
             throw preflightError
@@ -208,6 +267,132 @@ actor OpenRouterClient {
 
         let completionResponse = try JSONDecoder().decode(CompletionResponse.self, from: data)
         return completionResponse.choices.first?.message.content ?? ""
+    }
+
+    private func streamAnthropicCompletion(
+        apiKey: String?,
+        model: String,
+        messages: [Message],
+        maxTokens: Int,
+        baseURL: URL?
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream<String, Error> { continuation in
+            let task = Task {
+                do {
+                    let targetURL = baseURL ?? Self.anthropicMessagesURL(from: "https://api.anthropic.com")!
+                    guard let apiKey, !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                        continuation.finish(throwing: OpenRouterError.missingAPIKey(host: targetURL.host))
+                        return
+                    }
+
+                    let request = AnthropicRequest(
+                        model: model,
+                        max_tokens: maxTokens,
+                        messages: Self.anthropicMessages(from: messages),
+                        stream: true,
+                        temperature: nil,
+                        system: Self.anthropicSystemPrompt(from: messages)
+                    )
+
+                    var urlRequest = URLRequest(url: targetURL)
+                    urlRequest.httpMethod = "POST"
+                    urlRequest.timeoutInterval = 300
+                    urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                    urlRequest.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+                    urlRequest.setValue(Self.anthropicVersion, forHTTPHeaderField: "anthropic-version")
+                    urlRequest.httpBody = try JSONEncoder().encode(request)
+
+                    let (bytes, response) = try await URLSession.shared.bytes(for: urlRequest)
+                    guard let httpResponse = response as? HTTPURLResponse,
+                          (200...299).contains(httpResponse.statusCode) else {
+                        let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+                        continuation.finish(throwing: OpenRouterError.httpError(statusCode, host: targetURL.host))
+                        return
+                    }
+
+                    for try await line in bytes.lines {
+                        guard line.hasPrefix("data: ") else { continue }
+                        let payload = String(line.dropFirst(6))
+                        guard let data = payload.data(using: .utf8),
+                              let event = try? JSONDecoder().decode(AnthropicStreamEvent.self, from: data) else {
+                            continue
+                        }
+                        if event.type == "message_stop" { break }
+                        if event.type == "content_block_delta",
+                           event.delta?.type == "text_delta",
+                           let text = event.delta?.text {
+                            continuation.yield(text)
+                        }
+                    }
+
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    private func completeAnthropic(
+        apiKey: String?,
+        model: String,
+        messages: [Message],
+        maxTokens: Int,
+        temperature: Double?,
+        baseURL: URL?
+    ) async throws -> String {
+        let targetURL = baseURL ?? Self.anthropicMessagesURL(from: "https://api.anthropic.com")!
+        guard let apiKey, !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw OpenRouterError.missingAPIKey(host: targetURL.host)
+        }
+
+        let request = AnthropicRequest(
+            model: model,
+            max_tokens: maxTokens,
+            messages: Self.anthropicMessages(from: messages),
+            stream: false,
+            temperature: temperature,
+            system: Self.anthropicSystemPrompt(from: messages)
+        )
+
+        var urlRequest = URLRequest(url: targetURL)
+        urlRequest.httpMethod = "POST"
+        urlRequest.timeoutInterval = 300
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        urlRequest.setValue(Self.anthropicVersion, forHTTPHeaderField: "anthropic-version")
+        urlRequest.httpBody = try JSONEncoder().encode(request)
+
+        let (data, response) = try await URLSession.shared.data(for: urlRequest)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw OpenRouterError.httpError(statusCode, host: targetURL.host)
+        }
+
+        let decoded = try JSONDecoder().decode(AnthropicResponse.self, from: data)
+        return decoded.content.compactMap(\.text).joined()
+    }
+
+    private static func anthropicSystemPrompt(from messages: [Message]) -> String? {
+        let prompt = messages
+            .filter { $0.role == "system" }
+            .map(\.content)
+            .joined(separator: "\n\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return prompt.isEmpty ? nil : prompt
+    }
+
+    private static func anthropicMessages(from messages: [Message]) -> [AnthropicMessage] {
+        messages.compactMap { message in
+            guard message.role != "system" else { return nil }
+            let role = message.role == "assistant" ? "assistant" : "user"
+            return AnthropicMessage(role: role, content: message.content)
+        }
     }
 
     enum OpenRouterError: Error, LocalizedError {
@@ -258,6 +443,39 @@ actor OpenRouterClient {
 
         struct CompletionMessage: Codable {
             let content: String
+        }
+    }
+
+    private struct AnthropicRequest: Codable {
+        let model: String
+        let max_tokens: Int
+        let messages: [AnthropicMessage]
+        let stream: Bool
+        let temperature: Double?
+        let system: String?
+    }
+
+    private struct AnthropicMessage: Codable {
+        let role: String
+        let content: String
+    }
+
+    private struct AnthropicStreamEvent: Codable {
+        let type: String
+        let delta: Delta?
+
+        struct Delta: Codable {
+            let type: String
+            let text: String?
+        }
+    }
+
+    private struct AnthropicResponse: Codable {
+        let content: [ContentBlock]
+
+        struct ContentBlock: Codable {
+            let type: String
+            let text: String?
         }
     }
 }

--- a/OpenOats/Sources/OpenOats/Intelligence/SidecastEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SidecastEngine.swift
@@ -85,7 +85,8 @@ final class SidecastEngine {
                     maxTokens: self.settings.sidecastMaxTokens,
                     temperature: self.settings.sidecastTemperature,
                     baseURL: self.llmBaseURL,
-                    webSearch: useWebSearch
+                    webSearch: useWebSearch,
+                    transport: self.settings.activeLLMTransport
                 )
                 let decoded = try self.decodeResponse(response)
 
@@ -372,6 +373,10 @@ final class SidecastEngine {
         switch settings.llmProvider {
         case .openRouter:
             return !settings.openRouterApiKey.isEmpty
+        case .openAI:
+            return !settings.openAIApiKey.isEmpty && llmBaseURL != nil
+        case .anthropic:
+            return !settings.anthropicApiKey.isEmpty && llmBaseURL != nil
         case .ollama, .mlx, .openAICompatible:
             return llmBaseURL != nil
         }
@@ -380,6 +385,10 @@ final class SidecastEngine {
     private var llmApiKey: String? {
         switch settings.llmProvider {
         case .openRouter: settings.openRouterApiKey
+        case .openAI:
+            settings.openAIApiKey.isEmpty ? nil : settings.openAIApiKey
+        case .anthropic:
+            settings.anthropicApiKey.isEmpty ? nil : settings.anthropicApiKey
         case .ollama: nil
         case .mlx: nil
         case .openAICompatible:
@@ -395,6 +404,10 @@ final class SidecastEngine {
     private var llmBaseURL: URL? {
         switch settings.llmProvider {
         case .openRouter: nil
+        case .openAI:
+            OpenRouterClient.chatCompletionsURL(from: settings.openAIBaseURL)
+        case .anthropic:
+            OpenRouterClient.anthropicMessagesURL(from: settings.anthropicBaseURL)
         case .ollama:
             OpenRouterClient.chatCompletionsURL(from: settings.ollamaBaseURL)
         case .mlx:

--- a/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
@@ -178,7 +178,8 @@ final class SuggestionEngine {
                 model: activePrimaryModel,
                 messages: statePrompt,
                 maxTokens: 512,
-                baseURL: llmBaseURL(forRealtime: false)
+                baseURL: llmBaseURL(forRealtime: false),
+                transport: settings.activeLLMTransport
             )
 
             let jsonString = extractJSON(from: response)
@@ -222,6 +223,10 @@ final class SuggestionEngine {
         switch settings.llmProvider {
         case .openRouter:
             guard !settings.openRouterApiKey.isEmpty else { return }
+        case .openAI:
+            guard !settings.openAIApiKey.isEmpty, llmBaseURL(forRealtime: true) != nil else { return }
+        case .anthropic:
+            guard !settings.anthropicApiKey.isEmpty, llmBaseURL(forRealtime: true) != nil else { return }
         case .ollama, .mlx, .openAICompatible:
             guard llmBaseURL(forRealtime: true) != nil else { return }
         }
@@ -386,7 +391,8 @@ final class SuggestionEngine {
                 model: settings.activeRealtimeModel,
                 messages: messages,
                 maxTokens: 200,
-                baseURL: llmBaseURL(forRealtime: true)
+                baseURL: llmBaseURL(forRealtime: true),
+                transport: settings.activeLLMTransport
             )
 
             var accumulated = ""
@@ -496,6 +502,8 @@ final class SuggestionEngine {
     private var activePrimaryModel: String {
         switch settings.llmProvider {
         case .openRouter: settings.selectedModel
+        case .openAI: settings.openAIModel
+        case .anthropic: settings.anthropicModel
         case .ollama: settings.ollamaLLMModel
         case .mlx: settings.mlxModel
         case .openAICompatible: settings.openAILLMModel
@@ -505,6 +513,10 @@ final class SuggestionEngine {
     private var llmApiKey: String? {
         switch settings.llmProvider {
         case .openRouter: settings.openRouterApiKey
+        case .openAI:
+            settings.openAIApiKey.isEmpty ? nil : settings.openAIApiKey
+        case .anthropic:
+            settings.anthropicApiKey.isEmpty ? nil : settings.anthropicApiKey
         case .ollama: nil
         case .mlx: nil
         case .openAICompatible:
@@ -515,6 +527,10 @@ final class SuggestionEngine {
     private func llmBaseURL(forRealtime: Bool) -> URL? {
         switch settings.llmProvider {
         case .openRouter: return nil
+        case .openAI:
+            return OpenRouterClient.chatCompletionsURL(from: settings.openAIBaseURL)
+        case .anthropic:
+            return OpenRouterClient.anthropicMessagesURL(from: settings.anthropicBaseURL)
         case .ollama:
             return OpenRouterClient.chatCompletionsURL(from: settings.ollamaBaseURL)
         case .mlx:

--- a/OpenOats/Sources/OpenOats/Models/SidecastPreset.swift
+++ b/OpenOats/Sources/OpenOats/Models/SidecastPreset.swift
@@ -78,6 +78,8 @@ struct SidecastPreset: Decodable {
     /// Maps debug tool provider strings to app LLMProvider enum values.
     private static let providerMap: [String: LLMProvider] = [
         "openrouter": .openRouter,
+        "openai": .openAI,
+        "anthropic": .anthropic,
         "ollama": .ollama,
         "openai-compatible": .openAICompatible,
     ]
@@ -91,6 +93,10 @@ struct SidecastPreset: Decodable {
                 switch mapped {
                 case .openRouter:
                     settings.openRouterApiKey = apiKey
+                case .openAI:
+                    settings.openAIApiKey = apiKey
+                case .anthropic:
+                    settings.anthropicApiKey = apiKey
                 case .openAICompatible:
                     settings.openAILLMApiKey = apiKey
                 case .ollama, .mlx:
@@ -100,6 +106,10 @@ struct SidecastPreset: Decodable {
 
             if let baseURL, !baseURL.isEmpty {
                 switch mapped {
+                case .openAI:
+                    settings.openAIBaseURL = baseURL
+                case .anthropic:
+                    settings.anthropicBaseURL = baseURL
                 case .ollama:
                     settings.ollamaBaseURL = baseURL
                 case .openAICompatible:
@@ -113,6 +123,10 @@ struct SidecastPreset: Decodable {
                 switch mapped {
                 case .openRouter:
                     settings.realtimeModel = model
+                case .openAI:
+                    settings.openAIModel = model
+                case .anthropic:
+                    settings.anthropicModel = model
                 case .ollama:
                     settings.realtimeOllamaModel = model
                 case .openAICompatible:

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -76,6 +76,86 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _openAIApiKey: String
+    var openAIApiKey: String {
+        get {
+            access(keyPath: \.openAIApiKey)
+            return loadSecretIfNeeded(key: "openAIApiKey", currentValue: _openAIApiKey) {
+                _openAIApiKey = $0
+            }
+        }
+        set {
+            withMutation(keyPath: \.openAIApiKey) {
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                _openAIApiKey = trimmed
+                markSecretLoaded("openAIApiKey")
+                secretStore.save(key: "openAIApiKey", value: trimmed)
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _openAIBaseURL: String
+    var openAIBaseURL: String {
+        get { access(keyPath: \.openAIBaseURL); return _openAIBaseURL }
+        set {
+            withMutation(keyPath: \.openAIBaseURL) {
+                _openAIBaseURL = newValue
+                defaults.set(newValue, forKey: "openAIBaseURL")
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _openAIModel: String
+    var openAIModel: String {
+        get { access(keyPath: \.openAIModel); return _openAIModel }
+        set {
+            withMutation(keyPath: \.openAIModel) {
+                _openAIModel = newValue
+                defaults.set(newValue, forKey: "openAIModel")
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _anthropicApiKey: String
+    var anthropicApiKey: String {
+        get {
+            access(keyPath: \.anthropicApiKey)
+            return loadSecretIfNeeded(key: "anthropicApiKey", currentValue: _anthropicApiKey) {
+                _anthropicApiKey = $0
+            }
+        }
+        set {
+            withMutation(keyPath: \.anthropicApiKey) {
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                _anthropicApiKey = trimmed
+                markSecretLoaded("anthropicApiKey")
+                secretStore.save(key: "anthropicApiKey", value: trimmed)
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _anthropicBaseURL: String
+    var anthropicBaseURL: String {
+        get { access(keyPath: \.anthropicBaseURL); return _anthropicBaseURL }
+        set {
+            withMutation(keyPath: \.anthropicBaseURL) {
+                _anthropicBaseURL = newValue
+                defaults.set(newValue, forKey: "anthropicBaseURL")
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _anthropicModel: String
+    var anthropicModel: String {
+        get { access(keyPath: \.anthropicModel); return _anthropicModel }
+        set {
+            withMutation(keyPath: \.anthropicModel) {
+                _anthropicModel = newValue
+                defaults.set(newValue, forKey: "anthropicModel")
+            }
+        }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _assemblyAIApiKey: String
     var assemblyAIApiKey: String {
         get {
@@ -1186,6 +1266,12 @@ final class SettingsStore {
         // AI Settings
         self._llmProvider = LLMProvider(rawValue: defaults.string(forKey: "llmProvider") ?? "") ?? .openRouter
         self._openRouterApiKey = ""
+        self._openAIApiKey = ""
+        self._openAIBaseURL = defaults.string(forKey: "openAIBaseURL") ?? "https://api.openai.com"
+        self._openAIModel = defaults.string(forKey: "openAIModel") ?? "gpt-4.1-mini"
+        self._anthropicApiKey = ""
+        self._anthropicBaseURL = defaults.string(forKey: "anthropicBaseURL") ?? "https://api.anthropic.com"
+        self._anthropicModel = defaults.string(forKey: "anthropicModel") ?? "claude-sonnet-4-5-20250929"
         self._assemblyAIApiKey = ""
         self._elevenLabsApiKey = ""
         self._ollamaBaseURL = defaults.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
@@ -1387,6 +1473,10 @@ final class SettingsStore {
         switch llmProvider {
         case .openRouter:
             selectedModel
+        case .openAI:
+            openAIModel
+        case .anthropic:
+            anthropicModel
         case .ollama:
             ollamaLLMModel
         case .mlx:
@@ -1405,6 +1495,10 @@ final class SettingsStore {
         switch llmProvider {
         case .openRouter:
             return !openRouterApiKey.isEmpty
+        case .openAI:
+            return !openAIApiKey.isEmpty && OpenRouterClient.chatCompletionsURL(from: openAIBaseURL) != nil
+        case .anthropic:
+            return !anthropicApiKey.isEmpty && OpenRouterClient.anthropicMessagesURL(from: anthropicBaseURL) != nil
         case .ollama:
             return OpenRouterClient.chatCompletionsURL(from: ollamaBaseURL) != nil
         case .mlx:
@@ -1424,9 +1518,47 @@ final class SettingsStore {
     var activeRealtimeModel: String {
         switch llmProvider {
         case .openRouter: return realtimeModel
+        case .openAI: return openAIModel
+        case .anthropic: return anthropicModel
         case .ollama: return realtimeOllamaModel.isEmpty ? ollamaLLMModel : realtimeOllamaModel
         case .mlx: return mlxModel
         case .openAICompatible: return openAILLMModel
+        }
+    }
+
+    var activeLLMTransport: OpenRouterClient.CompletionTransport {
+        llmProvider == .anthropic ? .anthropicMessages : .chatCompletions
+    }
+
+    var activeLLMApiKey: String? {
+        switch llmProvider {
+        case .openRouter:
+            openRouterApiKey.isEmpty ? nil : openRouterApiKey
+        case .openAI:
+            openAIApiKey.isEmpty ? nil : openAIApiKey
+        case .anthropic:
+            anthropicApiKey.isEmpty ? nil : anthropicApiKey
+        case .ollama, .mlx:
+            nil
+        case .openAICompatible:
+            openAILLMApiKey.isEmpty ? nil : openAILLMApiKey
+        }
+    }
+
+    var activeLLMBaseURL: URL? {
+        switch llmProvider {
+        case .openRouter:
+            nil
+        case .openAI:
+            OpenRouterClient.chatCompletionsURL(from: openAIBaseURL)
+        case .anthropic:
+            OpenRouterClient.anthropicMessagesURL(from: anthropicBaseURL)
+        case .ollama:
+            OpenRouterClient.chatCompletionsURL(from: ollamaBaseURL)
+        case .mlx:
+            OpenRouterClient.chatCompletionsURL(from: mlxBaseURL)
+        case .openAICompatible:
+            OpenRouterClient.chatCompletionsURL(from: openAILLMBaseURL)
         }
     }
 
@@ -1591,7 +1723,8 @@ extension SettingsStore {
 
         let keysToMigrate = [
             "kbFolderPath", "selectedModel", "transcriptionLocale", "transcriptionModel", "inputDeviceID",
-            "llmProvider", "embeddingProvider", "ollamaBaseURL", "ollamaLLMModel",
+            "llmProvider", "embeddingProvider", "openAIBaseURL", "openAIModel",
+            "anthropicBaseURL", "anthropicModel", "ollamaBaseURL", "ollamaLLMModel",
             "ollamaEmbedModel", "hideFromScreenShare",
             "isTranscriptExpanded", "hasCompletedOnboarding",
         ]
@@ -1623,7 +1756,8 @@ extension SettingsStore {
 
         let keysToMigrate = [
             "kbFolderPath", "selectedModel", "transcriptionLocale", "transcriptionModel", "inputDeviceID",
-            "llmProvider", "embeddingProvider", "ollamaBaseURL", "ollamaLLMModel",
+            "llmProvider", "embeddingProvider", "openAIBaseURL", "openAIModel",
+            "anthropicBaseURL", "anthropicModel", "ollamaBaseURL", "ollamaLLMModel",
             "ollamaEmbedModel", "hideFromScreenShare",
             "isTranscriptExpanded", "hasCompletedOnboarding",
             "hasAcknowledgedRecordingConsent",

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -294,6 +294,8 @@ enum PersonaAvatarTint: String, CaseIterable, Identifiable, Codable {
 
 enum LLMProvider: String, CaseIterable, Identifiable {
     case openRouter
+    case openAI
+    case anthropic
     case ollama
     case mlx
     case openAICompatible
@@ -303,6 +305,8 @@ enum LLMProvider: String, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .openRouter: "OpenRouter"
+        case .openAI: "OpenAI"
+        case .anthropic: "Anthropic"
         case .ollama: "Ollama"
         case .mlx: "MLX"
         case .openAICompatible: "OpenAI Compatible"

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -688,6 +688,24 @@ private struct IntelligenceSettingsTab: View {
 
                         TextField("Model", text: $settings.selectedModel, prompt: Text("e.g. google/gemini-3-flash-preview"))
                             .font(.system(size: 12, design: .monospaced))
+                    case .openAI:
+                        TextField("OpenAI URL", text: $settings.openAIBaseURL, prompt: Text("https://api.openai.com"))
+                            .font(.system(size: 12, design: .monospaced))
+
+                        SecureField("OpenAI API Key", text: $settings.openAIApiKey)
+                            .font(.system(size: 12, design: .monospaced))
+
+                        TextField("Model", text: $settings.openAIModel, prompt: Text("e.g. gpt-4.1-mini"))
+                            .font(.system(size: 12, design: .monospaced))
+                    case .anthropic:
+                        TextField("Anthropic URL", text: $settings.anthropicBaseURL, prompt: Text("https://api.anthropic.com"))
+                            .font(.system(size: 12, design: .monospaced))
+
+                        SecureField("Anthropic API Key", text: $settings.anthropicApiKey)
+                            .font(.system(size: 12, design: .monospaced))
+
+                        TextField("Model", text: $settings.anthropicModel, prompt: Text("e.g. claude-sonnet-4-5-20250929"))
+                            .font(.system(size: 12, design: .monospaced))
                     case .ollama:
                         TextField("Ollama URL", text: $settings.ollamaBaseURL, prompt: Text("http://localhost:11434"))
                             .font(.system(size: 12, design: .monospaced))
@@ -801,7 +819,7 @@ private struct IntelligenceSettingsTab: View {
                         Text("Optional Ollama model for real-time suggestions. Uses your main model if empty.")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)
-                    case .mlx, .openAICompatible:
+                    case .openAI, .anthropic, .mlx, .openAICompatible:
                         Text("Real-time suggestions currently reuse the active provider model for this provider.")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)

--- a/OpenOats/Sources/OpenOats/Wizard/WizardViewModel.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/WizardViewModel.swift
@@ -470,9 +470,13 @@ final class WizardViewModel {
     private func clearStaleSettings(for profile: WizardProfile, in settings: SettingsStore) {
         if !profile.isCloud {
             settings.openRouterApiKey = ""
+            settings.openAIApiKey = ""
+            settings.anthropicApiKey = ""
             settings.voyageApiKey = ""
             settings.selectedModel = "google/gemini-3-flash-preview"
             settings.realtimeModel = "google/gemini-3.1-flash-lite-preview"
+            settings.openAIModel = "gpt-4.1-mini"
+            settings.anthropicModel = "claude-sonnet-4-5-20250929"
         }
 
         if !profile.isLocal {
@@ -491,6 +495,10 @@ final class WizardViewModel {
         switch settings.llmProvider {
         case .openRouter:
             hasConfiguredLLM = !settings.openRouterApiKey.isEmpty
+        case .openAI:
+            hasConfiguredLLM = !settings.openAIApiKey.isEmpty
+        case .anthropic:
+            hasConfiguredLLM = !settings.anthropicApiKey.isEmpty
         case .ollama, .mlx, .openAICompatible:
             hasConfiguredLLM = true
         }
@@ -509,7 +517,7 @@ final class WizardViewModel {
         switch settings.llmProvider {
         case .ollama:
             privacy = .local
-        case .openRouter, .mlx, .openAICompatible:
+        case .openRouter, .openAI, .anthropic, .mlx, .openAICompatible:
             privacy = .cloud
         }
     }

--- a/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
@@ -22,8 +22,10 @@ final class AppSettingsTests: XCTestCase {
 
     func testLLMProviderAllCases() {
         let cases = LLMProvider.allCases
-        XCTAssertEqual(cases.count, 4)
+        XCTAssertEqual(cases.count, 6)
         XCTAssertTrue(cases.contains(.openRouter))
+        XCTAssertTrue(cases.contains(.openAI))
+        XCTAssertTrue(cases.contains(.anthropic))
         XCTAssertTrue(cases.contains(.ollama))
         XCTAssertTrue(cases.contains(.openAICompatible))
         XCTAssertTrue(cases.contains(.mlx))
@@ -31,6 +33,8 @@ final class AppSettingsTests: XCTestCase {
 
     func testLLMProviderDisplayNames() {
         XCTAssertEqual(LLMProvider.openRouter.displayName, "OpenRouter")
+        XCTAssertEqual(LLMProvider.openAI.displayName, "OpenAI")
+        XCTAssertEqual(LLMProvider.anthropic.displayName, "Anthropic")
         XCTAssertEqual(LLMProvider.ollama.displayName, "Ollama")
         XCTAssertEqual(LLMProvider.openAICompatible.displayName, "OpenAI Compatible")
         XCTAssertEqual(LLMProvider.mlx.displayName, "MLX")
@@ -38,6 +42,8 @@ final class AppSettingsTests: XCTestCase {
 
     func testLLMProviderRawValues() {
         XCTAssertEqual(LLMProvider.openRouter.rawValue, "openRouter")
+        XCTAssertEqual(LLMProvider.openAI.rawValue, "openAI")
+        XCTAssertEqual(LLMProvider.anthropic.rawValue, "anthropic")
         XCTAssertEqual(LLMProvider.ollama.rawValue, "ollama")
         XCTAssertEqual(LLMProvider.openAICompatible.rawValue, "openAICompatible")
         XCTAssertEqual(LLMProvider.mlx.rawValue, "mlx")

--- a/OpenOats/Tests/OpenOatsTests/OpenRouterClientTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/OpenRouterClientTests.swift
@@ -37,4 +37,23 @@ final class OpenRouterClientTests: XCTestCase {
 
         XCTAssertNil(error)
     }
+
+    func testAnthropicMessagesURLNormalizesBaseURL() {
+        XCTAssertEqual(
+            OpenRouterClient.anthropicMessagesURL(from: "https://api.anthropic.com")?.absoluteString,
+            "https://api.anthropic.com/v1/messages"
+        )
+        XCTAssertEqual(
+            OpenRouterClient.anthropicMessagesURL(from: "https://api.anthropic.com/v1")?.absoluteString,
+            "https://api.anthropic.com/v1/messages"
+        )
+        XCTAssertEqual(
+            OpenRouterClient.anthropicMessagesURL(from: "https://proxy.example.com/anthropic/v1/messages")?.absoluteString,
+            "https://proxy.example.com/anthropic/v1/messages"
+        )
+    }
+
+    func testAnthropicMessagesURLRejectsInvalidBaseURL() {
+        XCTAssertNil(OpenRouterClient.anthropicMessagesURL(from: "not a url"))
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -71,6 +71,36 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.selectedModel, "anthropic/claude-4-sonnet")
     }
 
+    func testNativeOpenAISettingsRoundTripAndRequireAPIKeyForAutoNotes() {
+        let store = makeStore()
+        store.llmProvider = .openAI
+        store.openAIBaseURL = "https://proxy.example.com/openai"
+        store.openAIModel = "gpt-4.1"
+
+        XCTAssertEqual(store.activeNotesModel, "gpt-4.1")
+        XCTAssertFalse(store.canAutoGeneratePostMeetingNotes)
+
+        store.openAIApiKey = "  sk-openai-test  "
+        XCTAssertEqual(store.openAIApiKey, "sk-openai-test")
+        XCTAssertTrue(store.canAutoGeneratePostMeetingNotes)
+        XCTAssertEqual(store.activeLLMTransport, .chatCompletions)
+    }
+
+    func testNativeAnthropicSettingsRoundTripAndRequireAPIKeyForAutoNotes() {
+        let store = makeStore()
+        store.llmProvider = .anthropic
+        store.anthropicBaseURL = "https://api.anthropic.com/v1"
+        store.anthropicModel = "claude-sonnet-4-5-20250929"
+
+        XCTAssertEqual(store.activeNotesModel, "claude-sonnet-4-5-20250929")
+        XCTAssertFalse(store.canAutoGeneratePostMeetingNotes)
+
+        store.anthropicApiKey = "  sk-ant-test  "
+        XCTAssertEqual(store.anthropicApiKey, "sk-ant-test")
+        XCTAssertTrue(store.canAutoGeneratePostMeetingNotes)
+        XCTAssertEqual(store.activeLLMTransport, .anthropicMessages)
+    }
+
     func testAutoPostMeetingNotesRequiresOpenRouterKey() {
         let store = makeStore()
         store.llmProvider = .openRouter


### PR DESCRIPTION
## Summary
- Adds first-class OpenAI and Anthropic LLM providers with separate API keys, base URL overrides, and model settings.
- Routes notes, cleanup, realtime suggestions, and Sidecast through the selected native provider, including Anthropic Messages API streaming.
- Includes the in-flight Homebrew cask bump to v1.78.0 per repo maintenance policy.

## Test plan
- `swift test --filter "SettingsStoreTests|AppSettingsTests|OpenRouterClientTests"`
- `SKIP_SIGN=1 SKIP_INSTALL=1 ./scripts/build_swift_app.sh`

Closes #602.

Made with [Cursor](https://cursor.com)