### PR TITLE
fix: Expand Advanced Detection Settings tap target to full row

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.79.1"
-  sha256 "d64cb2243fe14a9501859df3c69965b1dede8c6d9d4375fdf70a76283fa6c90e"
+  version "1.80.0"
+  sha256 "0db36f361a9061b3e4b8e23bc33693e667ee9e7043e250103873f7c9deab505a"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -67,6 +67,7 @@ private struct GeneralSettingsTab: View {
     @State private var automaticallyChecksForUpdates = false
     @State private var showAutoDetectExplanation = false
     @State private var launchAtLoginEnabled = false
+    @State private var showAdvancedDetection = false
     @State private var showWizard = false
     @State private var diagnosticsExportMessage: String?
     @State private var diagnosticsExportHadError = false
@@ -179,7 +180,7 @@ private struct GeneralSettingsTab: View {
                 }
 
                 if settings.meetingAutoDetectEnabled {
-                    DisclosureGroup("Advanced Detection Settings") {
+                    DisclosureGroup(isExpanded: $showAdvancedDetection, content: {
                         HStack {
                             Text("Silence timeout")
                                 .font(.system(size: 12))
@@ -201,7 +202,16 @@ private struct GeneralSettingsTab: View {
                         Text("Print detection events to the system console for debugging.")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)
-                    }
+                    }, label: {
+                        HStack {
+                            Text("Advanced Detection Settings")
+                            Spacer()
+                        }
+                        .padding(.vertical, 10)
+                        .contentShape(Rectangle())
+                        .onTapGesture { showAdvancedDetection.toggle() }
+                        .padding(.vertical, -10)
+                    })
                     .font(.system(size: 12))
                 }
 


### PR DESCRIPTION
## Summary

The **Advanced Detection Settings** row in Settings → General had a tap target limited to just the chevron (>). This PR makes the entire light-colored row rectangle tappable.

**Changes:**
- Bound `DisclosureGroup` expansion to a `@State` variable (`showAdvancedDetection`) for manual control
- Replaced the default string label with a custom label using a full-width `HStack + Spacer`
- Used `.padding(.vertical, 10)` → `.contentShape(Rectangle())` → `.padding(.vertical, -10)` to extend the hit area into the Form row's vertical insets, covering the full background rectangle without affecting row height

This is the same pattern used in #611 (intent card tap target fix).

## How to test

1. Open Settings → General
2. Enable **Auto-detect meetings** to reveal the Advanced Detection Settings row
3. Tap anywhere on the light-colored row (top edge, bottom edge, empty space) — it should expand/collapse