### PR TITLE
fix: Match Clean Up button height to Manage and copy buttons

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
+++ b/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
@@ -1985,6 +1985,7 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(OpenOatsProminentButtonStyle())
+            .controlSize(.mini)
             .disabled(state.loadedTranscript.isEmpty)
             .help("Remove filler words and fix punctuation")
 
@@ -2011,6 +2012,7 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                     .font(.system(size: 12))
             }
             .buttonStyle(OpenOatsProminentButtonStyle())
+            .controlSize(.mini)
             .help("Clean up remaining utterances")
 
             showOriginalButton(controller: controller, state: state)


### PR DESCRIPTION
## Summary

The **Clean Up** button was taller than the adjacent **Manage** and copy icon buttons in the transcript toolbar, making the row visually inconsistent.

**Root cause**: `OpenOatsProminentButtonStyle` defaults to `.regular` `controlSize`, which applies 7pt vertical padding on each side. The Manage and copy buttons use the native `.bordered` style which renders at standard macOS control height — shorter than the custom style at `.regular`.

**Fix**: Added `.controlSize(.mini)` to both Clean Up button instances (`.notCleaned` and `.partiallyCleaned` states), reducing vertical padding to 4pt and aligning the button height with the rest of the toolbar.

The blue accent color already gives Clean Up sufficient visual prominence — the extra height was unnecessary.