### PR TITLE
Fix live echo handling and diarization timing

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -504,12 +504,14 @@ final class LiveSessionController {
 
         let sessionID = currentSessionID
 
-        // Trigger the active realtime assistant from either speaker
-        switch settings.sidebarMode {
-        case .classicSuggestions:
-            coordinator.suggestionEngine?.onUtterance(last)
-        case .sidecast:
-            coordinator.sidecastEngine?.onUtterance(last)
+        // Echoed speaker audio can briefly land as "You"; do not let it drive the sidebar.
+        if !coordinator.transcriptStore.shouldSkipRealtimeAssistant(for: last) {
+            switch settings.sidebarMode {
+            case .classicSuggestions:
+                coordinator.suggestionEngine?.onUtterance(last)
+            case .sidecast:
+                coordinator.sidecastEngine?.onUtterance(last)
+            }
         }
 
         Task {

--- a/OpenOats/Sources/OpenOats/Models/TranscriptStore.swift
+++ b/OpenOats/Sources/OpenOats/Models/TranscriptStore.swift
@@ -5,11 +5,6 @@ import os
 @Observable
 @MainActor
 final class TranscriptStore {
-    private let acousticEchoWindow: TimeInterval = 1.75
-    private let acousticEchoSimilarityThreshold = 0.78
-    private let acousticEchoMinimumWordCount = 4
-    private let acousticEchoMinimumCharacterCount = 20
-
     @ObservationIgnored nonisolated(unsafe) private var _utterances: [Utterance] = []
     private(set) var utterances: [Utterance] {
         get { access(keyPath: \.utterances); return _utterances }
@@ -95,6 +90,11 @@ final class TranscriptStore {
         utterancesSinceStateUpdate = 0
         recentUtteranceTimestamps.removeAll()
         recentQuestionTimestamps.removeAll()
+    }
+
+    func shouldSkipRealtimeAssistant(for utterance: Utterance) -> Bool {
+        guard utterance.speaker == .you else { return false }
+        return micEchoMatch(for: utterance) != nil
     }
 
     func updateConversationState(_ state: ConversationState) {
@@ -186,40 +186,59 @@ final class TranscriptStore {
     private func shouldSuppressAcousticEcho(_ utterance: Utterance) -> Bool {
         guard utterance.speaker == .you else { return false }
 
-        let normalizedYouText = TextSimilarity.normalizedText(utterance.text)
-        guard isEligibleForEchoCheck(normalizedYouText) else { return false }
+        guard let match = micEchoMatch(for: utterance) else { return false }
 
-        for candidate in utterances.reversed() where candidate.speaker.isRemote {
-            let timeDelta = utterance.timestamp.timeIntervalSince(candidate.timestamp)
-            guard timeDelta >= 0 else { continue }
-            guard timeDelta <= acousticEchoWindow else { break }
-
-            let normalizedThemText = TextSimilarity.normalizedText(candidate.text)
-            guard isEligibleForEchoCheck(normalizedThemText) else { continue }
-
-            let similarity = TextSimilarity.jaccard(normalizedYouText, normalizedThemText)
-            let containsOther =
-                normalizedYouText.contains(normalizedThemText) ||
-                normalizedThemText.contains(normalizedYouText)
-
-            guard similarity >= acousticEchoSimilarityThreshold || containsOther else { continue }
-
+        switch match.source {
+        case .remotePartial:
+            let simFormatted = String(format: "%.2f", match.similarity)
+            let youSnippet = String(utterance.text.prefix(80))
+            let themSnippet = String(volatileThemText.prefix(80))
+            Log.transcript.info(
+                "Dropped mic utterance as current system-audio echo sim=\(simFormatted, privacy: .public) you='\(youSnippet, privacy: .private)' them_partial='\(themSnippet, privacy: .private)'"
+            )
+        case .remoteFinal(let candidate, let timeDelta):
             let dtFormatted = String(format: "%.2f", timeDelta)
-            let simFormatted = String(format: "%.2f", similarity)
+            let simFormatted = String(format: "%.2f", match.similarity)
             let youSnippet = String(utterance.text.prefix(80))
             let themSnippet = String(candidate.text.prefix(80))
             Log.transcript.info(
                 "Dropped mic utterance as system-audio echo dt=\(dtFormatted, privacy: .public) similarity=\(simFormatted, privacy: .public) you='\(youSnippet, privacy: .private)' them='\(themSnippet, privacy: .private)'"
             )
-            return true
         }
 
-        return false
+        return true
     }
 
-    private func isEligibleForEchoCheck(_ normalizedText: String) -> Bool {
-        let wordCount = normalizedText.split(separator: " ").count
-        return wordCount >= acousticEchoMinimumWordCount ||
-            normalizedText.count >= acousticEchoMinimumCharacterCount
+    private struct MicEchoMatch {
+        enum Source {
+            case remotePartial
+            case remoteFinal(Utterance, TimeInterval)
+        }
+
+        let source: Source
+        let similarity: Double
+    }
+
+    private func micEchoMatch(for utterance: Utterance) -> MicEchoMatch? {
+        if let similarity = AcousticEchoFilter.textSimilarityIfEcho(utterance.text, volatileThemText) {
+            return MicEchoMatch(source: .remotePartial, similarity: similarity)
+        }
+
+        for candidate in utterances.reversed() where candidate.speaker.isRemote {
+            guard let match = AcousticEchoFilter.match(
+                micText: utterance.text,
+                remoteText: candidate.text,
+                micTimestamp: utterance.timestamp,
+                remoteTimestamp: candidate.timestamp,
+                direction: .micAfterRemote
+            ) else { continue }
+
+            return MicEchoMatch(
+                source: .remoteFinal(candidate, match.timeDelta),
+                similarity: match.similarity
+            )
+        }
+
+        return nil
     }
 }

--- a/OpenOats/Sources/OpenOats/Transcription/AcousticEchoFilter.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/AcousticEchoFilter.swift
@@ -5,51 +5,105 @@ import os
 /// Detects when mic (YOU) utterances are echoes of system (THEM) audio based on
 /// Jaccard word-set similarity and substring containment.
 enum AcousticEchoFilter {
+    struct Match: Equatable {
+        let timeDelta: TimeInterval
+        let similarity: Double
+    }
+
+    enum TimeDirection {
+        case micAfterRemote
+        case either
+    }
+
+    static let defaultWindow: TimeInterval = 1.75
+    static let defaultSimilarityThreshold = 0.78
+    static let defaultMinimumWordCount = 4
+    static let defaultMinimumCharacterCount = 20
 
     /// Suppress mic records that are acoustic echoes of system records.
     /// Modifies `micRecords` in place, removing entries that match.
     static func suppress(
         micRecords: inout [SessionRecord],
         against sysRecords: [SessionRecord],
-        window: TimeInterval = 1.75,
-        similarityThreshold: Double = 0.78,
-        minimumWordCount: Int = 4,
-        minimumCharacterCount: Int = 20
+        window: TimeInterval = defaultWindow,
+        similarityThreshold: Double = defaultSimilarityThreshold,
+        minimumWordCount: Int = defaultMinimumWordCount,
+        minimumCharacterCount: Int = defaultMinimumCharacterCount
     ) {
         micRecords.removeAll { micRecord in
-            let normalizedYou = TextSimilarity.normalizedText(micRecord.text)
-            guard isEligible(normalizedYou, minimumWordCount: minimumWordCount, minimumCharacterCount: minimumCharacterCount) else {
-                return false
-            }
-
             for sysRecord in sysRecords.reversed() {
-                let timeDelta = micRecord.timestamp.timeIntervalSince(sysRecord.timestamp)
-                guard timeDelta >= 0 else { continue }
-                guard timeDelta <= window else { break }
+                guard let match = match(
+                    micText: micRecord.text,
+                    remoteText: sysRecord.text,
+                    micTimestamp: micRecord.timestamp,
+                    remoteTimestamp: sysRecord.timestamp,
+                    window: window,
+                    similarityThreshold: similarityThreshold,
+                    minimumWordCount: minimumWordCount,
+                    minimumCharacterCount: minimumCharacterCount,
+                    direction: .micAfterRemote
+                ) else { continue }
 
-                let normalizedThem = TextSimilarity.normalizedText(sysRecord.text)
-                guard isEligible(normalizedThem, minimumWordCount: minimumWordCount, minimumCharacterCount: minimumCharacterCount) else {
-                    continue
-                }
-
-                let similarity = TextSimilarity.jaccard(normalizedYou, normalizedThem)
-                let containsOther =
-                    normalizedYou.contains(normalizedThem) ||
-                    normalizedThem.contains(normalizedYou)
-
-                if similarity >= similarityThreshold || containsOther {
-                    let dtFormatted = String(format: "%.2f", timeDelta)
-                    let simFormatted = String(format: "%.2f", similarity)
-                    let micSnippet = String(micRecord.text.prefix(80))
-                    let sysSnippet = String(sysRecord.text.prefix(80))
-                    Log.echo.info(
-                        "Suppressed mic record as echo dt=\(dtFormatted, privacy: .public) sim=\(simFormatted, privacy: .public) mic='\(micSnippet, privacy: .private)' sys='\(sysSnippet, privacy: .private)'"
-                    )
-                    return true
-                }
+                let dtFormatted = String(format: "%.2f", match.timeDelta)
+                let simFormatted = String(format: "%.2f", match.similarity)
+                let micSnippet = String(micRecord.text.prefix(80))
+                let sysSnippet = String(sysRecord.text.prefix(80))
+                Log.echo.info(
+                    "Suppressed mic record as echo dt=\(dtFormatted, privacy: .public) sim=\(simFormatted, privacy: .public) mic='\(micSnippet, privacy: .private)' sys='\(sysSnippet, privacy: .private)'"
+                )
+                return true
             }
             return false
         }
+    }
+
+    static func match(
+        micText: String,
+        remoteText: String,
+        micTimestamp: Date,
+        remoteTimestamp: Date,
+        window: TimeInterval = defaultWindow,
+        similarityThreshold: Double = defaultSimilarityThreshold,
+        minimumWordCount: Int = defaultMinimumWordCount,
+        minimumCharacterCount: Int = defaultMinimumCharacterCount,
+        direction: TimeDirection = .micAfterRemote
+    ) -> Match? {
+        let timeDelta = micTimestamp.timeIntervalSince(remoteTimestamp)
+        switch direction {
+        case .micAfterRemote:
+            guard timeDelta >= 0, timeDelta <= window else { return nil }
+        case .either:
+            guard abs(timeDelta) <= window else { return nil }
+        }
+
+        guard let similarity = textSimilarityIfEcho(
+            micText,
+            remoteText,
+            similarityThreshold: similarityThreshold,
+            minimumWordCount: minimumWordCount,
+            minimumCharacterCount: minimumCharacterCount
+        ) else { return nil }
+
+        return Match(timeDelta: timeDelta, similarity: similarity)
+    }
+
+    static func textSimilarityIfEcho(
+        _ firstText: String,
+        _ secondText: String,
+        similarityThreshold: Double = defaultSimilarityThreshold,
+        minimumWordCount: Int = defaultMinimumWordCount,
+        minimumCharacterCount: Int = defaultMinimumCharacterCount
+    ) -> Double? {
+        let first = TextSimilarity.normalizedText(firstText)
+        let second = TextSimilarity.normalizedText(secondText)
+        guard isEligible(first, minimumWordCount: minimumWordCount, minimumCharacterCount: minimumCharacterCount),
+              isEligible(second, minimumWordCount: minimumWordCount, minimumCharacterCount: minimumCharacterCount) else {
+            return nil
+        }
+
+        let similarity = TextSimilarity.jaccard(first, second)
+        let containsOther = first.contains(second) || second.contains(first)
+        return similarity >= similarityThreshold || containsOther ? similarity : nil
     }
 
     private static func isEligible(

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriber.swift
@@ -5,6 +5,12 @@ import os
 /// Consumes an audio buffer stream, detects speech via Silero VAD,
 /// and transcribes completed speech segments via the TranscriptionBackend protocol.
 final class StreamingTranscriber: @unchecked Sendable {
+    struct FinalSegment: Sendable, Equatable {
+        let text: String
+        let startTime: TimeInterval
+        let endTime: TimeInterval
+    }
+
     struct CloudSegmentStatus: Sendable, Equatable {
         enum Kind: String, Sendable, Equatable {
             case success
@@ -38,7 +44,7 @@ final class StreamingTranscriber: @unchecked Sendable {
     private let sessionID: String?
     private let transcriptionModel: String
     private let onPartial: @Sendable (String) -> Void
-    private let onFinal: @Sendable (String) -> Void
+    private let onFinal: @Sendable (FinalSegment) -> Void
     private let onCloudSegmentStatus: (@Sendable (CloudSegmentStatus) -> Void)?
     private let onCloudProcessingChanged: (@Sendable (Bool) -> Void)?
 
@@ -86,7 +92,7 @@ final class StreamingTranscriber: @unchecked Sendable {
         flushInterval: Int,
         skipPartials: Bool = false,
         onPartial: @escaping @Sendable (String) -> Void,
-        onFinal: @escaping @Sendable (String) -> Void,
+        onFinal: @escaping @Sendable (FinalSegment) -> Void,
         onCloudSegmentStatus: (@Sendable (CloudSegmentStatus) -> Void)? = nil,
         onCloudProcessingChanged: (@Sendable (Bool) -> Void)? = nil
     ) {
@@ -126,6 +132,8 @@ final class StreamingTranscriber: @unchecked Sendable {
         var bufferCount = 0
         var lastPartialTime: Date = .distantPast
         var isRunningPartial = false
+        var processedSampleCount = 0
+        var speechStartSample: Int?
 
         for await buffer in stream {
             guard !Task.isCancelled else { break }
@@ -148,6 +156,7 @@ final class StreamingTranscriber: @unchecked Sendable {
             vadBuffer.append(contentsOf: samples)
 
             while vadBuffer.count - vadReadIndex >= Self.vadChunkSize {
+                let chunkStartSample = processedSampleCount
                 let chunk = Array(vadBuffer[vadReadIndex..<(vadReadIndex + Self.vadChunkSize)])
                 vadReadIndex += Self.vadChunkSize
 
@@ -176,7 +185,9 @@ final class StreamingTranscriber: @unchecked Sendable {
                             if !wasSpeaking {
                                 isSpeaking = true
                                 startedSpeech = true
-                                speechSamples = recentChunks.suffix(Self.prerollChunkCount).flatMap { $0 }
+                                let prerollChunks = recentChunks.suffix(Self.prerollChunkCount)
+                                speechSamples = prerollChunks.flatMap { $0 }
+                                speechStartSample = max(0, chunkStartSample - speechSamples.count)
                                 Log.streaming.debug("[\(self.speaker.storageKey, privacy: .public)] speech start")
                             }
 
@@ -200,12 +211,17 @@ final class StreamingTranscriber: @unchecked Sendable {
                         isRunningPartial = false
                         Log.streaming.debug("[\(self.speaker.storageKey, privacy: .public)] speech end, samples=\(speechSamples.count, privacy: .public)")
                         if speechSamples.count > Self.minimumSpeechSamples {
-                            let segment = speechSamples
+                            let segment = makeSegment(
+                                samples: speechSamples,
+                                startSample: speechStartSample
+                            )
                             speechSamples.removeAll(keepingCapacity: true)
+                            speechStartSample = nil
                             onPartial("")  // Clear partial display
                             await submitSegment(segment, using: segmentQueue)
                         } else {
                             speechSamples.removeAll(keepingCapacity: true)
+                            speechStartSample = nil
                             onPartial("")  // Clear partial display
                         }
                     } else if isSpeaking {
@@ -233,8 +249,12 @@ final class StreamingTranscriber: @unchecked Sendable {
 
                         // Flush on long continuous speech (see flushInterval)
                         if speechSamples.count >= flushInterval {
-                            let segment = speechSamples
+                            let segment = makeSegment(
+                                samples: speechSamples,
+                                startSample: speechStartSample
+                            )
                             speechSamples.removeAll(keepingCapacity: true)
+                            speechStartSample = Int((segment.endTime * 16_000).rounded())
                             onPartial("")  // Clear partial display
                             await submitSegment(segment, using: segmentQueue)
                         }
@@ -242,12 +262,17 @@ final class StreamingTranscriber: @unchecked Sendable {
                 } catch {
                     Log.streaming.error("VAD error: \(error, privacy: .public)")
                 }
+
+                processedSampleCount += Self.vadChunkSize
             }
         }
 
         if speechSamples.count > Self.minimumSpeechSamples {
             onPartial("")  // Clear partial display
-            await submitSegment(speechSamples, using: segmentQueue)
+            await submitSegment(
+                makeSegment(samples: speechSamples, startSample: speechStartSample),
+                using: segmentQueue
+            )
         }
 
         if let segmentQueue {
@@ -272,18 +297,19 @@ final class StreamingTranscriber: @unchecked Sendable {
     }
 
     private func submitSegment(
-        _ samples: [Float],
+        _ segment: StreamingTranscriptionSegment,
         using queue: StreamingTranscriptionSegmentQueue?
     ) async {
         if let queue {
-            await queue.enqueue(samples)
+            await queue.enqueue(segment)
         } else {
-            await transcribeSegment(samples)
+            await transcribeSegment(segment)
         }
     }
 
-    private func transcribeSegment(_ samples: [Float]) async {
+    private func transcribeSegment(_ segment: StreamingTranscriptionSegment) async {
         let startedAt = Date()
+        let samples = segment.samples
         do {
             try Task.checkCancellation()
             let text = try await backend.transcribe(samples, locale: locale, previousContext: previousContext)
@@ -320,7 +346,13 @@ final class StreamingTranscriber: @unchecked Sendable {
             // Store trailing words for cross-segment context
             let words = text.split(separator: " ")
             previousContext = words.suffix(Self.contextWordCount).joined(separator: " ")
-            onFinal(text)
+            onFinal(
+                FinalSegment(
+                    text: text,
+                    startTime: segment.startTime,
+                    endTime: segment.endTime
+                )
+            )
         } catch {
             onCloudSegmentStatus?(CloudSegmentStatus(kind: .error, presentation: CloudTranscriptCopy.presentation(for: error)))
             recordCloudSegmentDiagnostics(
@@ -333,6 +365,20 @@ final class StreamingTranscriber: @unchecked Sendable {
             )
             Log.streaming.error("ASR error: \(error, privacy: .public)")
         }
+    }
+
+    private func makeSegment(
+        samples: [Float],
+        startSample: Int?
+    ) -> StreamingTranscriptionSegment {
+        let resolvedStartSample = max(0, startSample ?? 0)
+        let startTime = Double(resolvedStartSample) / 16_000.0
+        let endTime = startTime + Double(samples.count) / 16_000.0
+        return StreamingTranscriptionSegment(
+            samples: samples,
+            startTime: startTime,
+            endTime: endTime
+        )
     }
 
     private func recordCloudSegmentDiagnostics(

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriptionSegmentQueue.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriptionSegmentQueue.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+struct StreamingTranscriptionSegment: Equatable, Sendable {
+    let samples: [Float]
+    let startTime: TimeInterval
+    let endTime: TimeInterval
+
+    init(samples: [Float], startTime: TimeInterval, endTime: TimeInterval) {
+        self.samples = samples
+        self.startTime = startTime
+        self.endTime = endTime
+    }
+}
+
 /// Serializes asynchronous segment processing without blocking the capture loop.
 final class StreamingTranscriptionSegmentQueue: @unchecked Sendable {
     private actor State {
@@ -22,15 +34,15 @@ final class StreamingTranscriptionSegmentQueue: @unchecked Sendable {
     }
 
     private let state = State()
-    private let continuation: AsyncStream<[Float]>.Continuation
+    private let continuation: AsyncStream<StreamingTranscriptionSegment>.Continuation
     private let workerTask: Task<Void, Never>
     private let onProcessingChanged: (@Sendable (Bool) -> Void)?
 
     init(
         onProcessingChanged: (@Sendable (Bool) -> Void)? = nil,
-        process: @escaping @Sendable ([Float]) async -> Void
+        process: @escaping @Sendable (StreamingTranscriptionSegment) async -> Void
     ) {
-        let (stream, continuation) = AsyncStream<[Float]>.makeStream()
+        let (stream, continuation) = AsyncStream<StreamingTranscriptionSegment>.makeStream()
         let state = self.state
         self.continuation = continuation
         self.onProcessingChanged = onProcessingChanged
@@ -45,11 +57,11 @@ final class StreamingTranscriptionSegmentQueue: @unchecked Sendable {
         }
     }
 
-    func enqueue(_ samples: [Float]) async {
+    func enqueue(_ segment: StreamingTranscriptionSegment) async {
         if let onProcessingChanged, await state.didEnqueue() {
             onProcessingChanged(true)
         }
-        continuation.yield(samples)
+        continuation.yield(segment)
     }
 
     func finish() async {

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -929,10 +929,10 @@ final class TranscriptionEngine {
             onPartial: { text in
                 Task { @MainActor in store.volatileYouText = text }
             },
-            onFinal: { text in
+            onFinal: { segment in
                 Task { @MainActor in
                     store.volatileYouText = ""
-                    store.append(Utterance(text: text, speaker: .you))
+                    store.append(Utterance(text: segment.text, speaker: .you))
                 }
             }
         ) else {
@@ -981,9 +981,6 @@ final class TranscriptionEngine {
             }
         }
 
-        // Track cumulative audio time for diarizer speaker attribution
-        let sysAudioTime = SyncDouble()
-
         // Tee system audio to diarization manager if enabled
         if let dm = diarizationManager {
             let diarFlushSize = 16000
@@ -998,7 +995,6 @@ final class TranscriptionEngine {
                     diarContinuation.yield(b)
                     guard let channelData = buffer.floatChannelData else { continue }
                     let frameCount = Int(buffer.frameLength)
-                    sysAudioTime.add(Double(frameCount) / buffer.format.sampleRate)
                     diarBuf.append(contentsOf: UnsafeBufferPointer(start: channelData[0], count: frameCount))
                     if diarBuf.count >= diarFlushSize {
                         let batch = diarBuf
@@ -1039,19 +1035,16 @@ final class TranscriptionEngine {
             onPartial: { text in
                 Task { @MainActor in store.volatileThemText = text }
             },
-            onFinal: { [weak self] text in
+            onFinal: { [weak self] segment in
                 Task { @MainActor in
                     store.volatileThemText = ""
                     let speaker: Speaker
                     if let dm = self?.diarizationManager {
-                        // Estimate segment time: each onFinal is ~3-5s of speech
-                        let endTime = sysAudioTime.value
-                        let startTime = max(0, endTime - 5.0)
-                        speaker = await dm.dominantSpeaker(from: startTime, to: endTime)
+                        speaker = await dm.dominantSpeaker(from: segment.startTime, to: segment.endTime)
                     } else {
                         speaker = .them
                     }
-                    store.append(Utterance(text: text, speaker: speaker))
+                    store.append(Utterance(text: segment.text, speaker: speaker))
                 }
             }
         ) else {
@@ -1069,7 +1062,7 @@ final class TranscriptionEngine {
         speaker: Speaker,
         vadManager: VadManager,
         onPartial: @escaping @Sendable (String) -> Void,
-        onFinal: @escaping @Sendable (String) -> Void
+        onFinal: @escaping @Sendable (StreamingTranscriber.FinalSegment) -> Void
     ) -> StreamingTranscriber? {
         let backend = speaker == .you ? micBackend : systemBackend
         guard let backend else {

--- a/OpenOats/Tests/OpenOatsTests/StreamingTranscriptionSegmentQueueTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/StreamingTranscriptionSegmentQueueTests.swift
@@ -9,13 +9,15 @@ final class StreamingTranscriptionSegmentQueueTests: XCTestCase {
             try? await Task.sleep(for: .milliseconds(10))
         }
 
-        await queue.enqueue([1, 2])
-        await queue.enqueue([3, 4])
-        await queue.enqueue([5, 6])
+        await queue.enqueue(.init(samples: [1, 2], startTime: 0, endTime: 0.125))
+        await queue.enqueue(.init(samples: [3, 4], startTime: 0.125, endTime: 0.25))
+        await queue.enqueue(.init(samples: [5, 6], startTime: 0.25, endTime: 0.375))
         await queue.finish()
 
         let processed = await recorder.processedSegments
-        XCTAssertEqual(processed, [[1, 2], [3, 4], [5, 6]])
+        XCTAssertEqual(processed.map(\.samples), [[1, 2], [3, 4], [5, 6]])
+        XCTAssertEqual(processed.map(\.startTime), [0, 0.125, 0.25])
+        XCTAssertEqual(processed.map(\.endTime), [0.125, 0.25, 0.375])
     }
 
     func testQueueSignalsProcessingLifecycle() async {
@@ -34,8 +36,8 @@ final class StreamingTranscriptionSegmentQueueTests: XCTestCase {
             }
         )
 
-        await queue.enqueue([1])
-        await queue.enqueue([2])
+        await queue.enqueue(.init(samples: [1], startTime: 0, endTime: 1))
+        await queue.enqueue(.init(samples: [2], startTime: 1, endTime: 2))
         await queue.finish()
         await fulfillment(of: [expectation], timeout: 1.0)
 
@@ -45,9 +47,9 @@ final class StreamingTranscriptionSegmentQueueTests: XCTestCase {
 }
 
 private actor SegmentQueueRecorder {
-    private(set) var processedSegments: [[Float]] = []
+    private(set) var processedSegments: [StreamingTranscriptionSegment] = []
 
-    func record(_ segment: [Float]) {
+    func record(_ segment: StreamingTranscriptionSegment) {
         processedSegments.append(segment)
     }
 }

--- a/OpenOats/Tests/OpenOatsTests/TranscriptStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/TranscriptStoreTests.swift
@@ -35,6 +35,43 @@ final class TranscriptStoreTests: XCTestCase {
         XCTAssertEqual(store.utterances.count, 3)
     }
 
+    func testAppendSuppressesMicEchoAgainstCurrentRemotePartial() {
+        let store = makeStore()
+        store.volatileThemText = "We should ship the pilot next Friday after the customer review"
+
+        let accepted = store.append(
+            makeUtterance(
+                text: "We should ship the pilot next Friday after the customer review",
+                speaker: .you
+            )
+        )
+
+        XCTAssertFalse(accepted)
+        XCTAssertTrue(store.utterances.isEmpty)
+    }
+
+    func testRealtimeAssistantSkipsMicEchoAgainstCurrentRemotePartial() {
+        let store = makeStore()
+        store.volatileThemText = "Can we walk through the pricing change and rollout risk"
+        let echoedYou = makeUtterance(
+            text: "Can we walk through the pricing change and rollout risk",
+            speaker: .you
+        )
+
+        XCTAssertTrue(store.shouldSkipRealtimeAssistant(for: echoedYou))
+    }
+
+    func testRealtimeAssistantDoesNotSkipOwnDistinctSpeech() {
+        let store = makeStore()
+        store.volatileThemText = "Can we walk through the pricing change and rollout risk"
+        let ownSpeech = makeUtterance(
+            text: "I think we should pause and check the onboarding data first",
+            speaker: .you
+        )
+
+        XCTAssertFalse(store.shouldSkipRealtimeAssistant(for: ownSpeech))
+    }
+
     // MARK: - Clear
 
     func testClearRemovesAllUtterances() {


### PR DESCRIPTION
## Summary
- Reuse one acoustic echo matcher for batch and live transcript paths.
- Suppress mic echo against current remote partials and skip sidebar generation for echoed `You` turns.
- Carry live transcription segment timing through the queue so diarization uses actual segment windows instead of a 5-second estimate.

## Test plan
- [x] `swift test`

Fixes #279.
Refs #506.