### PR TITLE
Fix tap target on language selection tiles in onboarding

### DIFF
--- a/OpenOats/Sources/OpenOats/Wizard/LanguagePrivacyStepView.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/LanguagePrivacyStepView.swift
@@ -143,9 +143,10 @@ struct LanguagePrivacyStepView: View {
             Text(title)
                 .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(isSelected ? Color.accentTeal : .primary)
+                .frame(maxWidth: .infinity)
+                .contentShape(Rectangle())
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
-                .frame(maxWidth: .infinity)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
                         .fill(isSelected ? Color.accentTeal.opacity(0.08) : Color.clear)


### PR DESCRIPTION
## Summary
- The language option tiles ("English only" / "Other languages") on the onboarding wizard only responded to taps on the text content, not the empty space within the tile
- Added `.contentShape(Rectangle())` so the full card area is tappable
- Matches the same fix applied to `IntentStepView` in 5c49355

## Test plan
- [ ] Open the app and go through the onboarding wizard
- [ ] On the "What language are your meetings in?" screen, tap the empty space within a language tile (not the text)
- [ ] Verify the tile registers the tap and selects the option

🤖 Generated with [Claude Code](https://claude.com/claude-code)