### PR TITLE
Fix: camera-triggered detection notification shows wrong app name

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -13,7 +13,7 @@ cask "openoats" do
   end
 
   auto_updates true
-  depends_on macos: ">= :sequoia"
+  depends_on macos: :sequoia
 
   app "OpenOats.app"
 

--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.80.0"
-  sha256 "0db36f361a9061b3e4b8e23bc33693e667ee9e7043e250103873f7c9deab505a"
+  version "1.80.1"
+  sha256 "9245a737e7163ff2966ce37770cf6a1c0a48fcb0799bfbb2e76aae80d9587607"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -131,6 +131,8 @@ final class LiveSessionController {
     private var downloadTask: Task<Void, Never>?
     private var startPreflightTask: Task<Void, Never>?
     private var scratchpadSaveTask: Task<Void, Never>?
+    private var silenceMonitorTask: Task<Void, Never>?
+    private var lastUtteranceAt: Date?
     private var pendingInitialScratchpad: String?
 
     // Tracked-change sentinels
@@ -492,6 +494,7 @@ final class LiveSessionController {
 
     private func handleNewUtterance(_ last: Utterance, settings: AppSettings) {
         container.detectionController?.noteUtterance()
+        lastUtteranceAt = Date()
 
         if settings.enableLiveTranscriptCleanup, let engine = coordinator.liveTranscriptCleaner {
             Task {
@@ -675,12 +678,44 @@ final class LiveSessionController {
                 transcriptionModel: settings.transcriptionModel,
                 sessionID: handle.sessionID
             )
+
+            // Start silence monitoring for manual sessions (auto-detected sessions are
+            // already monitored by MeetingDetectionController).
+            let timeoutMinutes = settings.silenceTimeoutMinutes
+            if timeoutMinutes > 0, metadata.detectionContext == nil {
+                startSilenceMonitoring(timeoutMinutes: timeoutMinutes)
+            }
         }
+    }
+
+    private func startSilenceMonitoring(timeoutMinutes: Int) {
+        silenceMonitorTask?.cancel()
+        lastUtteranceAt = Date()
+        silenceMonitorTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(60))
+                guard !Task.isCancelled, let self else { break }
+                if let last = self.lastUtteranceAt,
+                   Date().timeIntervalSince(last) >= Double(timeoutMinutes) * 60 {
+                    await MainActor.run {
+                        self.coordinator.handle(.userStopped)
+                    }
+                    break
+                }
+            }
+        }
+    }
+
+    private func stopSilenceMonitoring() {
+        silenceMonitorTask?.cancel()
+        silenceMonitorTask = nil
+        lastUtteranceAt = nil
     }
 
     func finalizeCurrentSession(settings: AppSettings?) async {
         // 0. Flush scratchpad
         scratchpadSaveTask?.cancel()
+        stopSilenceMonitoring()
         if let sessionID = _currentSessionID, !state.scratchpadText.isEmpty {
             await coordinator.sessionRepository.saveScratchpad(sessionID: sessionID, text: state.scratchpadText)
         }

--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -375,7 +375,12 @@ final class MeetingDetectionController {
             Log.meetingDetection.info("Detected: \(app?.name ?? "unknown", privacy: .public) (trigger: \(isCameraTrigger ? "camera" : "mic+app", privacy: .public))")
         }
 
-        let posted = await notificationService?.postMeetingDetected(appName: app?.name, isCameraTrigger: isCameraTrigger) ?? false
+        // Don't attribute camera-triggered detections to a background meeting app —
+        // the camera could have been activated by a different app (e.g. browser for Google Meet).
+        let posted = await notificationService?.postMeetingDetected(
+            appName: isCameraTrigger ? nil : app?.name,
+            isCameraTrigger: isCameraTrigger
+        ) ?? false
         if !posted {
             if activeSettings?.detectionLogEnabled == true {
                 Log.meetingDetection.debug("Failed to post notification (permission denied?)")

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -1034,6 +1034,13 @@ final class NotesController {
         }
     }
 
+    func updateSessionSpeakerNames(sessionID: String, speakerNames: [String: String]) {
+        Task {
+            await coordinator.sessionRepository.updateSessionSpeakerNames(sessionID: sessionID, speakerNames: speakerNames)
+            await loadHistory()
+        }
+    }
+
     func setTagFilter(_ tag: String?) {
         state.tagFilter = tag
     }

--- a/OpenOats/Sources/OpenOats/Domain/Utterance.swift
+++ b/OpenOats/Sources/OpenOats/Domain/Utterance.swift
@@ -15,6 +15,10 @@ enum Speaker: Codable, Sendable, Hashable {
         }
     }
 
+    func displayName(speakerNames: [String: String]?) -> String {
+        speakerNames?[storageKey] ?? displayLabel
+    }
+
     /// True for any non-mic speaker (.them or .remote).
     var isRemote: Bool {
         switch self {

--- a/OpenOats/Sources/OpenOats/Models/Models.swift
+++ b/OpenOats/Sources/OpenOats/Models/Models.swift
@@ -511,6 +511,8 @@ struct SessionIndex: Identifiable, Codable, Sendable, Equatable {
     var transcriptIssue: SessionTranscriptIssue? = nil
     /// Non-nil when a previously failed transcript was later recovered.
     var transcriptRecovery: SessionTranscriptRecoveryState? = nil
+    /// Per-session custom speaker display names. Keys are Speaker.storageKey values.
+    var speakerNames: [String: String]? = nil
 }
 
 struct SessionSidecar: Codable, Sendable {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -157,6 +157,8 @@ struct SessionMetadata: Codable, Sendable {
     var transcriptIssue: SessionTranscriptIssue?
     var transcriptRecovery: SessionTranscriptRecoveryState? = nil
     var customNotesGuidance: String?
+    /// Per-session custom speaker display names. Keys are Speaker.storageKey values.
+    var speakerNames: [String: String]?
 }
 
 // MARK: - SessionRepository
@@ -856,7 +858,8 @@ actor SessionRepository {
                         source: meta.source,
                         meetingFamilyKey: meta.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) },
                         transcriptIssue: meta.transcriptIssue,
-                        transcriptRecovery: meta.transcriptRecovery
+                        transcriptRecovery: meta.transcriptRecovery,
+                        speakerNames: meta.speakerNames
                     ))
                     continue
                 }
