### PR TITLE
Fix menu bar popover action crash

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.79.0"
-  sha256 "4acfdebcbf2018c7c0e59f4cf1d9f4d75c07b721ad763d04a5853890fb8f110b"
+  version "1.79.1"
+  sha256 "d64cb2243fe14a9501859df3c69965b1dede8c6d9d4375fdf70a76283fa6c90e"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/App/MenuBarController.swift
+++ b/OpenOats/Sources/OpenOats/App/MenuBarController.swift
@@ -2,6 +2,21 @@ import AppKit
 import Observation
 import SwiftUI
 
+private final class MenuBarStatusItemActionTarget: NSObject {
+    weak var controller: MenuBarController?
+
+    init(controller: MenuBarController) {
+        self.controller = controller
+    }
+
+    @objc func togglePopover(_ sender: Any?) {
+        let controller = controller
+        Task { @MainActor in
+            controller?.togglePopoverFromStatusItem()
+        }
+    }
+}
+
 @MainActor
 final class MenuBarController {
     private let statusItem: NSStatusItem
@@ -9,6 +24,7 @@ final class MenuBarController {
     private let coordinator: AppCoordinator
     private let settings: AppSettings
     private let onToggleMeeting: () -> Void
+    private lazy var statusItemActionTarget = MenuBarStatusItemActionTarget(controller: self)
     private var iconUpdateTask: Task<Void, Never>?
     private var hasConfiguredButton = false
 
@@ -64,9 +80,9 @@ final class MenuBarController {
         iconUpdateTask?.cancel()
     }
 
-    @objc private func togglePopover(_ sender: Any?) {
+    func togglePopoverFromStatusItem() {
         if popover.isShown {
-            popover.performClose(sender)
+            popover.performClose(nil)
         } else if let button = statusItem.button {
             popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
         }
@@ -101,8 +117,8 @@ final class MenuBarController {
         }
 
         if !hasConfiguredButton {
-            button.target = self
-            button.action = #selector(togglePopover(_:))
+            button.target = statusItemActionTarget
+            button.action = #selector(MenuBarStatusItemActionTarget.togglePopover(_:))
             hasConfiguredButton = true
             DiagnosticsSupport.record(category: "menu", message: "Status item button configured")
         }


### PR DESCRIPTION
## Summary
- routes the menu bar status item action through an NSObject target before hopping back to the main actor
- avoids AppKit directly invoking a @MainActor Swift action selector, matching the crash signature in #629
- bumps the Homebrew cask to the current v1.79.1 release and sha256

Fixes #629

## Validation
- swift test --filter LiveSessionControllerTests