### PR TITLE
Add LM Studio, diarization, and transcript Q&A

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -115,12 +115,12 @@ final class LiveSessionController {
         let hasBlockingError: Bool
     }
 
-    struct AutomaticSilencePauseEvaluation: Equatable {
+    struct AutomaticSilenceTimeoutEvaluation: Equatable {
         let lastAudibleActivityAt: Date?
-        let shouldPause: Bool
+        let shouldStop: Bool
     }
 
-    static let automaticSilencePauseInterval: TimeInterval = 300
+    static let automaticSilenceTimeoutInterval: TimeInterval = 300
     static let audibleActivityLevelThreshold: Float = 0.01
 
     private(set) var state = LiveSessionState()
@@ -1269,31 +1269,31 @@ final class LiveSessionController {
         return max(0, Int(Date().timeIntervalSince(startedAt)))
     }
 
-    static func automaticSilencePauseEvaluation(
+    static func automaticSilenceTimeoutEvaluation(
         isRunning: Bool,
         isRecordingPaused: Bool,
         audioLevel: Float,
         now: Date,
         lastAudibleActivityAt: Date?,
-        pauseInterval: TimeInterval = automaticSilencePauseInterval,
+        timeoutInterval: TimeInterval = automaticSilenceTimeoutInterval,
         audibleThreshold: Float = audibleActivityLevelThreshold
-    ) -> AutomaticSilencePauseEvaluation {
+    ) -> AutomaticSilenceTimeoutEvaluation {
         guard isRunning else {
-            return AutomaticSilencePauseEvaluation(lastAudibleActivityAt: nil, shouldPause: false)
+            return AutomaticSilenceTimeoutEvaluation(lastAudibleActivityAt: nil, shouldStop: false)
         }
 
         guard !isRecordingPaused else {
-            return AutomaticSilencePauseEvaluation(lastAudibleActivityAt: now, shouldPause: false)
+            return AutomaticSilenceTimeoutEvaluation(lastAudibleActivityAt: now, shouldStop: false)
         }
 
         if audioLevel >= audibleThreshold {
-            return AutomaticSilencePauseEvaluation(lastAudibleActivityAt: now, shouldPause: false)
+            return AutomaticSilenceTimeoutEvaluation(lastAudibleActivityAt: now, shouldStop: false)
         }
 
         let lastActivity = lastAudibleActivityAt ?? now
-        return AutomaticSilencePauseEvaluation(
+        return AutomaticSilenceTimeoutEvaluation(
             lastAudibleActivityAt: lastActivity,
-            shouldPause: now.timeIntervalSince(lastActivity) >= pauseInterval
+            shouldStop: now.timeIntervalSince(lastActivity) >= timeoutInterval
         )
     }
 
@@ -1574,7 +1574,7 @@ final class LiveSessionController {
             set(\.recordingHealthNotice, nil)
         }
 
-        updateAutomaticSilencePause(currentState: currentState)
+        updateAutomaticSilenceTimeout(currentState: currentState, settings: settings)
 
         if currentState.isRunning != observedIsRunning {
             observedIsRunning = currentState.isRunning
@@ -1602,13 +1602,13 @@ final class LiveSessionController {
         }
     }
 
-    private func updateAutomaticSilencePause(currentState: LiveSessionState) {
+    private func updateAutomaticSilenceTimeout(currentState: LiveSessionState, settings: AppSettings) {
         guard let engine = coordinator.transcriptionEngine else {
             observedLastAudibleActivityAt = nil
             return
         }
 
-        let evaluation = Self.automaticSilencePauseEvaluation(
+        let evaluation = Self.automaticSilenceTimeoutEvaluation(
             isRunning: currentState.isRunning && engine.isRunning,
             isRecordingPaused: engine.isRecordingPaused,
             audioLevel: currentState.audioLevel,
@@ -1617,9 +1617,9 @@ final class LiveSessionController {
         )
         observedLastAudibleActivityAt = evaluation.lastAudibleActivityAt
 
-        guard evaluation.shouldPause, !engine.isRecordingPaused else { return }
-        engine.isRecordingPaused = true
-        set(\.isRecordingPaused, true)
-        DiagnosticsSupport.record(category: "meeting", message: "Recording auto-paused after 5 minutes of silence")
+        guard evaluation.shouldStop, !engine.isRecordingPaused else { return }
+        observedLastAudibleActivityAt = nil
+        DiagnosticsSupport.record(category: "meeting", message: "Recording auto-stopped after 5 minutes of silence")
+        stopSession(settings: settings)
     }
 }

--- a/OpenOats/Sources/OpenOats/Intelligence/BatchTextCleaner.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/BatchTextCleaner.swift
@@ -97,6 +97,16 @@ final class BatchTextCleaner {
             baseURL = ollamaURL
             model = settings.ollamaLLMModel
             transport = settings.activeLLMTransport
+        case .lmStudio:
+            apiKey = settings.activeLLMApiKey
+            guard let lmStudioURL = OpenRouterClient.chatCompletionsURL(from: settings.lmStudioBaseURL) else {
+                error = "Invalid LM Studio URL: \(settings.lmStudioBaseURL)"
+                isCleaningUp = false
+                return records
+            }
+            baseURL = lmStudioURL
+            model = settings.lmStudioModel
+            transport = settings.activeLLMTransport
         case .mlx:
             apiKey = nil
             guard let mlxURL = OpenRouterClient.chatCompletionsURL(from: settings.mlxBaseURL) else {

--- a/OpenOats/Sources/OpenOats/Intelligence/LiveTranscriptCleaner.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/LiveTranscriptCleaner.swift
@@ -106,6 +106,9 @@ actor LiveTranscriptCleaner {
         let anthropicModel = await MainActor.run { settings.anthropicModel }
         let ollamaURL = await MainActor.run { settings.ollamaBaseURL }
         let ollamaModel = await MainActor.run { settings.ollamaLLMModel }
+        let lmStudioURL = await MainActor.run { settings.lmStudioBaseURL }
+        let lmStudioKey = await MainActor.run { settings.lmStudioApiKey }
+        let lmStudioModelName = await MainActor.run { settings.lmStudioModel }
         let mlxURL = await MainActor.run { settings.mlxBaseURL }
         let mlxModelName = await MainActor.run { settings.mlxModel }
         let openAILLMURL = await MainActor.run { settings.openAILLMBaseURL }
@@ -144,6 +147,15 @@ actor LiveTranscriptCleaner {
             }
             baseURL = url
             model = ollamaModel
+            transport = .chatCompletions
+        case .lmStudio:
+            apiKey = lmStudioKey.isEmpty ? nil : lmStudioKey
+            guard let url = OpenRouterClient.chatCompletionsURL(from: lmStudioURL) else {
+                await markFailed(utterance.id)
+                return
+            }
+            baseURL = url
+            model = lmStudioModelName
             transport = .chatCompletions
         case .mlx:
             apiKey = nil

--- a/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
@@ -151,6 +151,17 @@ final class NotesEngine {
             baseURL = ollamaURL
             model = settings.ollamaLLMModel
             transport = settings.activeLLMTransport
+        case .lmStudio:
+            apiKey = settings.activeLLMApiKey
+            guard let lmStudioURL = OpenRouterClient.chatCompletionsURL(from: settings.lmStudioBaseURL) else {
+                error = "Invalid LM Studio URL: \(settings.lmStudioBaseURL)"
+                isGenerating = false
+                onFinished()
+                return
+            }
+            baseURL = lmStudioURL
+            model = settings.lmStudioModel
+            transport = settings.activeLLMTransport
         case .mlx:
             apiKey = nil
             guard let mlxURL = OpenRouterClient.chatCompletionsURL(from: settings.mlxBaseURL) else {
@@ -314,7 +325,7 @@ final class NotesEngine {
         allowCloudCalendarContext: Bool
     ) -> Bool {
         switch provider {
-        case .ollama, .mlx:
+        case .ollama, .lmStudio, .mlx:
             return true
         case .openRouter, .openAI, .anthropic:
             return allowCloudCalendarContext

--- a/OpenOats/Sources/OpenOats/Intelligence/SidecastEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SidecastEngine.swift
@@ -389,7 +389,7 @@ final class SidecastEngine {
             return !settings.openAIApiKey.isEmpty && llmBaseURL != nil
         case .anthropic:
             return !settings.anthropicApiKey.isEmpty && llmBaseURL != nil
-        case .ollama, .mlx, .openAICompatible:
+        case .ollama, .lmStudio, .mlx, .openAICompatible:
             return llmBaseURL != nil
         }
     }
@@ -402,6 +402,8 @@ final class SidecastEngine {
         case .anthropic:
             settings.anthropicApiKey.isEmpty ? nil : settings.anthropicApiKey
         case .ollama: nil
+        case .lmStudio:
+            settings.lmStudioApiKey.isEmpty ? nil : settings.lmStudioApiKey
         case .mlx: nil
         case .openAICompatible:
             settings.openAILLMApiKey.isEmpty ? nil : settings.openAILLMApiKey
@@ -422,6 +424,8 @@ final class SidecastEngine {
             OpenRouterClient.anthropicMessagesURL(from: settings.anthropicBaseURL)
         case .ollama:
             OpenRouterClient.chatCompletionsURL(from: settings.ollamaBaseURL)
+        case .lmStudio:
+            OpenRouterClient.chatCompletionsURL(from: settings.lmStudioBaseURL)
         case .mlx:
             OpenRouterClient.chatCompletionsURL(from: settings.mlxBaseURL)
         case .openAICompatible:

--- a/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
@@ -227,7 +227,7 @@ final class SuggestionEngine {
             guard !settings.openAIApiKey.isEmpty, llmBaseURL(forRealtime: true) != nil else { return }
         case .anthropic:
             guard !settings.anthropicApiKey.isEmpty, llmBaseURL(forRealtime: true) != nil else { return }
-        case .ollama, .mlx, .openAICompatible:
+        case .ollama, .lmStudio, .mlx, .openAICompatible:
             guard llmBaseURL(forRealtime: true) != nil else { return }
         }
 
@@ -505,6 +505,7 @@ final class SuggestionEngine {
         case .openAI: settings.openAIModel
         case .anthropic: settings.anthropicModel
         case .ollama: settings.ollamaLLMModel
+        case .lmStudio: settings.lmStudioModel
         case .mlx: settings.mlxModel
         case .openAICompatible: settings.openAILLMModel
         }
@@ -518,6 +519,8 @@ final class SuggestionEngine {
         case .anthropic:
             settings.anthropicApiKey.isEmpty ? nil : settings.anthropicApiKey
         case .ollama: nil
+        case .lmStudio:
+            settings.lmStudioApiKey.isEmpty ? nil : settings.lmStudioApiKey
         case .mlx: nil
         case .openAICompatible:
             settings.openAILLMApiKey.isEmpty ? nil : settings.openAILLMApiKey
@@ -533,6 +536,8 @@ final class SuggestionEngine {
             return OpenRouterClient.anthropicMessagesURL(from: settings.anthropicBaseURL)
         case .ollama:
             return OpenRouterClient.chatCompletionsURL(from: settings.ollamaBaseURL)
+        case .lmStudio:
+            return OpenRouterClient.chatCompletionsURL(from: settings.lmStudioBaseURL)
         case .mlx:
             return OpenRouterClient.chatCompletionsURL(from: settings.mlxBaseURL)
         case .openAICompatible:

--- a/OpenOats/Sources/OpenOats/Models/SidecastPreset.swift
+++ b/OpenOats/Sources/OpenOats/Models/SidecastPreset.swift
@@ -81,6 +81,8 @@ struct SidecastPreset: Decodable {
         "openai": .openAI,
         "anthropic": .anthropic,
         "ollama": .ollama,
+        "lmstudio": .lmStudio,
+        "lm-studio": .lmStudio,
         "openai-compatible": .openAICompatible,
     ]
 
@@ -97,6 +99,8 @@ struct SidecastPreset: Decodable {
                     settings.openAIApiKey = apiKey
                 case .anthropic:
                     settings.anthropicApiKey = apiKey
+                case .lmStudio:
+                    settings.lmStudioApiKey = apiKey
                 case .openAICompatible:
                     settings.openAILLMApiKey = apiKey
                 case .ollama, .mlx:
@@ -112,6 +116,8 @@ struct SidecastPreset: Decodable {
                     settings.anthropicBaseURL = baseURL
                 case .ollama:
                     settings.ollamaBaseURL = baseURL
+                case .lmStudio:
+                    settings.lmStudioBaseURL = baseURL
                 case .openAICompatible:
                     settings.openAILLMBaseURL = baseURL
                 case .openRouter, .mlx:
@@ -129,6 +135,8 @@ struct SidecastPreset: Decodable {
                     settings.anthropicModel = model
                 case .ollama:
                     settings.realtimeOllamaModel = model
+                case .lmStudio:
+                    settings.lmStudioModel = model
                 case .openAICompatible:
                     settings.openAILLMModel = model
                 case .mlx:

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -252,6 +252,46 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _lmStudioBaseURL: String
+    var lmStudioBaseURL: String {
+        get { access(keyPath: \.lmStudioBaseURL); return _lmStudioBaseURL }
+        set {
+            withMutation(keyPath: \.lmStudioBaseURL) {
+                _lmStudioBaseURL = newValue
+                defaults.set(newValue, forKey: "lmStudioBaseURL")
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _lmStudioApiKey: String
+    var lmStudioApiKey: String {
+        get {
+            access(keyPath: \.lmStudioApiKey)
+            return loadSecretIfNeeded(key: "lmStudioApiKey", currentValue: _lmStudioApiKey) {
+                _lmStudioApiKey = $0
+            }
+        }
+        set {
+            withMutation(keyPath: \.lmStudioApiKey) {
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                _lmStudioApiKey = trimmed
+                markSecretLoaded("lmStudioApiKey")
+                secretStore.save(key: "lmStudioApiKey", value: trimmed)
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _lmStudioModel: String
+    var lmStudioModel: String {
+        get { access(keyPath: \.lmStudioModel); return _lmStudioModel }
+        set {
+            withMutation(keyPath: \.lmStudioModel) {
+                _lmStudioModel = newValue
+                defaults.set(newValue, forKey: "lmStudioModel")
+            }
+        }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _openAILLMBaseURL: String
     var openAILLMBaseURL: String {
         get { access(keyPath: \.openAILLMBaseURL); return _openAILLMBaseURL }
@@ -1300,6 +1340,9 @@ final class SettingsStore {
         self._ollamaEmbedModel = defaults.string(forKey: "ollamaEmbedModel") ?? "nomic-embed-text"
         self._mlxBaseURL = defaults.string(forKey: "mlxBaseURL") ?? "http://localhost:8080"
         self._mlxModel = defaults.string(forKey: "mlxModel") ?? "mlx-community/Llama-3.2-3B-Instruct-4bit"
+        self._lmStudioBaseURL = defaults.string(forKey: "lmStudioBaseURL") ?? "http://localhost:1234"
+        self._lmStudioApiKey = ""
+        self._lmStudioModel = defaults.string(forKey: "lmStudioModel") ?? ""
         self._openAILLMBaseURL = defaults.string(forKey: "openAILLMBaseURL") ?? "http://localhost:4000"
         self._openAILLMApiKey = ""
         self._openAILLMModel = defaults.string(forKey: "openAILLMModel") ?? ""
@@ -1503,6 +1546,8 @@ final class SettingsStore {
             anthropicModel
         case .ollama:
             ollamaLLMModel
+        case .lmStudio:
+            lmStudioModel
         case .mlx:
             mlxModel
         case .openAICompatible:
@@ -1525,6 +1570,8 @@ final class SettingsStore {
             return !anthropicApiKey.isEmpty && OpenRouterClient.anthropicMessagesURL(from: anthropicBaseURL) != nil
         case .ollama:
             return OpenRouterClient.chatCompletionsURL(from: ollamaBaseURL) != nil
+        case .lmStudio:
+            return OpenRouterClient.chatCompletionsURL(from: lmStudioBaseURL) != nil
         case .mlx:
             return OpenRouterClient.chatCompletionsURL(from: mlxBaseURL) != nil
         case .openAICompatible:
@@ -1545,6 +1592,7 @@ final class SettingsStore {
         case .openAI: return openAIModel
         case .anthropic: return anthropicModel
         case .ollama: return realtimeOllamaModel.isEmpty ? ollamaLLMModel : realtimeOllamaModel
+        case .lmStudio: return lmStudioModel
         case .mlx: return mlxModel
         case .openAICompatible: return openAILLMModel
         }
@@ -1564,6 +1612,8 @@ final class SettingsStore {
             anthropicApiKey.isEmpty ? nil : anthropicApiKey
         case .ollama, .mlx:
             nil
+        case .lmStudio:
+            lmStudioApiKey.isEmpty ? nil : lmStudioApiKey
         case .openAICompatible:
             openAILLMApiKey.isEmpty ? nil : openAILLMApiKey
         }
@@ -1579,6 +1629,8 @@ final class SettingsStore {
             OpenRouterClient.anthropicMessagesURL(from: anthropicBaseURL)
         case .ollama:
             OpenRouterClient.chatCompletionsURL(from: ollamaBaseURL)
+        case .lmStudio:
+            OpenRouterClient.chatCompletionsURL(from: lmStudioBaseURL)
         case .mlx:
             OpenRouterClient.chatCompletionsURL(from: mlxBaseURL)
         case .openAICompatible:
@@ -1749,6 +1801,7 @@ extension SettingsStore {
             "kbFolderPath", "selectedModel", "transcriptionLocale", "transcriptionModel", "inputDeviceID",
             "llmProvider", "embeddingProvider", "openAIBaseURL", "openAIModel",
             "anthropicBaseURL", "anthropicModel", "ollamaBaseURL", "ollamaLLMModel",
+            "lmStudioBaseURL", "lmStudioModel",
             "ollamaEmbedModel", "hideFromScreenShare",
             "isTranscriptExpanded", "hasCompletedOnboarding",
         ]
@@ -1759,7 +1812,7 @@ extension SettingsStore {
         }
 
         let oldService = "com.onthespot.app"
-        let keychainKeys = ["openRouterApiKey", "voyageApiKey"]
+        let keychainKeys = ["openRouterApiKey", "lmStudioApiKey", "voyageApiKey"]
         for key in keychainKeys {
             if let oldValue = Self.loadKeychain(service: oldService, key: key) {
                 KeychainHelper.saveIfMissing(key: key, value: oldValue)
@@ -1782,6 +1835,7 @@ extension SettingsStore {
             "kbFolderPath", "selectedModel", "transcriptionLocale", "transcriptionModel", "inputDeviceID",
             "llmProvider", "embeddingProvider", "openAIBaseURL", "openAIModel",
             "anthropicBaseURL", "anthropicModel", "ollamaBaseURL", "ollamaLLMModel",
+            "lmStudioBaseURL", "lmStudioModel",
             "ollamaEmbedModel", "hideFromScreenShare",
             "isTranscriptExpanded", "hasCompletedOnboarding",
             "hasAcknowledgedRecordingConsent",
@@ -1793,7 +1847,7 @@ extension SettingsStore {
         }
 
         let oldService = "com.opengranola.app"
-        let keychainKeys = ["openRouterApiKey", "voyageApiKey"]
+        let keychainKeys = ["openRouterApiKey", "lmStudioApiKey", "voyageApiKey"]
         for key in keychainKeys {
             if let oldValue = Self.loadKeychain(service: oldService, key: key) {
                 KeychainHelper.saveIfMissing(key: key, value: oldValue)

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -297,6 +297,7 @@ enum LLMProvider: String, CaseIterable, Identifiable {
     case openAI
     case anthropic
     case ollama
+    case lmStudio
     case mlx
     case openAICompatible
 
@@ -308,6 +309,7 @@ enum LLMProvider: String, CaseIterable, Identifiable {
         case .openAI: "OpenAI"
         case .anthropic: "Anthropic"
         case .ollama: "Ollama"
+        case .lmStudio: "LM Studio"
         case .mlx: "MLX"
         case .openAICompatible: "OpenAI Compatible"
         }

--- a/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
@@ -565,7 +565,8 @@ actor BatchAudioTranscriber {
         if let sysURL = urls.sys {
             // Optionally run diarization on the full system audio
             var batchDiarizer: DiarizationManager?
-            if enableDiarization {
+            let useElevenLabsNativeDiarization = enableDiarization && model == .elevenLabsScribe
+            if enableDiarization && !useElevenLabsNativeDiarization {
                 Log.batchTranscription.info("Running LS-EEND diarization on system audio...")
                 let dm = DiarizationManager()
                 let variant = LSEENDVariant(rawValue: diarizationVariant.rawValue) ?? .dihard3
@@ -580,6 +581,8 @@ actor BatchAudioTranscriber {
                 await dm.finalize()
                 batchDiarizer = dm
                 Log.batchTranscription.info("Diarization complete")
+            } else if useElevenLabsNativeDiarization {
+                Log.batchTranscription.info("Using ElevenLabs native diarization for system audio")
             }
 
             sysRecords = try await transcribeFile(
@@ -592,7 +595,8 @@ actor BatchAudioTranscriber {
                 locale: locale,
                 progressBase: Double(filesProcessed) / Double(totalFiles),
                 progressScale: 1.0 / Double(totalFiles),
-                diarizationManager: batchDiarizer
+                diarizationManager: batchDiarizer,
+                useElevenLabsNativeDiarization: useElevenLabsNativeDiarization
             )
             Log.batchTranscription.debug("Sys transcription: \(sysRecords.count, privacy: .public) records")
         }
@@ -658,7 +662,8 @@ actor BatchAudioTranscriber {
         locale: Locale,
         progressBase: Double,
         progressScale: Double,
-        diarizationManager: DiarizationManager? = nil
+        diarizationManager: DiarizationManager? = nil,
+        useElevenLabsNativeDiarization: Bool = false
     ) async throws -> [SessionRecord] {
         guard let audioFile = try? AVAudioFile(forReading: url) else {
             Log.batchTranscription.warning("Cannot open audio file: \(url.lastPathComponent, privacy: .public)")
@@ -702,6 +707,23 @@ actor BatchAudioTranscriber {
                 let segmentStartTime = sampleOffsetInFile / resolvedSampleRate
                 let segmentDuration = Double(segment.samples.count) / 16000.0
                 let segmentEndTime = segmentStartTime + segmentDuration
+
+                if useElevenLabsNativeDiarization,
+                   let elevenLabsBackend = backend as? ElevenLabsScribeBackend
+                {
+                    let result = try await elevenLabsBackend.transcribeDiarized(
+                        segment.samples,
+                        locale: locale,
+                        previousContext: nil
+                    )
+                    let diarizedRecords = makeRecords(
+                        from: result,
+                        fallbackSpeaker: speaker,
+                        baseTimestamp: resolvedStartDate.addingTimeInterval(segmentStartTime)
+                    )
+                    records.append(contentsOf: diarizedRecords)
+                    continue
+                }
 
                 let slices: [BatchTranscriptionSegmentLayout.Slice]
                 if let dm = diarizationManager {
@@ -753,6 +775,31 @@ actor BatchAudioTranscriber {
         }
 
         return records
+    }
+
+    private func makeRecords(
+        from result: ElevenLabsScribeBackend.TranscriptResult,
+        fallbackSpeaker: Speaker,
+        baseTimestamp: Date
+    ) -> [SessionRecord] {
+        if result.segments.isEmpty {
+            guard !result.text.isEmpty else { return [] }
+            return [
+                SessionRecord(
+                    speaker: fallbackSpeaker,
+                    text: result.text,
+                    timestamp: baseTimestamp
+                )
+            ]
+        }
+
+        return result.segments.map { segment in
+            SessionRecord(
+                speaker: segment.speaker,
+                text: segment.text,
+                timestamp: baseTimestamp.addingTimeInterval(segment.startTime)
+            )
+        }
     }
 
     // MARK: - Audio Reading

--- a/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/ElevenLabsScribeBackend.swift
@@ -8,6 +8,36 @@ import os
 final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
     let displayName = "ElevenLabs Scribe"
 
+    struct DiarizedSegment: Equatable {
+        let speaker: Speaker
+        let text: String
+        let startTime: TimeInterval
+        let endTime: TimeInterval
+    }
+
+    struct TranscriptResult: Equatable {
+        let text: String
+        let segments: [DiarizedSegment]
+    }
+
+    private struct ScribeResponse: Decodable {
+        let text: String
+        let words: [ScribeWord]?
+    }
+
+    private struct ScribeWord: Decodable {
+        let text: String
+        let start: TimeInterval?
+        let end: TimeInterval?
+        let type: String?
+        let speakerID: String?
+
+        enum CodingKeys: String, CodingKey {
+            case text, start, end, type
+            case speakerID = "speaker_id"
+        }
+    }
+
     private let apiKey: String
     private let keyterms: [String]
     private let removeFillerWords: Bool
@@ -67,6 +97,24 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
         locale: Locale,
         previousContext: String? = nil
     ) async throws -> String {
+        let result = try await transcribe(samples, locale: locale, previousContext: previousContext, diarize: false)
+        return result.text
+    }
+
+    func transcribeDiarized(
+        _ samples: [Float],
+        locale: Locale,
+        previousContext: String? = nil
+    ) async throws -> TranscriptResult {
+        try await transcribe(samples, locale: locale, previousContext: previousContext, diarize: true)
+    }
+
+    private func transcribe(
+        _ samples: [Float],
+        locale: Locale,
+        previousContext: String?,
+        diarize: Bool
+    ) async throws -> TranscriptResult {
         guard prepared else { throw TranscriptionBackendError.notPrepared }
 
         // 1. Encode audio as WAV
@@ -80,7 +128,8 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
             wavData: wavData,
             languageCode: languageCode,
             keyterms: keyterms,
-            removeFillerWords: removeFillerWords
+            removeFillerWords: removeFillerWords,
+            diarize: diarize
         )
 
         // 3. POST to speech-to-text endpoint
@@ -93,7 +142,7 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
         request.httpBody = body
         request.timeoutInterval = 30
 
-        let text: String = try await withTransientRetry { [session] in
+        let result: TranscriptResult = try await withTransientRetry { [session] in
             let (responseData, response) = try await session.data(for: request)
 
             if let http = response as? HTTPURLResponse {
@@ -107,15 +156,11 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
                 }
             }
 
-            let json = try JSONSerialization.jsonObject(with: responseData) as? [String: Any]
-            guard let text = json?["text"] as? String else {
-                throw CloudASRError.transcriptionFailed("Missing text field in response.")
-            }
-            return text
+            return try Self.parseTranscriptResponse(responseData)
         }
 
         Self.log.info("ElevenLabs Scribe transcription completed")
-        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return result
     }
 
     // MARK: - Multipart Body Builder (internal for tests)
@@ -132,11 +177,15 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
         wavData: Data,
         languageCode: String,
         keyterms: [String],
-        removeFillerWords: Bool
+        removeFillerWords: Bool,
+        diarize: Bool = false
     ) -> Data {
         var body = Data()
 
         body.appendMultipart(boundary: boundary, name: "model_id", value: "scribe_v2")
+        if diarize {
+            body.appendMultipart(boundary: boundary, name: "diarize", value: "true")
+        }
 
         if !languageCode.isEmpty {
             body.appendMultipart(boundary: boundary, name: "language_code", value: languageCode)
@@ -160,6 +209,79 @@ final class ElevenLabsScribeBackend: TranscriptionBackend, @unchecked Sendable {
 
         body.append("--\(boundary)--\r\n".data(using: .utf8)!)
         return body
+    }
+
+    static func parseTranscriptResponse(_ data: Data) throws -> TranscriptResult {
+        let response = try JSONDecoder().decode(ScribeResponse.self, from: data)
+        let text = response.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let segments = buildDiarizedSegments(from: response.words ?? [])
+        return TranscriptResult(text: text, segments: segments)
+    }
+
+    private static func buildDiarizedSegments(from words: [ScribeWord]) -> [DiarizedSegment] {
+        var speakerIDs: [String: Speaker] = [:]
+        var nextSpeakerIndex = 1
+        var segments: [DiarizedSegment] = []
+
+        var currentSpeaker: Speaker?
+        var currentText = ""
+        var currentStart: TimeInterval?
+        var currentEnd: TimeInterval?
+
+        func flushCurrent() {
+            let text = currentText.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let speaker = currentSpeaker,
+                  let start = currentStart,
+                  let end = currentEnd,
+                  !text.isEmpty
+            else { return }
+            segments.append(DiarizedSegment(speaker: speaker, text: text, startTime: start, endTime: end))
+        }
+
+        for word in words {
+            guard let speakerID = word.speakerID,
+                  let start = word.start,
+                  let end = word.end,
+                  start <= end
+            else { continue }
+            let trimmedWord = word.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedWord.isEmpty else { continue }
+            let isPunctuationOnly = trimmedWord.unicodeScalars.allSatisfy {
+                CharacterSet.punctuationCharacters.contains($0)
+            }
+            guard word.type == nil || word.type == "word" || isPunctuationOnly else { continue }
+
+            let speaker = speakerIDs[speakerID] ?? {
+                let mapped = Speaker.remote(nextSpeakerIndex)
+                speakerIDs[speakerID] = mapped
+                nextSpeakerIndex += 1
+                return mapped
+            }()
+
+            if currentSpeaker != speaker {
+                flushCurrent()
+                currentSpeaker = speaker
+                currentText = ""
+                currentStart = start
+                currentEnd = end
+            }
+
+            appendWord(trimmedWord, to: &currentText)
+            currentEnd = end
+        }
+
+        flushCurrent()
+        return segments
+    }
+
+    private static func appendWord(_ word: String, to text: inout String) {
+        let trimmed = word.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if text.isEmpty || trimmed.unicodeScalars.allSatisfy({ CharacterSet.punctuationCharacters.contains($0) }) {
+            text += trimmed
+        } else {
+            text += " " + trimmed
+        }
     }
 
     // MARK: - Private: Keyterms Parser

--- a/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
+++ b/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
@@ -5,6 +5,7 @@ import UniformTypeIdentifiers
 enum MeetingDetailViewMode: String, CaseIterable {
     case transcript = "Transcript"
     case notes = "Notes"
+    case ask = "Ask"
 }
 
 private enum MeetingDetailPaneFormatters {
@@ -13,6 +14,17 @@ private enum MeetingDetailPaneFormatters {
         f.dateFormat = "HH:mm:ss"
         return f
     }()
+}
+
+private struct TranscriptChatMessage: Identifiable, Equatable {
+    enum Role: Equatable {
+        case user
+        case assistant
+    }
+
+    let id = UUID()
+    let role: Role
+    let text: String
 }
 
 extension SessionIndex {
@@ -59,6 +71,10 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
     @State private var newFolderPath: String = ""
     @State private var newFolderColor: NotesFolderColor = .orange
     @FocusState private var newFolderFieldFocused: Bool
+    @State private var askQuestion: String = ""
+    @State private var askMessages: [TranscriptChatMessage] = []
+    @State private var askError: String?
+    @State private var askTask: Task<Void, Never>?
 
     private enum AppleNotesSyncState {
         case idle, syncing, failed
@@ -199,6 +215,7 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
             .onChange(of: state.selectedSessionID) {
                 appleNotesSyncState = .idle
                 appleNotesLastSyncDate = state.selectedSessionID.flatMap { AppleNotesService.lastSyncDate(for: $0) }
+                resetAskConversation()
                 if renamingSessionID != state.selectedSessionID {
                     cancelRename()
                 }
@@ -213,6 +230,9 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                 if meetingFamilyBottomTab != .history {
                     cancelBulkDeleteMode()
                 }
+            }
+            .onDisappear {
+                cancelAskTask()
             }
             .onChange(of: state.meetingHistoryEntries.map(\.session.id)) {
                 let validSessionIDs = Set(state.meetingHistoryEntries.map(\.session.id))
@@ -1115,6 +1135,8 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                     .keyboardShortcut("1", modifiers: .command)
                 Button("") { detailViewMode = .notes }
                     .keyboardShortcut("2", modifiers: .command)
+                Button("") { detailViewMode = .ask }
+                    .keyboardShortcut("3", modifiers: .command)
             }
             .frame(width: 0, height: 0)
             .opacity(0)
@@ -1431,6 +1453,12 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
         )
         NSApp.activate(ignoringOtherApps: true)
         openWindow(id: OpenOatsRootApp.mainWindowID)
+        Task { @MainActor in
+            await Task.yield()
+            coordinator.liveSessionController?.handlePendingExternalCommandIfPossible(settings: settings) {
+                openWindow(id: "notes")
+            }
+        }
     }
 
     private func createManualTranscriptSessionAndMaybePrompt(controller: NotesController, event: CalendarEvent) {
@@ -1495,6 +1523,8 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
             transcriptToolbarActions(controller: controller, state: state)
         } else if detailViewMode == .notes {
             notesToolbarActions(controller: controller, state: state)
+        } else if detailViewMode == .ask {
+            askToolbarActions()
         }
 
         if state.selectedSessionID != nil,
@@ -1503,6 +1533,7 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
         }
 
         if state.selectedSessionID != nil {
+            renameSessionButton(state: state)
             sessionManagementMenu(controller: controller, state: state)
         }
 
@@ -1525,6 +1556,22 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
         .buttonStyle(.bordered)
         .disabled(copyContentIsEmpty(state: state))
         .help("Copy to clipboard")
+    }
+
+    @ViewBuilder
+    private func renameSessionButton(state: NotesState) -> some View {
+        if let session = selectedSession(in: state) {
+            Button {
+                beginRenaming(session)
+            } label: {
+                Label("Rename", systemImage: "pencil")
+                    .font(.system(size: 12))
+            }
+            .buttonStyle(.bordered)
+            .fixedSize()
+            .help("Rename this meeting")
+            .accessibilityIdentifier("meetingDetail.rename")
+        }
     }
 
     @ViewBuilder
@@ -2096,6 +2143,19 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
     }
 
     @ViewBuilder
+    private func askToolbarActions() -> some View {
+        Button {
+            resetAskConversation()
+        } label: {
+            Label("Clear Chat", systemImage: "trash")
+                .font(.system(size: 12))
+        }
+        .buttonStyle(.bordered)
+        .disabled(askMessages.isEmpty && askQuestion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && askError == nil)
+        .help("Clear transcript chat")
+    }
+
+    @ViewBuilder
     private func appleNotesSyncButton(controller: NotesController, state: NotesState) -> some View {
         Button {
             guard appleNotesSyncState != .syncing else { return }
@@ -2372,6 +2432,8 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                 transcriptView(controller: controller, state: state)
             case .notes:
                 notesTab(controller: controller, state: state, sessionID: sessionID)
+            case .ask:
+                askTab(state: state)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -2409,6 +2471,161 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                 }
             }
         }
+    }
+
+    private func askTab(state: NotesState) -> some View {
+        VStack(spacing: 0) {
+            if state.loadedTranscript.isEmpty {
+                ContentUnavailableView(
+                    "No Transcript",
+                    systemImage: "message.badge",
+                    description: Text("Add or recover a transcript before asking questions.")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 12) {
+                            if askMessages.isEmpty {
+                                VStack(alignment: .leading, spacing: 8) {
+                                    Label("Ask this transcript", systemImage: "sparkles")
+                                        .font(.system(size: 18, weight: .semibold))
+                                    Text("Questions stay local to this meeting and use your active notes LLM provider.")
+                                        .font(.system(size: 12))
+                                        .foregroundStyle(.secondary)
+                                }
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(16)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .fill(Color(nsColor: .controlBackgroundColor))
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 12)
+                                        .strokeBorder(.quaternary, lineWidth: 1)
+                                )
+                            }
+
+                            ForEach(askMessages) { message in
+                                askMessageBubble(message)
+                                    .id(message.id)
+                            }
+
+                            if askTask != nil {
+                                HStack(spacing: 8) {
+                                    ProgressView()
+                                        .controlSize(.small)
+                                    Text("Reading transcript...")
+                                        .font(.system(size: 12))
+                                        .foregroundStyle(.secondary)
+                                }
+                                .padding(.horizontal, 4)
+                            }
+
+                            if let askError {
+                                Label(askError, systemImage: "exclamationmark.triangle.fill")
+                                    .font(.system(size: 12))
+                                    .foregroundStyle(.red)
+                                    .padding(.horizontal, 4)
+                            }
+                        }
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 20)
+                    }
+                    .onChange(of: askMessages.count) {
+                        guard let lastID = askMessages.last?.id else { return }
+                        withAnimation(.easeOut(duration: 0.18)) {
+                            proxy.scrollTo(lastID, anchor: .bottom)
+                        }
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    ZStack(alignment: .topLeading) {
+                        if askQuestion.isEmpty {
+                            Text("Ask about decisions, action items, risks, or anything said in this transcript...")
+                                .font(.system(size: 12))
+                                .foregroundStyle(.quaternary)
+                                .padding(.horizontal, 4)
+                                .padding(.vertical, 6)
+                        }
+
+                        TextEditor(text: $askQuestion)
+                            .font(.system(size: 12))
+                            .scrollContentBackground(.hidden)
+                            .frame(minHeight: 54, maxHeight: 90)
+                    }
+                    .padding(6)
+                    .background(
+                        RoundedRectangle(cornerRadius: 10)
+                            .fill(Color(nsColor: .textBackgroundColor))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .strokeBorder(.quaternary, lineWidth: 1)
+                    )
+
+                    HStack {
+                        Text("\(state.loadedTranscript.count) utterances available")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+
+                        Spacer()
+
+                        Button {
+                            submitAskQuestion(state: state)
+                        } label: {
+                            Label("Ask", systemImage: "paperplane.fill")
+                                .frame(minWidth: 72)
+                        }
+                        .buttonStyle(OpenOatsProminentButtonStyle())
+                        .disabled(askQuestion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || askTask != nil)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 14)
+                .background(.regularMaterial)
+            }
+        }
+    }
+
+    private func askMessageBubble(_ message: TranscriptChatMessage) -> some View {
+        let isUser = message.role == .user
+
+        return HStack {
+            if isUser {
+                Spacer(minLength: 48)
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(isUser ? "You" : "OpenOats")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+
+                Text(message.text)
+                    .font(.system(size: 13))
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(isUser ? Color.accentColor.opacity(0.13) : Color(nsColor: .controlBackgroundColor))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(isUser ? Color.accentColor.opacity(0.25) : Color.secondary.opacity(0.12), lineWidth: 1)
+            )
+            .frame(maxWidth: 620, alignment: isUser ? .trailing : .leading)
+
+            if !isUser {
+                Spacer(minLength: 48)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
     }
 
     private func notesAssetDropSurface<Content: View>(
@@ -3134,6 +3351,8 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                 return state.manualNotesDraft.isEmpty
             }
             return state.loadedNotes == nil
+        case .ask:
+            return formattedAskConversation().isEmpty
         }
     }
 
@@ -3369,10 +3588,127 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
             }.joined(separator: "\n")
         case .notes:
             text = state.loadedTranscript.isEmpty ? state.manualNotesDraft : (state.loadedNotes?.markdown ?? "")
+        case .ask:
+            text = formattedAskConversation()
         }
 
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(text, forType: .string)
+    }
+
+    private func submitAskQuestion(state: NotesState) {
+        let question = askQuestion.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !question.isEmpty, askTask == nil else { return }
+
+        let history = askMessages
+        askQuestion = ""
+        askError = nil
+        askMessages.append(TranscriptChatMessage(role: .user, text: question))
+
+        let messages = buildAskMessages(question: question, transcript: state.loadedTranscript, history: history)
+        let apiKey = settings.activeLLMApiKey
+        let model = settings.activeNotesModel
+        let baseURL = settings.activeLLMBaseURL
+        let transport = settings.activeLLMTransport
+
+        askTask = Task {
+            do {
+                let client = OpenRouterClient()
+                let answer = try await client.complete(
+                    apiKey: apiKey,
+                    model: model,
+                    messages: messages,
+                    baseURL: baseURL,
+                    transport: transport
+                )
+                await MainActor.run {
+                    askMessages.append(TranscriptChatMessage(role: .assistant, text: answer.trimmingCharacters(in: .whitespacesAndNewlines)))
+                    askTask = nil
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    askTask = nil
+                }
+            } catch {
+                await MainActor.run {
+                    askError = error.localizedDescription
+                    askTask = nil
+                }
+            }
+        }
+    }
+
+    private func buildAskMessages(
+        question: String,
+        transcript: [SessionRecord],
+        history: [TranscriptChatMessage]
+    ) -> [OpenRouterClient.Message] {
+        var messages = [
+            OpenRouterClient.Message(
+                role: "system",
+                content: """
+                You answer questions about a meeting transcript. Use only the transcript and the chat history. If the transcript does not contain the answer, say that. Be concise, cite speaker labels and rough timestamps when useful, and do not invent details.
+                """
+            ),
+            OpenRouterClient.Message(
+                role: "user",
+                content: """
+                Transcript:
+                \(truncatedTranscriptText(transcript))
+                """
+            )
+        ]
+
+        let recentHistory = history.suffix(12)
+        messages.append(contentsOf: recentHistory.map { message in
+            OpenRouterClient.Message(
+                role: message.role == .user ? "user" : "assistant",
+                content: message.text
+            )
+        })
+        messages.append(OpenRouterClient.Message(role: "user", content: question))
+
+        return messages
+    }
+
+    private func truncatedTranscriptText(_ transcript: [SessionRecord]) -> String {
+        let fullText = formattedTranscript(transcript)
+        let maxCharacters = 80_000
+        guard fullText.count > maxCharacters else { return fullText }
+
+        let halfLimit = maxCharacters / 2
+        let prefix = fullText.prefix(halfLimit)
+        let suffix = fullText.suffix(halfLimit)
+        return "\(prefix)\n\n[Transcript truncated: middle omitted]\n\n\(suffix)"
+    }
+
+    private func formattedTranscript(_ transcript: [SessionRecord]) -> String {
+        transcript.map { record in
+            let timestamp = MeetingDetailPaneFormatters.transcriptTimeFormatter.string(from: record.timestamp)
+            let text = record.cleanedText ?? record.text
+            return "[\(timestamp)] \(record.speaker.displayLabel): \(text)"
+        }
+        .joined(separator: "\n")
+    }
+
+    private func formattedAskConversation() -> String {
+        askMessages.map { message in
+            let label = message.role == .user ? "You" : "OpenOats"
+            return "\(label): \(message.text)"
+        }
+        .joined(separator: "\n\n")
+    }
+
+    private func resetAskConversation() {
+        cancelAskTask()
+        askQuestion = ""
+        askMessages = []
+        askError = nil
+    }
+
+    private func cancelAskTask() {
+        askTask?.cancel()
+        askTask = nil
     }
 
     @ViewBuilder

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -721,6 +721,15 @@ private struct IntelligenceSettingsTab: View {
                             .font(.system(size: 12, design: .monospaced))
 
                         OllamaModelField(modelName: $settings.ollamaLLMModel, baseURL: settings.ollamaBaseURL, placeholder: "e.g. qwen3:8b")
+                    case .lmStudio:
+                        TextField("LM Studio URL", text: $settings.lmStudioBaseURL, prompt: Text("http://localhost:1234"))
+                            .font(.system(size: 12, design: .monospaced))
+
+                        SecureField("API Key (optional)", text: $settings.lmStudioApiKey)
+                            .font(.system(size: 12, design: .monospaced))
+
+                        TextField("Model", text: $settings.lmStudioModel, prompt: Text("e.g. qwen3-8b"))
+                            .font(.system(size: 12, design: .monospaced))
                     case .mlx:
                         TextField("MLX Server URL", text: $settings.mlxBaseURL, prompt: Text("http://localhost:8080"))
                             .font(.system(size: 12, design: .monospaced))
@@ -829,7 +838,7 @@ private struct IntelligenceSettingsTab: View {
                         Text("Optional Ollama model for real-time suggestions. Uses your main model if empty.")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)
-                    case .openAI, .anthropic, .mlx, .openAICompatible:
+                    case .openAI, .anthropic, .lmStudio, .mlx, .openAICompatible:
                         Text("Real-time suggestions currently reuse the active provider model for this provider.")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)

--- a/OpenOats/Sources/OpenOats/Wizard/APIKeyValidator.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/APIKeyValidator.swift
@@ -39,6 +39,33 @@ enum APIKeyValidator {
         }
     }
 
+    /// Validate an AssemblyAI API key by hitting the transcript list endpoint.
+    static func validateAssemblyAIKey(_ key: String) async -> ValidationResult {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .invalid(message: "API key is empty")
+        }
+
+        guard let url = URL(string: "https://api.assemblyai.com/v2/transcript?limit=1") else {
+            return .networkError(message: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue(trimmed, forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 5
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            return validationResult(
+                for: response,
+                authFailureMessage: "This key didn't work - double-check it on assemblyai.com"
+            )
+        } catch {
+            return .networkError(message: "Could not verify - will test when you go online")
+        }
+    }
+
     /// Validate an OpenRouter API key by hitting the models list endpoint.
     static func validateOpenRouterKey(_ key: String) async -> ValidationResult {
         let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/OpenOats/Sources/OpenOats/Wizard/ProviderSetupStepView.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/ProviderSetupStepView.swift
@@ -112,6 +112,8 @@ struct ProviderSetupStepView: View {
                 .foregroundStyle(Color.accentTeal)
             }
 
+            cloudASRKeyField
+
             if viewModel.intent == .fullCopilot {
                 VStack(alignment: .leading, spacing: 6) {
                     Text("Voyage AI key (optional, for knowledge retrieval)")
@@ -142,6 +144,74 @@ struct ProviderSetupStepView: View {
                     .foregroundStyle(Color.accentTeal)
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private var cloudASRKeyField: some View {
+        switch viewModel.recommendation?.transcriptionModel {
+        case .assemblyAI?:
+            VStack(alignment: .leading, spacing: 6) {
+                Text("AssemblyAI API key")
+                    .font(.system(size: 12, weight: .medium))
+
+                Text("Required for the recommended English cloud transcription model.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 8) {
+                    TextField("AssemblyAI API key", text: $viewModel.assemblyAIKeyInput)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12, design: .monospaced))
+
+                    validationIndicator(
+                        isValidating: viewModel.isValidatingAssemblyAI,
+                        result: viewModel.assemblyAIValidation
+                    )
+                }
+
+                validationMessage(result: viewModel.assemblyAIValidation)
+
+                Link(
+                    "Don't have a key? Create one on AssemblyAI",
+                    destination: URL(string: "https://www.assemblyai.com/dashboard/api-keys")!
+                )
+                .font(.system(size: 11))
+                .foregroundStyle(Color.accentTeal)
+            }
+
+        case .elevenLabsScribe?:
+            VStack(alignment: .leading, spacing: 6) {
+                Text("ElevenLabs API key")
+                    .font(.system(size: 12, weight: .medium))
+
+                Text("Required for the recommended multilingual cloud transcription model.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 8) {
+                    TextField("ElevenLabs API key", text: $viewModel.elevenLabsKeyInput)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12, design: .monospaced))
+
+                    validationIndicator(
+                        isValidating: viewModel.isValidatingElevenLabs,
+                        result: viewModel.elevenLabsValidation
+                    )
+                }
+
+                validationMessage(result: viewModel.elevenLabsValidation)
+
+                Link(
+                    "Don't have a key? Create one on ElevenLabs",
+                    destination: URL(string: "https://elevenlabs.io/app/settings/api-keys")!
+                )
+                .font(.system(size: 11))
+                .foregroundStyle(Color.accentTeal)
+            }
+
+        default:
+            EmptyView()
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Wizard/RecommendationEngine.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/RecommendationEngine.swift
@@ -98,17 +98,14 @@ enum RecommendationEngine {
 
     private static func transcriptionConfig(for profile: WizardProfile, ramTier: RAMTier) -> TranscriptionConfig {
         switch profile {
-        case .transcriptEN, .cloudEN, .localENLight, .localENFull:
+        case .transcriptEN, .localENLight, .localENFull:
             return TranscriptionConfig(model: .parakeetV2, locale: "en-US")
+        case .cloudEN:
+            return TranscriptionConfig(model: .assemblyAI, locale: "en-US")
         case .transcriptMulti:
             return TranscriptionConfig(model: .parakeetV3, locale: "")
         case .cloudMulti:
-            switch ramTier {
-            case .low:
-                return TranscriptionConfig(model: .whisperSmall, locale: "")
-            case .high:
-                return TranscriptionConfig(model: .whisperLargeV3Turbo, locale: "")
-            }
+            return TranscriptionConfig(model: .elevenLabsScribe, locale: "")
         case .localMultiLight:
             return TranscriptionConfig(model: .whisperSmall, locale: "")
         case .localMultiFull:

--- a/OpenOats/Sources/OpenOats/Wizard/SetupDetector.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/SetupDetector.swift
@@ -14,6 +14,8 @@ actor SetupDetector {
         func modelStatuses() -> [TranscriptionModel: BackendStatus]
         func existingOpenRouterKey() async -> String
         func existingVoyageKey() async -> String
+        func existingAssemblyAIKey() async -> String
+        func existingElevenLabsKey() async -> String
         func fetchOllamaModels() async -> Result<[String], OllamaModelFetcher.FetchError>
     }
 
@@ -64,6 +66,14 @@ actor SetupDetector {
             await MainActor.run { settings.voyageApiKey }
         }
 
+        func existingAssemblyAIKey() async -> String {
+            await MainActor.run { settings.assemblyAIApiKey }
+        }
+
+        func existingElevenLabsKey() async -> String {
+            await MainActor.run { settings.elevenLabsApiKey }
+        }
+
         nonisolated func fetchOllamaModels() async -> Result<[String], OllamaModelFetcher.FetchError> {
             await OllamaModelFetcher.fetchModels(baseURL: "http://localhost:11434")
         }
@@ -85,12 +95,16 @@ actor SetupDetector {
 
         async let openRouterKey = deps.existingOpenRouterKey()
         async let voyageKey = deps.existingVoyageKey()
+        async let assemblyAIKey = deps.existingAssemblyAIKey()
+        async let elevenLabsKey = deps.existingElevenLabsKey()
         let ollamaResult = await withTimeoutResult(seconds: 3.0) {
             await self.deps.fetchOllamaModels()
         }
 
         let resolvedOpenRouterKey = await openRouterKey
         let resolvedVoyageKey = await voyageKey
+        let resolvedAssemblyAIKey = await assemblyAIKey
+        let resolvedElevenLabsKey = await elevenLabsKey
 
         return SetupSnapshot(
             physicalMemoryBytes: ram,
@@ -100,8 +114,12 @@ actor SetupDetector {
             modelStatuses: modelStatuses,
             hasOpenRouterKey: !resolvedOpenRouterKey.isEmpty,
             hasVoyageKey: !resolvedVoyageKey.isEmpty,
+            hasAssemblyAIKey: !resolvedAssemblyAIKey.isEmpty,
+            hasElevenLabsKey: !resolvedElevenLabsKey.isEmpty,
             existingOpenRouterKey: resolvedOpenRouterKey,
             existingVoyageKey: resolvedVoyageKey,
+            existingAssemblyAIKey: resolvedAssemblyAIKey,
+            existingElevenLabsKey: resolvedElevenLabsKey,
             ollamaResult: ollamaResult
         )
     }

--- a/OpenOats/Sources/OpenOats/Wizard/SetupSnapshot.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/SetupSnapshot.swift
@@ -35,11 +35,23 @@ struct SetupSnapshot: Sendable {
     /// Whether a Voyage AI API key was found in existing settings.
     let hasVoyageKey: Bool
 
+    /// Whether an AssemblyAI API key was found in existing settings.
+    let hasAssemblyAIKey: Bool
+
+    /// Whether an ElevenLabs API key was found in existing settings.
+    let hasElevenLabsKey: Bool
+
     /// Existing OpenRouter API key value for pre-populating fields.
     let existingOpenRouterKey: String
 
     /// Existing Voyage AI API key value for pre-populating fields.
     let existingVoyageKey: String
+
+    /// Existing AssemblyAI API key value for pre-populating fields.
+    let existingAssemblyAIKey: String
+
+    /// Existing ElevenLabs API key value for pre-populating fields.
+    let existingElevenLabsKey: String
 
     /// Ollama probe result.
     let ollamaResult: Result<[String], OllamaModelFetcher.FetchError>
@@ -98,8 +110,12 @@ struct SetupSnapshot: Sendable {
         modelStatuses: [:],
         hasOpenRouterKey: false,
         hasVoyageKey: false,
+        hasAssemblyAIKey: false,
+        hasElevenLabsKey: false,
         existingOpenRouterKey: "",
         existingVoyageKey: "",
+        existingAssemblyAIKey: "",
+        existingElevenLabsKey: "",
         ollamaResult: .failure(.networkError("not probed"))
     )
 }

--- a/OpenOats/Sources/OpenOats/Wizard/WizardViewModel.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/WizardViewModel.swift
@@ -81,6 +81,36 @@ final class WizardViewModel {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _assemblyAIKeyInput = ""
+    var assemblyAIKeyInput: String {
+        get { access(keyPath: \.assemblyAIKeyInput); return _assemblyAIKeyInput }
+        set {
+            withMutation(keyPath: \.assemblyAIKeyInput) { _assemblyAIKeyInput = newValue }
+            if !newValue.isEmpty {
+                validateAssemblyAIKey()
+            } else {
+                assemblyAIValidationTask?.cancel()
+                assemblyAIValidation = nil
+                isValidatingAssemblyAI = false
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _elevenLabsKeyInput = ""
+    var elevenLabsKeyInput: String {
+        get { access(keyPath: \.elevenLabsKeyInput); return _elevenLabsKeyInput }
+        set {
+            withMutation(keyPath: \.elevenLabsKeyInput) { _elevenLabsKeyInput = newValue }
+            if !newValue.isEmpty {
+                validateElevenLabsKey()
+            } else {
+                elevenLabsValidationTask?.cancel()
+                elevenLabsValidation = nil
+                isValidatingElevenLabs = false
+            }
+        }
+    }
+
     // MARK: - Validation State
 
     @ObservationIgnored nonisolated(unsafe) private var _openRouterValidation: APIKeyValidator.ValidationResult?
@@ -95,6 +125,18 @@ final class WizardViewModel {
         set { withMutation(keyPath: \.voyageValidation) { _voyageValidation = newValue } }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _assemblyAIValidation: APIKeyValidator.ValidationResult?
+    var assemblyAIValidation: APIKeyValidator.ValidationResult? {
+        get { access(keyPath: \.assemblyAIValidation); return _assemblyAIValidation }
+        set { withMutation(keyPath: \.assemblyAIValidation) { _assemblyAIValidation = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _elevenLabsValidation: APIKeyValidator.ValidationResult?
+    var elevenLabsValidation: APIKeyValidator.ValidationResult? {
+        get { access(keyPath: \.elevenLabsValidation); return _elevenLabsValidation }
+        set { withMutation(keyPath: \.elevenLabsValidation) { _elevenLabsValidation = newValue } }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _isValidatingOpenRouter = false
     var isValidatingOpenRouter: Bool {
         get { access(keyPath: \.isValidatingOpenRouter); return _isValidatingOpenRouter }
@@ -105,6 +147,18 @@ final class WizardViewModel {
     var isValidatingVoyage: Bool {
         get { access(keyPath: \.isValidatingVoyage); return _isValidatingVoyage }
         set { withMutation(keyPath: \.isValidatingVoyage) { _isValidatingVoyage = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _isValidatingAssemblyAI = false
+    var isValidatingAssemblyAI: Bool {
+        get { access(keyPath: \.isValidatingAssemblyAI); return _isValidatingAssemblyAI }
+        set { withMutation(keyPath: \.isValidatingAssemblyAI) { _isValidatingAssemblyAI = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _isValidatingElevenLabs = false
+    var isValidatingElevenLabs: Bool {
+        get { access(keyPath: \.isValidatingElevenLabs); return _isValidatingElevenLabs }
+        set { withMutation(keyPath: \.isValidatingElevenLabs) { _isValidatingElevenLabs = newValue } }
     }
 
     // MARK: - Ollama State
@@ -189,6 +243,8 @@ final class WizardViewModel {
 
     private var openRouterValidationTask: Task<Void, Never>?
     private var voyageValidationTask: Task<Void, Never>?
+    private var assemblyAIValidationTask: Task<Void, Never>?
+    private var elevenLabsValidationTask: Task<Void, Never>?
 
     // MARK: - Initialization
 
@@ -208,6 +264,12 @@ final class WizardViewModel {
         }
         if !snapshot.existingVoyageKey.isEmpty {
             voyageKeyInput = snapshot.existingVoyageKey
+        }
+        if !snapshot.existingAssemblyAIKey.isEmpty {
+            assemblyAIKeyInput = snapshot.existingAssemblyAIKey
+        }
+        if !snapshot.existingElevenLabsKey.isEmpty {
+            elevenLabsKeyInput = snapshot.existingElevenLabsKey
         }
 
         if isReconfiguration, let currentSettings {
@@ -234,7 +296,12 @@ final class WizardViewModel {
             if recommendation.profile.isCloud {
                 let openRouterValid = openRouterValidation == .valid || openRouterValidation?.isNetworkError == true
                 let voyageValid = voyageKeyInput.isEmpty || voyageValidation == .valid || voyageValidation?.isNetworkError == true
-                return !openRouterKeyInput.isEmpty && openRouterValid && voyageValid
+                let asrKeyValid = cloudASRKeyValidation == .valid || cloudASRKeyValidation?.isNetworkError == true
+                return !openRouterKeyInput.isEmpty
+                    && openRouterValid
+                    && voyageValid
+                    && !cloudASRKeyInput.isEmpty
+                    && asrKeyValid
             }
             if recommendation.profile.isLocal {
                 return ollamaStatus == .readyWithModels
@@ -322,6 +389,39 @@ final class WizardViewModel {
         return .cloud
     }
 
+    var requiredCloudASRProviderName: String? {
+        switch recommendation?.transcriptionModel {
+        case .assemblyAI?:
+            return "AssemblyAI"
+        case .elevenLabsScribe?:
+            return "ElevenLabs"
+        default:
+            return nil
+        }
+    }
+
+    private var cloudASRKeyInput: String {
+        switch recommendation?.transcriptionModel {
+        case .assemblyAI?:
+            return assemblyAIKeyInput
+        case .elevenLabsScribe?:
+            return elevenLabsKeyInput
+        default:
+            return ""
+        }
+    }
+
+    private var cloudASRKeyValidation: APIKeyValidator.ValidationResult? {
+        switch recommendation?.transcriptionModel {
+        case .assemblyAI?:
+            return assemblyAIValidation
+        case .elevenLabsScribe?:
+            return elevenLabsValidation
+        default:
+            return nil
+        }
+    }
+
     // MARK: - API Key Validation
 
     private func validateOpenRouterKey() {
@@ -355,6 +455,40 @@ final class WizardViewModel {
 
             self.voyageValidation = result
             self.isValidatingVoyage = false
+        }
+    }
+
+    private func validateAssemblyAIKey() {
+        assemblyAIValidationTask?.cancel()
+        isValidatingAssemblyAI = true
+        assemblyAIValidation = nil
+
+        assemblyAIValidationTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled, let self else { return }
+
+            let result = await APIKeyValidator.validateAssemblyAIKey(self.assemblyAIKeyInput)
+            guard !Task.isCancelled else { return }
+
+            self.assemblyAIValidation = result
+            self.isValidatingAssemblyAI = false
+        }
+    }
+
+    private func validateElevenLabsKey() {
+        elevenLabsValidationTask?.cancel()
+        isValidatingElevenLabs = true
+        elevenLabsValidation = nil
+
+        elevenLabsValidationTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled, let self else { return }
+
+            let result = await APIKeyValidator.validateElevenLabsKey(self.elevenLabsKeyInput)
+            guard !Task.isCancelled else { return }
+
+            self.elevenLabsValidation = result
+            self.isValidatingElevenLabs = false
         }
     }
 
@@ -456,6 +590,16 @@ final class WizardViewModel {
         if intent == .fullCopilot, recommendation.profile.isCloud {
             settings.voyageApiKey = voyageKeyInput
         }
+        switch recommendation.transcriptionModel {
+        case .assemblyAI:
+            settings.assemblyAIApiKey = assemblyAIKeyInput
+            settings.elevenLabsApiKey = ""
+        case .elevenLabsScribe:
+            settings.elevenLabsApiKey = elevenLabsKeyInput
+            settings.assemblyAIApiKey = ""
+        default:
+            break
+        }
 
         settings.suggestionVerbosity = recommendation.suggestionVerbosity
         settings.sidebarMode = recommendation.sidebarMode
@@ -479,6 +623,11 @@ final class WizardViewModel {
             settings.anthropicModel = "claude-sonnet-4-5-20250929"
         }
 
+        if !profile.isCloud {
+            settings.assemblyAIApiKey = ""
+            settings.elevenLabsApiKey = ""
+        }
+
         if !profile.isLocal {
             settings.ollamaBaseURL = "http://localhost:11434"
             settings.ollamaLLMModel = "qwen3:8b"
@@ -499,7 +648,7 @@ final class WizardViewModel {
             hasConfiguredLLM = !settings.openAIApiKey.isEmpty
         case .anthropic:
             hasConfiguredLLM = !settings.anthropicApiKey.isEmpty
-        case .ollama, .mlx, .openAICompatible:
+        case .ollama, .lmStudio, .mlx, .openAICompatible:
             hasConfiguredLLM = true
         }
 
@@ -515,7 +664,7 @@ final class WizardViewModel {
         }
 
         switch settings.llmProvider {
-        case .ollama:
+        case .ollama, .lmStudio:
             privacy = .local
         case .openRouter, .openAI, .anthropic, .mlx, .openAICompatible:
             privacy = .cloud

--- a/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
@@ -22,11 +22,12 @@ final class AppSettingsTests: XCTestCase {
 
     func testLLMProviderAllCases() {
         let cases = LLMProvider.allCases
-        XCTAssertEqual(cases.count, 6)
+        XCTAssertEqual(cases.count, 7)
         XCTAssertTrue(cases.contains(.openRouter))
         XCTAssertTrue(cases.contains(.openAI))
         XCTAssertTrue(cases.contains(.anthropic))
         XCTAssertTrue(cases.contains(.ollama))
+        XCTAssertTrue(cases.contains(.lmStudio))
         XCTAssertTrue(cases.contains(.openAICompatible))
         XCTAssertTrue(cases.contains(.mlx))
     }
@@ -36,6 +37,7 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(LLMProvider.openAI.displayName, "OpenAI")
         XCTAssertEqual(LLMProvider.anthropic.displayName, "Anthropic")
         XCTAssertEqual(LLMProvider.ollama.displayName, "Ollama")
+        XCTAssertEqual(LLMProvider.lmStudio.displayName, "LM Studio")
         XCTAssertEqual(LLMProvider.openAICompatible.displayName, "OpenAI Compatible")
         XCTAssertEqual(LLMProvider.mlx.displayName, "MLX")
     }
@@ -45,6 +47,7 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(LLMProvider.openAI.rawValue, "openAI")
         XCTAssertEqual(LLMProvider.anthropic.rawValue, "anthropic")
         XCTAssertEqual(LLMProvider.ollama.rawValue, "ollama")
+        XCTAssertEqual(LLMProvider.lmStudio.rawValue, "lmStudio")
         XCTAssertEqual(LLMProvider.openAICompatible.rawValue, "openAICompatible")
         XCTAssertEqual(LLMProvider.mlx.rawValue, "mlx")
     }
@@ -52,6 +55,7 @@ final class AppSettingsTests: XCTestCase {
     func testLLMProviderIdentifiable() {
         XCTAssertEqual(LLMProvider.openRouter.id, "openRouter")
         XCTAssertEqual(LLMProvider.ollama.id, "ollama")
+        XCTAssertEqual(LLMProvider.lmStudio.id, "lmStudio")
     }
 
     func testLLMProviderRoundTripFromRawValue() {

--- a/OpenOats/Tests/OpenOatsTests/ElevenLabsScribeBackendTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/ElevenLabsScribeBackendTests.swift
@@ -39,6 +39,59 @@ final class ElevenLabsScribeBackendTests: XCTestCase {
                        "no keyterms part when vocabulary is empty")
     }
 
+    func testDiarizeFlagIsSentOnlyWhenRequested() {
+        let diarizedBody = ElevenLabsScribeBackend.buildMultipartBody(
+            boundary: boundary,
+            wavData: Data(),
+            languageCode: "en",
+            keyterms: [],
+            removeFillerWords: false,
+            diarize: true
+        )
+        let plainBody = ElevenLabsScribeBackend.buildMultipartBody(
+            boundary: boundary,
+            wavData: Data(),
+            languageCode: "en",
+            keyterms: [],
+            removeFillerWords: false,
+            diarize: false
+        )
+
+        XCTAssertEqual(
+            extractMultipartValues(String(data: diarizedBody, encoding: .utf8) ?? "", fieldName: "diarize"),
+            ["true"]
+        )
+        XCTAssertFalse((String(data: plainBody, encoding: .utf8) ?? "").contains("name=\"diarize\""))
+    }
+
+    func testTranscriptResponseBuildsDiarizedSpeakerSegments() throws {
+        let response = """
+        {
+          "text": "Hello there. Yes.",
+          "words": [
+            { "text": "Hello", "start": 0.0, "end": 0.3, "type": "word", "speaker_id": "speaker_0" },
+            { "text": "there", "start": 0.3, "end": 0.7, "type": "word", "speaker_id": "speaker_0" },
+            { "text": ".", "start": 0.7, "end": 0.75, "type": "spacing", "speaker_id": "speaker_0" },
+            { "text": "Yes", "start": 1.0, "end": 1.4, "type": "word", "speaker_id": "speaker_1" },
+            { "text": ".", "start": 1.4, "end": 1.45, "type": "spacing", "speaker_id": "speaker_1" }
+          ]
+        }
+        """
+
+        let result = try ElevenLabsScribeBackend.parseTranscriptResponse(Data(response.utf8))
+
+        XCTAssertEqual(result.text, "Hello there. Yes.")
+        XCTAssertEqual(result.segments.count, 2)
+        XCTAssertEqual(result.segments[0].speaker, .remote(1))
+        XCTAssertEqual(result.segments[0].text, "Hello there.")
+        XCTAssertEqual(result.segments[0].startTime, 0.0)
+        XCTAssertEqual(result.segments[0].endTime, 0.75)
+        XCTAssertEqual(result.segments[1].speaker, .remote(2))
+        XCTAssertEqual(result.segments[1].text, "Yes.")
+        XCTAssertEqual(result.segments[1].startTime, 1.0)
+        XCTAssertEqual(result.segments[1].endTime, 1.45)
+    }
+
     // Extracts values for every multipart part matching `name="<fieldName>"`.
     // Assumes the appendMultipart format used by ElevenLabsScribeBackend:
     //   --<boundary>\r\n

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -981,11 +981,11 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertFalse(plan.shouldRunRecoveryBatch)
     }
 
-    func testAutomaticSilencePauseWaitsForFiveMinutesOfSilence() {
+    func testAutomaticSilenceTimeoutWaitsForFiveMinutesOfSilence() {
         let now = Date()
         let lastActivity = now.addingTimeInterval(-299)
 
-        let evaluation = LiveSessionController.automaticSilencePauseEvaluation(
+        let evaluation = LiveSessionController.automaticSilenceTimeoutEvaluation(
             isRunning: true,
             isRecordingPaused: false,
             audioLevel: 0,
@@ -994,14 +994,14 @@ final class LiveSessionControllerTests: XCTestCase {
         )
 
         XCTAssertEqual(evaluation.lastAudibleActivityAt, lastActivity)
-        XCTAssertFalse(evaluation.shouldPause)
+        XCTAssertFalse(evaluation.shouldStop)
     }
 
-    func testAutomaticSilencePauseTriggersAfterFiveMinutesOfSilence() {
+    func testAutomaticSilenceTimeoutTriggersStopAfterFiveMinutesOfSilence() {
         let now = Date()
         let lastActivity = now.addingTimeInterval(-300)
 
-        let evaluation = LiveSessionController.automaticSilencePauseEvaluation(
+        let evaluation = LiveSessionController.automaticSilenceTimeoutEvaluation(
             isRunning: true,
             isRecordingPaused: false,
             audioLevel: 0,
@@ -1010,14 +1010,14 @@ final class LiveSessionControllerTests: XCTestCase {
         )
 
         XCTAssertEqual(evaluation.lastAudibleActivityAt, lastActivity)
-        XCTAssertTrue(evaluation.shouldPause)
+        XCTAssertTrue(evaluation.shouldStop)
     }
 
-    func testAutomaticSilencePauseResetsOnAudibleActivity() {
+    func testAutomaticSilenceTimeoutResetsOnAudibleActivity() {
         let now = Date()
         let lastActivity = now.addingTimeInterval(-180)
 
-        let evaluation = LiveSessionController.automaticSilencePauseEvaluation(
+        let evaluation = LiveSessionController.automaticSilenceTimeoutEvaluation(
             isRunning: true,
             isRecordingPaused: false,
             audioLevel: LiveSessionController.audibleActivityLevelThreshold,
@@ -1026,14 +1026,14 @@ final class LiveSessionControllerTests: XCTestCase {
         )
 
         XCTAssertEqual(evaluation.lastAudibleActivityAt, now)
-        XCTAssertFalse(evaluation.shouldPause)
+        XCTAssertFalse(evaluation.shouldStop)
     }
 
-    func testAutomaticSilencePauseDoesNotAccrueWhileAlreadyPaused() {
+    func testAutomaticSilenceTimeoutDoesNotAccrueWhileAlreadyPaused() {
         let now = Date()
         let lastActivity = now.addingTimeInterval(-300)
 
-        let evaluation = LiveSessionController.automaticSilencePauseEvaluation(
+        let evaluation = LiveSessionController.automaticSilenceTimeoutEvaluation(
             isRunning: true,
             isRecordingPaused: true,
             audioLevel: 0,
@@ -1042,7 +1042,7 @@ final class LiveSessionControllerTests: XCTestCase {
         )
 
         XCTAssertEqual(evaluation.lastAudibleActivityAt, now)
-        XCTAssertFalse(evaluation.shouldPause)
+        XCTAssertFalse(evaluation.shouldStop)
     }
 
     func testRecordingHealthNoticeWarnsWhenNoAudioDetected() {

--- a/OpenOats/Tests/OpenOatsTests/RecommendationEngineTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/RecommendationEngineTests.swift
@@ -6,6 +6,8 @@ final class RecommendationEngineTests: XCTestCase {
         ram: UInt64 = 16 * 1024 * 1024 * 1024,
         locale: String = "en-US",
         hasOpenRouterKey: Bool = false,
+        hasAssemblyAIKey: Bool = false,
+        hasElevenLabsKey: Bool = false,
         hasVoyageKey: Bool = false,
         ollamaModels: Result<[String], OllamaModelFetcher.FetchError> = .failure(.networkError("not probed"))
     ) -> SetupSnapshot {
@@ -17,8 +19,12 @@ final class RecommendationEngineTests: XCTestCase {
             modelStatuses: [:],
             hasOpenRouterKey: hasOpenRouterKey,
             hasVoyageKey: hasVoyageKey,
+            hasAssemblyAIKey: hasAssemblyAIKey,
+            hasElevenLabsKey: hasElevenLabsKey,
             existingOpenRouterKey: hasOpenRouterKey ? "sk-test" : "",
             existingVoyageKey: hasVoyageKey ? "pa-test" : "",
+            existingAssemblyAIKey: hasAssemblyAIKey ? "aai-test" : "",
+            existingElevenLabsKey: hasElevenLabsKey ? "xi-test" : "",
             ollamaResult: ollamaModels
         )
     }
@@ -65,7 +71,7 @@ final class RecommendationEngineTests: XCTestCase {
         )
 
         XCTAssertEqual(recommendation.profile, .cloudEN)
-        XCTAssertEqual(recommendation.transcriptionModel, .parakeetV2)
+        XCTAssertEqual(recommendation.transcriptionModel, .assemblyAI)
         XCTAssertEqual(recommendation.llmProvider, .openRouter)
         XCTAssertEqual(recommendation.selectedModel, "google/gemini-3-flash-preview")
         XCTAssertEqual(recommendation.realtimeModel, "google/gemini-3.1-flash-lite-preview")
@@ -95,7 +101,7 @@ final class RecommendationEngineTests: XCTestCase {
         )
 
         XCTAssertEqual(recommendation.profile, .cloudMulti)
-        XCTAssertEqual(recommendation.transcriptionModel, .whisperSmall)
+        XCTAssertEqual(recommendation.transcriptionModel, .elevenLabsScribe)
     }
 
     func testCloudMultiHighRAM() {
@@ -107,7 +113,7 @@ final class RecommendationEngineTests: XCTestCase {
         )
 
         XCTAssertEqual(recommendation.profile, .cloudMulti)
-        XCTAssertEqual(recommendation.transcriptionModel, .whisperLargeV3Turbo)
+        XCTAssertEqual(recommendation.transcriptionModel, .elevenLabsScribe)
     }
 
     func testLocalEnglishLowRAM() {

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -150,6 +150,29 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertFalse(store.canAutoGeneratePostMeetingNotes)
     }
 
+    func testLMStudioSettingsUseOpenAICompatibleEndpointAndOptionalKey() {
+        let store = makeStore()
+        store.llmProvider = .lmStudio
+
+        XCTAssertEqual(store.lmStudioBaseURL, "http://localhost:1234")
+        XCTAssertEqual(store.activeNotesModel, "")
+        XCTAssertEqual(store.activeRealtimeModel, "")
+        XCTAssertNil(store.activeLLMApiKey)
+        XCTAssertEqual(store.activeLLMTransport, .chatCompletions)
+        XCTAssertFalse(store.canAutoGeneratePostMeetingNotes)
+
+        store.lmStudioModel = "openai/gpt-oss-20b"
+        XCTAssertEqual(
+            store.activeLLMBaseURL?.absoluteString,
+            "http://localhost:1234/v1/chat/completions"
+        )
+        XCTAssertTrue(store.canAutoGeneratePostMeetingNotes)
+
+        store.lmStudioApiKey = "  lm-studio-test-key  \n"
+        XCTAssertEqual(store.lmStudioApiKey, "lm-studio-test-key")
+        XCTAssertEqual(store.activeLLMApiKey, "lm-studio-test-key")
+    }
+
     func testDefaultEmbeddingProvider() {
         let store = makeStore()
         XCTAssertEqual(store.embeddingProvider, .voyageAI)
@@ -789,7 +812,11 @@ final class SettingsStoreTests: XCTestCase {
         let secretStore = AppSecretStore(
             loadValue: { key in
                 tracker.loadedKeys.append(key)
-                return key == "openRouterApiKey" ? "sk-existing" : nil
+                switch key {
+                case "openRouterApiKey": return "sk-existing"
+                case "lmStudioApiKey": return "lm-existing"
+                default: return nil
+                }
             },
             saveValue: { key, value in
                 tracker.savedValues[key] = value
@@ -812,6 +839,14 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.openRouterApiKey, "sk-updated")
         XCTAssertEqual(tracker.loadedKeys, ["openRouterApiKey"])
         XCTAssertEqual(tracker.savedValues["openRouterApiKey"], "sk-updated")
+
+        XCTAssertEqual(store.lmStudioApiKey, "lm-existing")
+        XCTAssertEqual(tracker.loadedKeys, ["openRouterApiKey", "lmStudioApiKey"])
+
+        store.lmStudioApiKey = " lm-updated "
+        XCTAssertEqual(store.lmStudioApiKey, "lm-updated")
+        XCTAssertEqual(tracker.loadedKeys, ["openRouterApiKey", "lmStudioApiKey"])
+        XCTAssertEqual(tracker.savedValues["lmStudioApiKey"], "lm-updated")
     }
 
     // MARK: - Cloud ASR API Keys

--- a/OpenOats/Tests/OpenOatsTests/SetupDetectorTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SetupDetectorTests.swift
@@ -11,6 +11,8 @@ final class SetupDetectorTests: XCTestCase {
         var modelStatusMap: [TranscriptionModel: BackendStatus] = [:]
         var openRouterKey = ""
         var voyageKey = ""
+        var assemblyAIKey = ""
+        var elevenLabsKey = ""
         var ollamaFetchResult: Result<[String], OllamaModelFetcher.FetchError> = .failure(.networkError("not probed"))
 
         func availableInputDevices() -> [(id: AudioDeviceID, name: String)] {
@@ -31,6 +33,14 @@ final class SetupDetectorTests: XCTestCase {
 
         func existingVoyageKey() async -> String {
             voyageKey
+        }
+
+        func existingAssemblyAIKey() async -> String {
+            assemblyAIKey
+        }
+
+        func existingElevenLabsKey() async -> String {
+            elevenLabsKey
         }
 
         func fetchOllamaModels() async -> Result<[String], OllamaModelFetcher.FetchError> {
@@ -64,14 +74,20 @@ final class SetupDetectorTests: XCTestCase {
         var deps = MockDependencies()
         deps.openRouterKey = "sk-or-test"
         deps.voyageKey = "pa-test"
+        deps.assemblyAIKey = "aai-test"
+        deps.elevenLabsKey = "xi-test"
 
         let detector = SetupDetector(dependencies: deps)
         let snapshot = await detector.detect()
 
         XCTAssertTrue(snapshot.hasOpenRouterKey)
         XCTAssertTrue(snapshot.hasVoyageKey)
+        XCTAssertTrue(snapshot.hasAssemblyAIKey)
+        XCTAssertTrue(snapshot.hasElevenLabsKey)
         XCTAssertEqual(snapshot.existingOpenRouterKey, "sk-or-test")
         XCTAssertEqual(snapshot.existingVoyageKey, "pa-test")
+        XCTAssertEqual(snapshot.existingAssemblyAIKey, "aai-test")
+        XCTAssertEqual(snapshot.existingElevenLabsKey, "xi-test")
     }
 
     func testDetectReturnsOllamaSuccess() async {

--- a/OpenOats/Tests/OpenOatsTests/WizardViewModelTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/WizardViewModelTests.swift
@@ -7,6 +7,8 @@ final class WizardViewModelTests: XCTestCase {
         ram: UInt64 = 16 * 1024 * 1024 * 1024,
         locale: String = "en-US",
         hasOpenRouterKey: Bool = false,
+        hasAssemblyAIKey: Bool = false,
+        hasElevenLabsKey: Bool = false,
         hasVoyageKey: Bool = false,
         ollamaModels: Result<[String], OllamaModelFetcher.FetchError> = .failure(.networkError("no"))
     ) -> SetupSnapshot {
@@ -18,8 +20,12 @@ final class WizardViewModelTests: XCTestCase {
             modelStatuses: [:],
             hasOpenRouterKey: hasOpenRouterKey,
             hasVoyageKey: hasVoyageKey,
+            hasAssemblyAIKey: hasAssemblyAIKey,
+            hasElevenLabsKey: hasElevenLabsKey,
             existingOpenRouterKey: hasOpenRouterKey ? "sk-or-test" : "",
             existingVoyageKey: hasVoyageKey ? "pa-test" : "",
+            existingAssemblyAIKey: hasAssemblyAIKey ? "aai-test" : "",
+            existingElevenLabsKey: hasElevenLabsKey ? "xi-test" : "",
             ollamaResult: ollamaModels
         )
     }
@@ -127,10 +133,17 @@ final class WizardViewModelTests: XCTestCase {
 
     func testExistingKeysPrePopulated() {
         let viewModel = WizardViewModel()
-        viewModel.configure(with: makeSnapshot(hasOpenRouterKey: true, hasVoyageKey: true))
+        viewModel.configure(with: makeSnapshot(
+            hasOpenRouterKey: true,
+            hasAssemblyAIKey: true,
+            hasElevenLabsKey: true,
+            hasVoyageKey: true
+        ))
 
         XCTAssertEqual(viewModel.openRouterKeyInput, "sk-or-test")
         XCTAssertEqual(viewModel.voyageKeyInput, "pa-test")
+        XCTAssertEqual(viewModel.assemblyAIKeyInput, "aai-test")
+        XCTAssertEqual(viewModel.elevenLabsKeyInput, "xi-test")
     }
 
     func testApplySettingsWritesCloudProfile() {
@@ -139,11 +152,14 @@ final class WizardViewModelTests: XCTestCase {
         viewModel.intent = .notes
         viewModel.language = .english
         viewModel.privacy = .cloud
+        viewModel.assemblyAIKeyInput = "aai-new"
 
         viewModel.applySettings(to: store)
 
-        XCTAssertEqual(store.transcriptionModel, .parakeetV2)
+        XCTAssertEqual(store.transcriptionModel, .assemblyAI)
         XCTAssertEqual(store.transcriptionLocale, "en-US")
+        XCTAssertEqual(store.assemblyAIApiKey, "aai-new")
+        XCTAssertEqual(store.elevenLabsApiKey, "")
         XCTAssertEqual(store.llmProvider, .openRouter)
         XCTAssertEqual(store.selectedModel, "google/gemini-3-flash-preview")
         XCTAssertEqual(store.suggestionVerbosity, .balanced)
@@ -187,6 +203,8 @@ final class WizardViewModelTests: XCTestCase {
         let store = makeStore()
         store.openRouterApiKey = "old-key"
         store.voyageApiKey = "old-voyage"
+        store.assemblyAIApiKey = "old-aai"
+        store.elevenLabsApiKey = "old-xi"
 
         let viewModel = makeConfiguredVM()
         viewModel.intent = .notes
@@ -197,6 +215,8 @@ final class WizardViewModelTests: XCTestCase {
 
         XCTAssertEqual(store.openRouterApiKey, "")
         XCTAssertEqual(store.voyageApiKey, "")
+        XCTAssertEqual(store.assemblyAIApiKey, "")
+        XCTAssertEqual(store.elevenLabsApiKey, "")
     }
 
     func testReconfigurationSeedsCurrentSettings() {

--- a/scripts/build_swift_app.sh
+++ b/scripts/build_swift_app.sh
@@ -77,17 +77,18 @@ else
 fi
 
 # Copy SPM resource bundles (needed by swift-transformers for tokenizer fallback configs)
-ARCH=$(uname -m)
-BUNDLE_DIR="$SWIFT_DIR/.build/${ARCH}-apple-macosx/release"
 COPIED_BUNDLES=0
-for bundle in "$BUNDLE_DIR"/*.bundle; do
-  if [[ -d "$bundle" ]]; then
-    cp -R "$bundle" "$APP_DIR/Contents/Resources/"
-    COPIED_BUNDLES=$((COPIED_BUNDLES + 1))
-  fi
-done
+while IFS= read -r -d '' bundle; do
+  bundle_name="$(basename "$bundle")"
+  destination="$APP_DIR/Contents/Resources/$bundle_name"
+  rm -rf "$destination"
+  cp -R "$bundle" "$destination"
+  COPIED_BUNDLES=$((COPIED_BUNDLES + 1))
+done < <(find "$SWIFT_DIR/.build" -path "*/release/*.bundle" -type d -print0)
 if [[ $COPIED_BUNDLES -gt 0 ]]; then
   echo "Copied $COPIED_BUNDLES SPM resource bundle(s)"
+else
+  echo "Warning: no SPM resource bundles found under $SWIFT_DIR/.build"
 fi
 
 # Add PkgInfo

--- a/scripts/package_smoke_check.sh
+++ b/scripts/package_smoke_check.sh
@@ -8,6 +8,7 @@ APP_BINARY="$APP_PATH/Contents/MacOS/OpenOats"
 INFO_PLIST="$APP_PATH/Contents/Info.plist"
 PKGINFO="$APP_PATH/Contents/PkgInfo"
 SPARKLE_FW="$APP_PATH/Contents/Frameworks/Sparkle.framework"
+SWIFT_TRANSFORMERS_HUB_BUNDLE="$APP_PATH/Contents/Resources/swift-transformers_Hub.bundle"
 
 SKIP_SIGN=1 SKIP_INSTALL=1 bash ./scripts/build_swift_app.sh
 
@@ -16,6 +17,9 @@ SKIP_SIGN=1 SKIP_INSTALL=1 bash ./scripts/build_swift_app.sh
 [[ -f "$INFO_PLIST" ]] || { echo "Missing Info.plist at $INFO_PLIST"; exit 1; }
 [[ -f "$PKGINFO" ]] || { echo "Missing PkgInfo at $PKGINFO"; exit 1; }
 [[ -d "$SPARKLE_FW" ]] || { echo "Missing Sparkle framework at $SPARKLE_FW"; exit 1; }
+[[ -d "$SWIFT_TRANSFORMERS_HUB_BUNDLE" ]] || { echo "Missing swift-transformers Hub resource bundle at $SWIFT_TRANSFORMERS_HUB_BUNDLE"; exit 1; }
+[[ -f "$SWIFT_TRANSFORMERS_HUB_BUNDLE/gpt2_tokenizer_config.json" ]] || { echo "Missing GPT-2 tokenizer fallback config"; exit 1; }
+[[ -f "$SWIFT_TRANSFORMERS_HUB_BUNDLE/t5_tokenizer_config.json" ]] || { echo "Missing T5 tokenizer fallback config"; exit 1; }
 
 plutil -lint "$INFO_PLIST"
 


### PR DESCRIPTION
## Summary
- Adds LM Studio as a first-class local LLM provider across settings, onboarding, validation, and LLM routing.
- Adds ElevenLabs diarization parsing so Scribe transcripts preserve speaker-attributed segments.
- Adds an Ask tab for saved transcripts with transcript-scoped Q&A and recent chat context.
- Includes focused tests and packaging fixes for the touched flows.

## Test plan
- `swiftc -frontend -parse OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift`
- `swift test` attempted; blocked by local SwiftPM `.macOS(.v15)` platform resolution error in `OpenOats/Package.swift`.

Closes #615
Closes #630
Closes #523
Closes #646
Closes #650
Closes #645
Closes #647
Closes #605