### PR TITLE
Fix Sidecast generation timeout handling

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.78.0"
-  sha256 "91c8ca3916842524eec78c085dfd538899b4185169b9061d80ae926167f1d3b5"
+  version "1.79.0"
+  sha256 "4acfdebcbf2018c7c0e59f4cf1d9f4d75c07b721ad763d04a5853890fb8f110b"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
@@ -216,7 +216,8 @@ actor OpenRouterClient {
         temperature: Double? = nil,
         baseURL: URL? = nil,
         webSearch: Bool = false,
-        transport: CompletionTransport = .chatCompletions
+        transport: CompletionTransport = .chatCompletions,
+        requestTimeout: TimeInterval = 300
     ) async throws -> String {
         if transport == .anthropicMessages {
             return try await completeAnthropic(
@@ -225,7 +226,8 @@ actor OpenRouterClient {
                 messages: messages,
                 maxTokens: maxTokens,
                 temperature: temperature,
-                baseURL: baseURL
+                baseURL: baseURL,
+                requestTimeout: requestTimeout
             )
         }
 
@@ -247,7 +249,7 @@ actor OpenRouterClient {
         urlRequest.httpMethod = "POST"
         // Total request timeout — covers gate / judge / structured-JSON calls that may hit
         // slow local models or reasoning models. Default 60s is too aggressive in practice.
-        urlRequest.timeoutInterval = 300
+        urlRequest.timeoutInterval = requestTimeout
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let apiKey, !apiKey.isEmpty {
             urlRequest.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
@@ -343,7 +345,8 @@ actor OpenRouterClient {
         messages: [Message],
         maxTokens: Int,
         temperature: Double?,
-        baseURL: URL?
+        baseURL: URL?,
+        requestTimeout: TimeInterval
     ) async throws -> String {
         let targetURL = baseURL ?? Self.anthropicMessagesURL(from: "https://api.anthropic.com")!
         guard let apiKey, !apiKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -361,7 +364,7 @@ actor OpenRouterClient {
 
         var urlRequest = URLRequest(url: targetURL)
         urlRequest.httpMethod = "POST"
-        urlRequest.timeoutInterval = 300
+        urlRequest.timeoutInterval = requestTimeout
         urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         urlRequest.setValue(Self.anthropicVersion, forHTTPHeaderField: "anthropic-version")

--- a/OpenOats/Sources/OpenOats/Intelligence/SidecastEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SidecastEngine.swift
@@ -28,10 +28,13 @@ final class SidecastEngine {
     private let settings: AppSettings
 
     private var generationTask: Task<Void, Never>?
+    private var activeGenerationID: UUID?
     private var lastProcessedUtteranceID: UUID?
     private var lastGenerationStartedAt: Date = .distantPast
     private var recentBubbleTexts: [String] = []
     private var lastSpokenAtByPersona: [UUID: Date] = [:]
+
+    private static let liveGenerationTimeout: TimeInterval = 45
 
     init(transcriptStore: TranscriptStore, knowledgeBase: KnowledgeBase, settings: AppSettings) {
         self.transcriptStore = transcriptStore
@@ -55,6 +58,8 @@ final class SidecastEngine {
         lastGenerationStartedAt = now
 
         generationTask?.cancel()
+        let generationID = UUID()
+        activeGenerationID = generationID
         isGenerating = true
 
         let recentExchange = transcriptStore.recentExchange
@@ -86,7 +91,8 @@ final class SidecastEngine {
                     temperature: self.settings.sidecastTemperature,
                     baseURL: self.llmBaseURL,
                     webSearch: useWebSearch,
-                    transport: self.settings.activeLLMTransport
+                    transport: self.settings.activeLLMTransport,
+                    requestTimeout: Self.liveGenerationTimeout
                 )
                 let decoded = try self.decodeResponse(response)
 
@@ -99,15 +105,16 @@ final class SidecastEngine {
                         recentTexts: recentTexts,
                         lastSpokenAtByPersona: lastSpoken
                     )
+                    self.finishGeneration(generationID)
                 }
             } catch is CancellationError {
                 await MainActor.run {
-                    self.isGenerating = false
+                    self.finishGeneration(generationID)
                 }
             } catch {
                 Log.sidecast.error("Generation failed: \(error, privacy: .public)")
                 await MainActor.run {
-                    self.isGenerating = false
+                    self.finishGeneration(generationID)
                 }
             }
         }
@@ -122,10 +129,17 @@ final class SidecastEngine {
         generationTask = nil
         messages.removeAll()
         isGenerating = false
+        activeGenerationID = nil
         lastProcessedUtteranceID = nil
         lastGenerationStartedAt = .distantPast
         recentBubbleTexts.removeAll()
         lastSpokenAtByPersona.removeAll()
+    }
+
+    private func finishGeneration(_ generationID: UUID) {
+        guard activeGenerationID == generationID else { return }
+        activeGenerationID = nil
+        isGenerating = false
     }
 
     private func apply(
@@ -136,8 +150,6 @@ final class SidecastEngine {
         recentTexts: [String],
         lastSpokenAtByPersona: [UUID: Date]
     ) {
-        defer { isGenerating = false }
-
         let personaByID = Dictionary(uniqueKeysWithValues: personas.map { ($0.id, $0) })
         let topBreadcrumb = evidence.first?.displayBreadcrumb ?? ""
         let now = utterance.timestamp


### PR DESCRIPTION
## Summary
- Adds a shorter timeout for live Sidecast LLM requests so dropped provider calls don't leave the sidebar spinning for minutes.
- Guards Sidecast generation state by request ID so canceled older generations can't clear or corrupt the latest request state.
- Includes the in-flight Homebrew cask bump to v1.79.0.

Closes #624

## Test plan
- swift test
- swift build -c release