@@ -897,7 +900,8 @@ actor SessionRepository {
                 source: meta.source,
                 meetingFamilyKey: meta.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) },
                 transcriptIssue: meta.transcriptIssue,
-                transcriptRecovery: meta.transcriptRecovery
+                transcriptRecovery: meta.transcriptRecovery,
+                speakerNames: meta.speakerNames
             )
 
             let transcript = loadTranscript(sessionID: id)
@@ -1037,6 +1041,12 @@ actor SessionRepository {
         )
         let dir = sessionDirectory(for: sessionID)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        writeSessionMetadata(meta, sessionID: sessionID)
+    }
+
+    func updateSessionSpeakerNames(sessionID: String, speakerNames: [String: String]) {
+        guard var meta = loadSessionMetadataFile(sessionID: sessionID) else { return }
+        meta.speakerNames = speakerNames.isEmpty ? nil : speakerNames
         writeSessionMetadata(meta, sessionID: sessionID)
     }
 

--- a/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
+++ b/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
@@ -1160,10 +1160,23 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                         .foregroundStyle(.secondary)
                 } else {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text(selection.title)
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundStyle(.primary)
-                            .lineLimit(1)
+                        HStack(spacing: 4) {
+                            Text(selection.title)
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                            if let session = selectedSession {
+                                Button {
+                                    beginRenaming(session)
+                                } label: {
+                                    Image(systemName: "pencil")
+                                        .font(.system(size: 10))
+                                        .foregroundStyle(.tertiary)
+                                }
+                                .buttonStyle(.borderless)
+                                .help("Rename meeting")
+                            }
+                        }
 
                         HStack(spacing: 8) {
                             if let sessionID = state.selectedSessionID,
@@ -1425,14 +1438,18 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
     private func startRecording(for event: CalendarEvent, selectedTemplate: MeetingTemplate?) {
         coordinator.selectedTemplate = selectedTemplate
         let prepNotes = settings.meetingPrepNotes(for: event)
-        coordinator.queueExternalCommand(
-            .startSession(
-                calendarEvent: event,
-                scratchpadSeed: prepNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : prepNotes
-            )
-        )
+        let scratchpad = prepNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : prepNotes
         NSApp.activate(ignoringOtherApps: true)
         openWindow(id: OpenOatsRootApp.mainWindowID)
+        if let controller = coordinator.liveSessionController {
+            container.ensureMeetingServicesInitialized(settings: settings, coordinator: coordinator)
+            controller.startSession(settings: settings, calendarEventOverride: event, initialScratchpad: scratchpad)
+        } else {
+            // Fall back to the external command queue if the live session controller isn't available yet.
+            coordinator.queueExternalCommand(
+                .startSession(calendarEvent: event, scratchpadSeed: scratchpad)
+            )
+        }
     }
 
     private func createManualTranscriptSessionAndMaybePrompt(controller: NotesController, event: CalendarEvent) {

--- a/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
+++ b/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
@@ -46,6 +46,8 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
     @State private var renamingSessionID: String?
     @State private var renameText: String = ""
     @FocusState private var renameFieldFocused: Bool
+    @State private var renamingSpeakerKey: String? = nil
+    @State private var speakerRenameText: String = ""
     @State private var editingTagsSessionID: String?
     @State private var editingTags: [String] = []
     @State private var newTagText: String = ""
@@ -3047,7 +3049,13 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                         return false
                     }()
                     ForEach(Array(state.loadedTranscript.enumerated()), id: \.offset) { _, record in
-                        transcriptRow(record: record, isCleaning: isCleaning, showingOriginal: state.showingOriginal)
+                        transcriptRow(
+                            record: record,
+                            isCleaning: isCleaning,
+                            showingOriginal: state.showingOriginal,
+                            sessionID: selectedSession?.id,
+                            speakerNames: selectedSession?.speakerNames
+                        )
                     }
                 }
                 .padding(16)
@@ -3108,12 +3116,46 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
     }
 
     @ViewBuilder
-    private func transcriptRow(record: SessionRecord, isCleaning: Bool, showingOriginal: Bool) -> some View {
+    private func transcriptRow(record: SessionRecord, isCleaning: Bool, showingOriginal: Bool, sessionID: String? = nil, speakerNames: [String: String]? = nil) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 8) {
-            Text(record.speaker.displayLabel)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(record.speaker.color)
-                .frame(minWidth: 36, alignment: .trailing)
+            let speakerKey = record.speaker.storageKey
+            let isRenameable = sessionID != nil && record.speaker.isRemote
+            let label = record.speaker.displayName(speakerNames: speakerNames)
+
+            Group {
+                if isRenameable {
+                    Button(label) {
+                        speakerRenameText = label
+                        renamingSpeakerKey = speakerKey
+                    }
+                    .buttonStyle(.plain)
+                    .popover(isPresented: Binding(
+                        get: { renamingSpeakerKey == speakerKey },
+                        set: { if !$0 { renamingSpeakerKey = nil } }
+                    )) {
+                        SpeakerRenamePopover(
+                            text: $speakerRenameText,
+                            placeholder: record.speaker.displayLabel
+                        ) {
+                            guard let sid = sessionID else { return }
+                            var names = speakerNames ?? [:]
+                            let trimmed = speakerRenameText.trimmingCharacters(in: .whitespaces)
+                            if trimmed.isEmpty || trimmed == record.speaker.displayLabel {
+                                names.removeValue(forKey: speakerKey)
+                            } else {
+                                names[speakerKey] = trimmed
+                            }
+                            controller.updateSessionSpeakerNames(sessionID: sid, speakerNames: names)
+                            renamingSpeakerKey = nil
+                        }
+                    }
+                } else {
+                    Text(label)
+                }
+            }
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(record.speaker.color)
+            .frame(minWidth: 36, alignment: .trailing)
 
             let displayText = showingOriginal ? record.text : (record.cleanedText ?? record.text)
             Text(displayText)
@@ -3431,5 +3473,40 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
         guard !trimmed.isEmpty else { return }
         controller.addManualTranscript(trimmed)
         cancelAddTranscript()
+    }
+}
+
+// MARK: - Speaker Rename Popover
+
+private struct SpeakerRenamePopover: View {
+    @Binding var text: String
+    let placeholder: String
+    let onCommit: () -> Void
+
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Rename Speaker")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 180)
+                .focused($focused)
+                .onSubmit(onCommit)
+            HStack {
+                Button("Cancel") { text = ""; onCommit() }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Save") { onCommit() }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+            }
+        }
+        .padding(12)
+        .onAppear { focused = true }
     }
 }

--- a/OpenOats/Sources/OpenOats/Wizard/ProviderSetupStepView.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/ProviderSetupStepView.swift
@@ -112,6 +112,19 @@ struct ProviderSetupStepView: View {
                 .foregroundStyle(Color.accentTeal)
             }
 
+            VStack(alignment: .leading, spacing: 6) {
+                Label {
+                    Text("Transcription happens on your Mac by default. To use cloud transcription (AssemblyAI), add your key in **Settings → Transcription** after setup.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                } icon: {
+                    Image(systemName: "info.circle")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
             if viewModel.intent == .fullCopilot {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Voyage AI key (optional, for knowledge retrieval)")


### PR DESCRIPTION
## Summary

When meeting detection fires via camera (rather than mic+app), the notification was incorrectly attributing the detection to whatever meeting app happened to be running in the background (e.g. Teams).

The root cause: `postMeetingDetected` was always passed `app?.name` regardless of trigger type. Camera-triggered detection doesn't know which app the user is actually in.

Fix: pass `nil` as `appName` for camera-triggered detections so the notification omits app attribution.

## Change

`MeetingDetectionController.swift` line 378:
```swift
// Before
appName: app?.name

// After  
appName: isCameraTrigger ? nil : app?.name
```

Closes #643