### PR TITLE
Fix meeting auto-stop never triggering on a live mic (adaptive silence floor)

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -144,7 +144,9 @@ final class LiveSessionController {
            let seconds = TimeInterval(raw), seconds > 0 {
             return seconds
         }
-        if let configured = settings?.silenceTimeoutSeconds {
+        // Read the persisted value so a live recording honors a Settings change
+        // immediately (no app restart), falling back to the in-memory value.
+        if let configured = settings?.persistedSilenceTimeoutSeconds ?? settings?.silenceTimeoutSeconds {
             return TimeInterval(configured)   // 0 == disabled
         }
         return automaticSilenceTimeoutInterval

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -115,13 +115,63 @@ final class LiveSessionController {
         let hasBlockingError: Bool
     }
 
+    /// Persisted state for adaptive silence detection, threaded between
+    /// successive evaluations of the polling loop.
+    struct SilenceTracking: Equatable {
+        var lastAudibleActivityAt: Date?
+        /// Running estimate of the ambient (combined mic + system) audio level.
+        var noiseFloor: Float
+        /// Timestamp of the last sample folded into the floor estimate.
+        var lastSampleAt: Date?
+
+        static let initial = SilenceTracking(lastAudibleActivityAt: nil, noiseFloor: 0, lastSampleAt: nil)
+    }
+
     struct AutomaticSilenceTimeoutEvaluation: Equatable {
-        let lastAudibleActivityAt: Date?
+        let tracking: SilenceTracking
         let shouldStop: Bool
     }
 
     static let automaticSilenceTimeoutInterval: TimeInterval = 300
+
+    /// Effective silence timeout in seconds, applied to every session (manual
+    /// and auto-detected). Resolution order:
+    /// 1. `OPENOATS_SILENCE_TIMEOUT_SECONDS` env override (for testing),
+    /// 2. the user's `silenceTimeoutSeconds` setting (0 disables auto-stop),
+    /// 3. the built-in default.
+    static func effectiveAutomaticSilenceTimeoutInterval(settings: AppSettings?) -> TimeInterval {
+        if let raw = ProcessInfo.processInfo.environment["OPENOATS_SILENCE_TIMEOUT_SECONDS"],
+           let seconds = TimeInterval(raw), seconds > 0 {
+            return seconds
+        }
+        if let configured = settings?.silenceTimeoutSeconds {
+            return TimeInterval(configured)   // 0 == disabled
+        }
+        return automaticSilenceTimeoutInterval
+    }
+
+    /// Absolute lower bound on what counts as "audible". The adaptive floor
+    /// does the real work; this only guards against the dynamic threshold
+    /// collapsing toward zero on a near-silent input. ~ -68 dBFS combined.
     static let audibleActivityLevelThreshold: Float = 0.01
+
+    /// A sample counts as audible activity when it exceeds the estimated
+    /// noise floor by this factor (≈ 8 dB of headroom above ambient). Speech
+    /// typically sits 15–40 dB above the floor, so it clears this comfortably
+    /// while steady mic/room/electrical noise does not.
+    static let audibleActivityMargin: Float = 2.5
+
+    /// Time constant for the noise floor falling toward quieter input. Short,
+    /// so the estimate calibrates to ambient within seconds of going quiet.
+    static let noiseFloorFallTimeConstant: TimeInterval = 5
+
+    /// Time constant for the noise floor rising toward louder input. Long, so
+    /// transient speech bursts barely inflate the floor (asymmetric tracking).
+    static let noiseFloorRiseTimeConstant: TimeInterval = 60
+
+    /// Clamp on the per-sample time delta so a long gap between samples (app
+    /// suspended, debugger paused) can't collapse the floor in a single step.
+    static let noiseFloorMaxSampleInterval: TimeInterval = 5
 
     private(set) var state = LiveSessionState()
 
@@ -131,8 +181,6 @@ final class LiveSessionController {
     private var downloadTask: Task<Void, Never>?
     private var startPreflightTask: Task<Void, Never>?
     private var scratchpadSaveTask: Task<Void, Never>?
-    private var silenceMonitorTask: Task<Void, Never>?
-    private var lastUtteranceAt: Date?
     private var pendingInitialScratchpad: String?
 
     // Tracked-change sentinels
@@ -155,7 +203,7 @@ final class LiveSessionController {
     private var observedPeakAudioLevelSinceStart: Float = 0
     private var observedSystemHasEverCapturedFrames = false
     private var observedMicHasEverCapturedFrames = false
-    private var observedLastAudibleActivityAt: Date?
+    private var observedSilenceTracking: SilenceTracking = .initial
     private var pendingRecoveryDiagnostics: PendingRecoveryDiagnostics?
     private var pendingAutoNotesSessionID: String?
     private var autoGeneratingNotesSessionID: String?
@@ -360,7 +408,7 @@ final class LiveSessionController {
     func toggleRecordingPause() {
         guard let engine = coordinator.transcriptionEngine, engine.isRunning else { return }
         engine.isRecordingPaused.toggle()
-        observedLastAudibleActivityAt = Date()
+        observedSilenceTracking.lastAudibleActivityAt = Date()
     }
 
     /// Update the scratchpad text and schedule a debounced save.
@@ -494,7 +542,6 @@ final class LiveSessionController {
 
     private func handleNewUtterance(_ last: Utterance, settings: AppSettings) {
         container.detectionController?.noteUtterance()
-        lastUtteranceAt = Date()
 
         if settings.enableLiveTranscriptCleanup, let engine = coordinator.liveTranscriptCleaner {
             Task {
@@ -681,43 +728,15 @@ final class LiveSessionController {
                 sessionID: handle.sessionID
             )
 
-            // Start silence monitoring for manual sessions (auto-detected sessions are
-            // already monitored by MeetingDetectionController).
-            let timeoutMinutes = settings.silenceTimeoutMinutes
-            if timeoutMinutes > 0, metadata.detectionContext == nil {
-                startSilenceMonitoring(timeoutMinutes: timeoutMinutes)
-            }
+            // Silence-based auto-stop (manual and auto-detected) is handled by the
+            // adaptive audio-level evaluation in the polling loop; see
+            // updateAutomaticSilenceTimeout(_:settings:).
         }
-    }
-
-    private func startSilenceMonitoring(timeoutMinutes: Int) {
-        silenceMonitorTask?.cancel()
-        lastUtteranceAt = Date()
-        silenceMonitorTask = Task { [weak self] in
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(60))
-                guard !Task.isCancelled, let self else { break }
-                if let last = self.lastUtteranceAt,
-                   Date().timeIntervalSince(last) >= Double(timeoutMinutes) * 60 {
-                    await MainActor.run {
-                        self.coordinator.handle(.userStopped)
-                    }
-                    break
-                }
-            }
-        }
-    }
-
-    private func stopSilenceMonitoring() {
-        silenceMonitorTask?.cancel()
-        silenceMonitorTask = nil
-        lastUtteranceAt = nil
     }
 
     func finalizeCurrentSession(settings: AppSettings?) async {
         // 0. Flush scratchpad
         scratchpadSaveTask?.cancel()
-        stopSilenceMonitoring()
         if let sessionID = _currentSessionID, !state.scratchpadText.isEmpty {
             await coordinator.sessionRepository.saveScratchpad(sessionID: sessionID, text: state.scratchpadText)
         }
@@ -1306,30 +1325,79 @@ final class LiveSessionController {
         return max(0, Int(Date().timeIntervalSince(startedAt)))
     }
 
+    /// Advance the ambient noise floor estimate toward `level` over `dt`
+    /// seconds, falling fast and rising slowly so brief sounds don't inflate it.
+    static func updatedNoiseFloor(current: Float, level: Float, dt: TimeInterval) -> Float {
+        guard dt > 0 else { return current }
+        let tau = level < current ? noiseFloorFallTimeConstant : noiseFloorRiseTimeConstant
+        let alpha = Float(1 - exp(-dt / tau))
+        return current + (level - current) * alpha
+    }
+
+    /// Decide whether a recording should auto-stop after a sustained quiet
+    /// period. Rather than comparing the level to a fixed threshold (which
+    /// fails because a live mic's noise floor sits well above any fixed
+    /// "silence" value), this tracks the ambient floor for *this* mic and
+    /// treats audio as activity only when it rises clearly above that floor.
     static func automaticSilenceTimeoutEvaluation(
         isRunning: Bool,
         isRecordingPaused: Bool,
         audioLevel: Float,
         now: Date,
-        lastAudibleActivityAt: Date?,
+        tracking: SilenceTracking,
         timeoutInterval: TimeInterval = automaticSilenceTimeoutInterval,
-        audibleThreshold: Float = audibleActivityLevelThreshold
+        absoluteAudibleThreshold: Float = audibleActivityLevelThreshold,
+        activityMargin: Float = audibleActivityMargin
     ) -> AutomaticSilenceTimeoutEvaluation {
         guard isRunning else {
-            return AutomaticSilenceTimeoutEvaluation(lastAudibleActivityAt: nil, shouldStop: false)
+            return AutomaticSilenceTimeoutEvaluation(tracking: .initial, shouldStop: false)
         }
 
         guard !isRecordingPaused else {
-            return AutomaticSilenceTimeoutEvaluation(lastAudibleActivityAt: now, shouldStop: false)
+            // Don't accrue silence while paused; keep the floor estimate so it
+            // doesn't have to re-converge on resume.
+            return AutomaticSilenceTimeoutEvaluation(
+                tracking: SilenceTracking(
+                    lastAudibleActivityAt: now,
+                    noiseFloor: tracking.noiseFloor,
+                    lastSampleAt: now
+                ),
+                shouldStop: false
+            )
         }
 
-        if audioLevel >= audibleThreshold {
-            return AutomaticSilenceTimeoutEvaluation(lastAudibleActivityAt: now, shouldStop: false)
+        // Seed the floor with the first observed level so it calibrates to this
+        // mic immediately rather than ramping up from zero.
+        let isFirstSample = tracking.lastSampleAt == nil
+        let dt: TimeInterval = isFirstSample
+            ? 0
+            : min(max(0, now.timeIntervalSince(tracking.lastSampleAt!)), noiseFloorMaxSampleInterval)
+        let priorFloor = isFirstSample ? audioLevel : tracking.noiseFloor
+        let noiseFloor = updatedNoiseFloor(current: priorFloor, level: audioLevel, dt: dt)
+
+        // Audible when the level clearly exceeds the ambient floor (or the
+        // absolute backstop, whichever is higher).
+        let dynamicThreshold = max(absoluteAudibleThreshold, noiseFloor * activityMargin)
+        let isAudible = audioLevel > dynamicThreshold
+
+        if isAudible {
+            return AutomaticSilenceTimeoutEvaluation(
+                tracking: SilenceTracking(
+                    lastAudibleActivityAt: now,
+                    noiseFloor: noiseFloor,
+                    lastSampleAt: now
+                ),
+                shouldStop: false
+            )
         }
 
-        let lastActivity = lastAudibleActivityAt ?? now
+        let lastActivity = tracking.lastAudibleActivityAt ?? now
         return AutomaticSilenceTimeoutEvaluation(
-            lastAudibleActivityAt: lastActivity,
+            tracking: SilenceTracking(
+                lastAudibleActivityAt: lastActivity,
+                noiseFloor: noiseFloor,
+                lastSampleAt: now
+            ),
             shouldStop: now.timeIntervalSince(lastActivity) >= timeoutInterval
         )
     }
@@ -1641,22 +1709,34 @@ final class LiveSessionController {
 
     private func updateAutomaticSilenceTimeout(currentState: LiveSessionState, settings: AppSettings) {
         guard let engine = coordinator.transcriptionEngine else {
-            observedLastAudibleActivityAt = nil
+            observedSilenceTracking = .initial
             return
         }
 
+        let timeout = Self.effectiveAutomaticSilenceTimeoutInterval(settings: settings)
+        guard timeout > 0 else {
+            observedSilenceTracking = .initial
+            return
+        }
         let evaluation = Self.automaticSilenceTimeoutEvaluation(
             isRunning: currentState.isRunning && engine.isRunning,
             isRecordingPaused: engine.isRecordingPaused,
             audioLevel: currentState.audioLevel,
             now: Date(),
-            lastAudibleActivityAt: observedLastAudibleActivityAt
+            tracking: observedSilenceTracking,
+            timeoutInterval: timeout
         )
-        observedLastAudibleActivityAt = evaluation.lastAudibleActivityAt
+        observedSilenceTracking = evaluation.tracking
 
         guard evaluation.shouldStop, !engine.isRecordingPaused else { return }
-        observedLastAudibleActivityAt = nil
-        DiagnosticsSupport.record(category: "meeting", message: "Recording auto-stopped after 5 minutes of silence")
+        observedSilenceTracking = .initial
+        Log.meetingDetection.notice(
+            "Auto-stopping after \(Int(timeout), privacy: .public)s of silence (noise floor \(evaluation.tracking.noiseFloor, privacy: .public))"
+        )
+        DiagnosticsSupport.record(
+            category: "meeting",
+            message: "Recording auto-stopped after \(Int(timeout))s of silence (noise floor \(String(format: "%.3f", Double(evaluation.tracking.noiseFloor))))"
+        )
         stopSession(settings: settings)
     }
 }

--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -259,16 +259,19 @@ final class MeetingDetectionController {
 
         silenceCheckTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(60))
+                let timeoutSeconds = self?.activeSettings?.silenceTimeoutSeconds ?? 900
+                guard timeoutSeconds > 0 else { return }
+                // Poll frequently enough to honor sub-minute timeouts.
+                let pollInterval = max(1, min(timeoutSeconds, 15))
+                try? await Task.sleep(for: .seconds(pollInterval))
                 guard !Task.isCancelled else { break }
                 guard let self else { break }
 
-                let timeoutMinutes = self.activeSettings?.silenceTimeoutMinutes ?? 15
                 if let lastUtterance = self.lastUtteranceAt {
                     let elapsed = Date().timeIntervalSince(lastUtterance)
-                    if elapsed >= Double(timeoutMinutes) * 60.0 {
+                    if elapsed >= Double(timeoutSeconds) {
                         if self.activeSettings?.detectionLogEnabled == true {
-                            Log.meetingDetection.info("Silence timeout (\(timeoutMinutes, privacy: .public)m), stopping")
+                            Log.meetingDetection.info("Silence timeout (\(timeoutSeconds, privacy: .public)s), stopping")
                         }
                         self.eventContinuation.yield(.silenceTimeout)
                         break

--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -259,7 +259,8 @@ final class MeetingDetectionController {
 
         silenceCheckTask = Task { [weak self] in
             while !Task.isCancelled {
-                let timeoutSeconds = self?.activeSettings?.silenceTimeoutSeconds ?? 900
+                let timeoutSeconds = self?.activeSettings?.persistedSilenceTimeoutSeconds
+                    ?? self?.activeSettings?.silenceTimeoutSeconds ?? 900
                 guard timeoutSeconds > 0 else { return }
                 // Poll frequently enough to honor sub-minute timeouts.
                 let pollInterval = max(1, min(timeoutSeconds, 15))

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -807,6 +807,16 @@ final class SettingsStore {
         }
     }
 
+    /// The silence timeout read straight from persistent storage, bypassing the
+    /// in-memory cache. A long-running recording reads this every poll so that a
+    /// change made in the Settings window takes effect immediately, even if the
+    /// session happens to hold a different `SettingsStore` instance than the UI.
+    var persistedSilenceTimeoutSeconds: Int? {
+        defaults.object(forKey: "silenceTimeoutSeconds") != nil
+            ? defaults.integer(forKey: "silenceTimeoutSeconds")
+            : nil
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _silenceTimeoutUnitIsSeconds: Bool
     /// UI display preference for the silence timeout: true shows seconds, false minutes.
     var silenceTimeoutUnitIsSeconds: Bool {

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -794,13 +794,27 @@ final class SettingsStore {
         }
     }
 
-    @ObservationIgnored nonisolated(unsafe) private var _silenceTimeoutMinutes: Int
-    var silenceTimeoutMinutes: Int {
-        get { access(keyPath: \.silenceTimeoutMinutes); return _silenceTimeoutMinutes }
+    @ObservationIgnored nonisolated(unsafe) private var _silenceTimeoutSeconds: Int
+    /// Auto-stop a recording after this many seconds of silence. 0 disables it.
+    /// Applies to both manual and auto-detected sessions.
+    var silenceTimeoutSeconds: Int {
+        get { access(keyPath: \.silenceTimeoutSeconds); return _silenceTimeoutSeconds }
         set {
-            withMutation(keyPath: \.silenceTimeoutMinutes) {
-                _silenceTimeoutMinutes = newValue
-                defaults.set(newValue, forKey: "silenceTimeoutMinutes")
+            withMutation(keyPath: \.silenceTimeoutSeconds) {
+                _silenceTimeoutSeconds = max(0, newValue)
+                defaults.set(_silenceTimeoutSeconds, forKey: "silenceTimeoutSeconds")
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _silenceTimeoutUnitIsSeconds: Bool
+    /// UI display preference for the silence timeout: true shows seconds, false minutes.
+    var silenceTimeoutUnitIsSeconds: Bool {
+        get { access(keyPath: \.silenceTimeoutUnitIsSeconds); return _silenceTimeoutUnitIsSeconds }
+        set {
+            withMutation(keyPath: \.silenceTimeoutUnitIsSeconds) {
+                _silenceTimeoutUnitIsSeconds = newValue
+                defaults.set(newValue, forKey: "silenceTimeoutUnitIsSeconds")
             }
         }
     }
@@ -1435,8 +1449,19 @@ final class SettingsStore {
         }
         self._customMeetingAppBundleIDs = defaults.stringArray(forKey: "customMeetingAppBundleIDs") ?? []
         self._ignoredAppBundleIDs = defaults.stringArray(forKey: "ignoredAppBundleIDs") ?? []
-        self._silenceTimeoutMinutes = defaults.object(forKey: "silenceTimeoutMinutes") != nil
-            ? defaults.integer(forKey: "silenceTimeoutMinutes") : 15
+        // Canonical timeout is seconds; migrate from the legacy minutes key.
+        let silenceSeconds: Int
+        if defaults.object(forKey: "silenceTimeoutSeconds") != nil {
+            silenceSeconds = defaults.integer(forKey: "silenceTimeoutSeconds")
+        } else if defaults.object(forKey: "silenceTimeoutMinutes") != nil {
+            silenceSeconds = defaults.integer(forKey: "silenceTimeoutMinutes") * 60
+        } else {
+            silenceSeconds = 900
+        }
+        self._silenceTimeoutSeconds = silenceSeconds
+        self._silenceTimeoutUnitIsSeconds = defaults.object(forKey: "silenceTimeoutUnitIsSeconds") != nil
+            ? defaults.bool(forKey: "silenceTimeoutUnitIsSeconds")
+            : (silenceSeconds < 60)
         self._detectionLogEnabled = defaults.bool(forKey: "detectionLogEnabled")
         self._diagnosticLoggingEnabled = defaults.bool(forKey: "diagnosticLoggingEnabled")
         self._hasShownAutoDetectExplanation = defaults.bool(forKey: "hasShownAutoDetectExplanation")

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -73,6 +73,24 @@ private struct GeneralSettingsTab: View {
     @State private var diagnosticsExportHadError = false
     @State private var diagnosticsExportInFlight = false
 
+    /// Bridges the canonical seconds setting to the value shown in the field,
+    /// converting to/from the user's chosen display unit (seconds vs minutes).
+    private var silenceTimeoutDisplayValue: Binding<Int> {
+        Binding(
+            get: {
+                settings.silenceTimeoutUnitIsSeconds
+                    ? settings.silenceTimeoutSeconds
+                    : settings.silenceTimeoutSeconds / 60
+            },
+            set: { newValue in
+                let clamped = max(0, newValue)
+                settings.silenceTimeoutSeconds = settings.silenceTimeoutUnitIsSeconds
+                    ? clamped
+                    : clamped * 60
+            }
+        )
+    }
+
     var body: some View {
         ScrollView {
             Form {
@@ -181,22 +199,6 @@ private struct GeneralSettingsTab: View {
 
                 if settings.meetingAutoDetectEnabled {
                     DisclosureGroup(isExpanded: $showAdvancedDetection, content: {
-                        HStack {
-                            Text("Silence timeout")
-                                .font(.system(size: 12))
-                            Spacer()
-                            TextField("", value: $settings.silenceTimeoutMinutes, format: .number)
-                                .font(.system(size: 12, design: .monospaced))
-                                .frame(width: 50)
-                                .multilineTextAlignment(.trailing)
-                            Text("min")
-                                .font(.system(size: 12))
-                                .foregroundStyle(.secondary)
-                        }
-                        Text("Auto-detected sessions stop after this many minutes of silence.")
-                            .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
-
                         Toggle("Detection log", isOn: $settings.detectionLogEnabled)
                             .font(.system(size: 12))
                         Text("Print detection events to the system console for debugging.")
@@ -213,6 +215,28 @@ private struct GeneralSettingsTab: View {
                         .padding(.vertical, -10)
                     })
                     .font(.system(size: 12))
+                }
+
+                Section("Auto-Stop on Silence") {
+                    HStack {
+                        Text("Silence timeout")
+                            .font(.system(size: 12))
+                        Spacer()
+                        TextField("", value: silenceTimeoutDisplayValue, format: .number)
+                            .font(.system(size: 12, design: .monospaced))
+                            .frame(width: 50)
+                            .multilineTextAlignment(.trailing)
+                        Picker("", selection: $settings.silenceTimeoutUnitIsSeconds) {
+                            Text("sec").tag(true)
+                            Text("min").tag(false)
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.segmented)
+                        .frame(width: 110)
+                    }
+                    Text("Recordings automatically stop after this much silence — applies to both manual and auto-detected sessions. Set to 0 to disable.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
                 }
 
                 if !settings.ignoredAppBundleIDs.isEmpty {

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -981,68 +981,177 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertFalse(plan.shouldRunRecoveryBatch)
     }
 
+    /// Drive the evaluator over a sequence of constant-level samples at a fixed
+    /// cadence, returning the elapsed time at which it first asks to stop
+    /// (or nil if it never did over `duration`).
+    private func simulateSilenceTimeout(
+        level: Float,
+        duration: TimeInterval,
+        sampleInterval: TimeInterval = 0.25,
+        levelAt: ((TimeInterval) -> Float)? = nil
+    ) -> (firstStopAt: TimeInterval?, finalFloor: Float) {
+        let start = Date()
+        var tracking = LiveSessionController.SilenceTracking.initial
+        var firstStopAt: TimeInterval?
+        var t: TimeInterval = 0
+        while t <= duration {
+            let now = start.addingTimeInterval(t)
+            let evaluation = LiveSessionController.automaticSilenceTimeoutEvaluation(
+                isRunning: true,
+                isRecordingPaused: false,
+                audioLevel: levelAt?(t) ?? level,
+                now: now,
+                tracking: tracking
+            )
+            tracking = evaluation.tracking
+            if evaluation.shouldStop, firstStopAt == nil {
+                firstStopAt = t
+            }
+            t += sampleInterval
+        }
+        return (firstStopAt, tracking.noiseFloor)
+    }
+
     func testAutomaticSilenceTimeoutWaitsForFiveMinutesOfSilence() {
         let now = Date()
-        let lastActivity = now.addingTimeInterval(-299)
+        let tracking = LiveSessionController.SilenceTracking(
+            lastAudibleActivityAt: now.addingTimeInterval(-299),
+            noiseFloor: 0,
+            lastSampleAt: now.addingTimeInterval(-0.25)
+        )
 
         let evaluation = LiveSessionController.automaticSilenceTimeoutEvaluation(
             isRunning: true,
             isRecordingPaused: false,
             audioLevel: 0,
             now: now,
-            lastAudibleActivityAt: lastActivity
+            tracking: tracking
         )
 
-        XCTAssertEqual(evaluation.lastAudibleActivityAt, lastActivity)
+        XCTAssertEqual(evaluation.tracking.lastAudibleActivityAt, tracking.lastAudibleActivityAt)
         XCTAssertFalse(evaluation.shouldStop)
     }
 
     func testAutomaticSilenceTimeoutTriggersStopAfterFiveMinutesOfSilence() {
         let now = Date()
         let lastActivity = now.addingTimeInterval(-300)
+        let tracking = LiveSessionController.SilenceTracking(
+            lastAudibleActivityAt: lastActivity,
+            noiseFloor: 0,
+            lastSampleAt: now.addingTimeInterval(-0.25)
+        )
 
         let evaluation = LiveSessionController.automaticSilenceTimeoutEvaluation(
             isRunning: true,
             isRecordingPaused: false,
             audioLevel: 0,
             now: now,
-            lastAudibleActivityAt: lastActivity
+            tracking: tracking
         )
 
-        XCTAssertEqual(evaluation.lastAudibleActivityAt, lastActivity)
+        XCTAssertEqual(evaluation.tracking.lastAudibleActivityAt, lastActivity)
         XCTAssertTrue(evaluation.shouldStop)
     }
 
     func testAutomaticSilenceTimeoutResetsOnAudibleActivity() {
         let now = Date()
         let lastActivity = now.addingTimeInterval(-180)
+        // Established ambient floor of 0.05 with the timer already part-way.
+        let tracking = LiveSessionController.SilenceTracking(
+            lastAudibleActivityAt: lastActivity,
+            noiseFloor: 0.05,
+            lastSampleAt: now.addingTimeInterval(-0.25)
+        )
 
+        // A clearly-above-floor level (speech) should reset the timer.
         let evaluation = LiveSessionController.automaticSilenceTimeoutEvaluation(
             isRunning: true,
             isRecordingPaused: false,
-            audioLevel: LiveSessionController.audibleActivityLevelThreshold,
+            audioLevel: 0.5,
             now: now,
-            lastAudibleActivityAt: lastActivity
+            tracking: tracking
         )
 
-        XCTAssertEqual(evaluation.lastAudibleActivityAt, now)
+        XCTAssertEqual(evaluation.tracking.lastAudibleActivityAt, now)
         XCTAssertFalse(evaluation.shouldStop)
     }
 
     func testAutomaticSilenceTimeoutDoesNotAccrueWhileAlreadyPaused() {
         let now = Date()
-        let lastActivity = now.addingTimeInterval(-300)
+        let tracking = LiveSessionController.SilenceTracking(
+            lastAudibleActivityAt: now.addingTimeInterval(-300),
+            noiseFloor: 0.05,
+            lastSampleAt: now.addingTimeInterval(-0.25)
+        )
 
         let evaluation = LiveSessionController.automaticSilenceTimeoutEvaluation(
             isRunning: true,
             isRecordingPaused: true,
             audioLevel: 0,
             now: now,
-            lastAudibleActivityAt: lastActivity
+            tracking: tracking
         )
 
-        XCTAssertEqual(evaluation.lastAudibleActivityAt, now)
+        XCTAssertEqual(evaluation.tracking.lastAudibleActivityAt, now)
         XCTAssertFalse(evaluation.shouldStop)
+    }
+
+    // MARK: - Adaptive noise floor
+
+    /// Regression test for the original bug: a live mic's steady noise floor
+    /// (here ~0.06 combined level, well above the old fixed 0.01 threshold)
+    /// must NOT count as audible activity — the session should still auto-stop.
+    func testSteadyMicNoiseFloorStillAutoStops() {
+        let ambient: Float = 0.06
+        // Sanity: this ambient would have defeated the old fixed threshold.
+        XCTAssertGreaterThan(ambient, LiveSessionController.audibleActivityLevelThreshold)
+
+        let result = simulateSilenceTimeout(level: ambient, duration: 360)
+
+        XCTAssertNotNil(result.firstStopAt, "Steady mic noise floor never triggered auto-stop")
+        if let stopAt = result.firstStopAt {
+            // Should stop right around the 5-minute mark, not before.
+            XCTAssertGreaterThanOrEqual(stopAt, 300)
+            XCTAssertLessThan(stopAt, 305)
+        }
+        // Floor should have converged to the ambient level.
+        XCTAssertEqual(result.finalFloor, ambient, accuracy: 0.01)
+    }
+
+    /// A much louder constant tone also calibrates and stops — proving the
+    /// fix is relative to the mic, not tied to any particular absolute level.
+    func testLoudConstantNoiseFloorAlsoAutoStops() {
+        let result = simulateSilenceTimeout(level: 0.3, duration: 360)
+        XCTAssertNotNil(result.firstStopAt)
+        if let stopAt = result.firstStopAt {
+            XCTAssertGreaterThanOrEqual(stopAt, 300)
+            XCTAssertLessThan(stopAt, 305)
+        }
+    }
+
+    /// Periodic speech bursts above the ambient floor must keep the session
+    /// alive indefinitely (no false auto-stop during an active meeting).
+    func testPeriodicSpeechAboveFloorPreventsAutoStop() {
+        let ambient: Float = 0.06
+        let result = simulateSilenceTimeout(level: ambient, duration: 900) { t in
+            // 2s of speech (level 0.5) every 60s, ambient otherwise.
+            (t.truncatingRemainder(dividingBy: 60) < 2) ? 0.5 : ambient
+        }
+        XCTAssertNil(result.firstStopAt, "Active meeting with periodic speech should not auto-stop")
+    }
+
+    func testNoiseFloorFallsFasterThanItRises() {
+        // Falling toward quiet: large move over 5s.
+        let fell = LiveSessionController.updatedNoiseFloor(current: 0.5, level: 0.05, dt: 5)
+        // Rising toward loud: small move over the same 5s.
+        let rose = LiveSessionController.updatedNoiseFloor(current: 0.05, level: 0.5, dt: 5)
+
+        let fallDelta = 0.5 - fell      // how far it dropped
+        let riseDelta = rose - 0.05     // how far it climbed
+        XCTAssertGreaterThan(fallDelta, riseDelta)
+        // Sanity bounds on the asymmetry.
+        XCTAssertGreaterThan(fallDelta, 0.2)
+        XCTAssertLessThan(riseDelta, 0.1)
     }
 
     func testRecordingHealthNoticeWarnsWhenNoAudioDetected() {

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -399,15 +399,38 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertFalse(store.meetingAutoDetectEnabled)
     }
 
-    func testDefaultSilenceTimeoutMinutes() {
+    func testDefaultSilenceTimeoutSeconds() {
         let store = makeStore()
-        XCTAssertEqual(store.silenceTimeoutMinutes, 15)
+        XCTAssertEqual(store.silenceTimeoutSeconds, 900)
     }
 
-    func testSilenceTimeoutMinutesRoundTrip() {
+    func testSilenceTimeoutSecondsRoundTrip() {
         let store = makeStore()
-        store.silenceTimeoutMinutes = 30
-        XCTAssertEqual(store.silenceTimeoutMinutes, 30)
+        store.silenceTimeoutSeconds = 30
+        XCTAssertEqual(store.silenceTimeoutSeconds, 30)
+    }
+
+    func testSilenceTimeoutClampsNegativeToZero() {
+        let store = makeStore()
+        store.silenceTimeoutSeconds = -5
+        XCTAssertEqual(store.silenceTimeoutSeconds, 0)
+    }
+
+    func testSilenceTimeoutMigratesFromLegacyMinutesKey() {
+        let name = "com.openoats.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        // Simulate a user upgrading from the old minutes-based setting.
+        defaults.set(10, forKey: "silenceTimeoutMinutes")
+
+        let store = makeStore(defaults: defaults)
+        XCTAssertEqual(store.silenceTimeoutSeconds, 600)
+    }
+
+    func testSilenceTimeoutUnitRoundTrip() {
+        let store = makeStore()
+        store.silenceTimeoutUnitIsSeconds = true
+        XCTAssertTrue(store.silenceTimeoutUnitIsSeconds)
     }
 
     func testDefaultCustomMeetingAppBundleIDs() {
@@ -784,13 +807,13 @@ final class SettingsStoreTests: XCTestCase {
 
         let store1 = makeStore(defaults: defaults)
         store1.llmProvider = .mlx
-        store1.silenceTimeoutMinutes = 42
+        store1.silenceTimeoutSeconds = 42
         store1.transcriptionModel = .qwen3ASR06B
 
         // Create a second store from the same defaults
         let store2 = makeStore(defaults: defaults)
         XCTAssertEqual(store2.llmProvider, .mlx)
-        XCTAssertEqual(store2.silenceTimeoutMinutes, 42)
+        XCTAssertEqual(store2.silenceTimeoutSeconds, 42)
         XCTAssertEqual(store2.transcriptionModel, .qwen3ASR06B)
     }
 

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -433,6 +433,23 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(store.silenceTimeoutUnitIsSeconds)
     }
 
+    /// A live recording must honor a Settings change immediately. The in-memory
+    /// value can go stale (e.g. a second SettingsStore instance persisted the
+    /// change), so the persisted read is the source of truth.
+    func testPersistedSilenceTimeoutReflectsExternalWrite() {
+        let name = "com.openoats.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+
+        let store = makeStore(defaults: defaults)
+        store.silenceTimeoutSeconds = 30
+        // Simulate another instance (the Settings window) persisting a change.
+        defaults.set(10, forKey: "silenceTimeoutSeconds")
+
+        XCTAssertEqual(store.silenceTimeoutSeconds, 30, "in-memory cache stays at its last set value")
+        XCTAssertEqual(store.persistedSilenceTimeoutSeconds, 10, "persisted read reflects the live change")
+    }
+
     func testDefaultCustomMeetingAppBundleIDs() {
         let store = makeStore()
         XCTAssertEqual(store.customMeetingAppBundleIDs, [])


### PR DESCRIPTION
## Problem

The feature that auto-stops a recording after a meeting ends never fired for manual (press-Start) sessions — recordings would run for hours or days after the meeting was over.

**Root cause:** the last-ditch silence auto-stop in `LiveSessionController` compared the combined audio level against a **fixed `0.01` threshold**. Because mic/system levels are computed as `min(rms * 25, 1.0)`, that threshold corresponds to roughly **−68 dBFS** — below the noise floor of essentially every microphone. A live mic's ambient/electrical noise (measured **~0.08–0.10 / ≈−50 dBFS** on the reporter's hardware) always exceeded the bar, so every poll reset the silence timer and the timeout never elapsed.

Separately, the user-facing **"Silence timeout"** setting applied only to *auto-detected* sessions and was minutes-only, so it didn't cover manual recordings.

## Solution

**Adaptive, per-mic noise floor.** Replace the fixed threshold with a learned ambient floor:
- An asymmetric EMA tracks the noise floor — falls fast toward quiet (τ≈5s), rises slowly (τ≈60s) so speech bursts don't inflate it.
- Audio counts as *activity* only when it exceeds the floor by **2.5×** (~8 dB headroom). Speech sits 15–40 dB above the floor, so it clears easily; steady mic/room/electrical noise does not.
- Calibrates to any mic automatically — no magic absolute number.

**Unified, configurable timeout.**
- The adaptive stop already runs for *every* session in the polling loop, so wiring its timeout to the setting makes the setting apply to **manual and auto-detected** sessions alike. Resolution order: `OPENOATS_SILENCE_TIMEOUT_SECONDS` env (testing) → user setting → default. `0` disables.
- The setting is now stored in **seconds** with a **sec/min** unit picker in a new always-visible **"Auto-Stop on Silence"** section. The legacy `silenceTimeoutMinutes` value is migrated automatically.
- Removed the redundant, coarse (60s-poll) utterance-based manual monitor; the adaptive audio-level stop replaces it.

**Setting takes effect live (no restart).** The timeout is resolved from the *persisted* value (`SettingsStore.persistedSilenceTimeoutSeconds`) rather than the in-memory cache, so a change made in the Settings window is honored by an in-progress recording on the next poll.

> Note / follow-up: the reason the in-memory cache could go stale is that the live session and the Settings window can hold **different `SettingsStore` instances** (app bootstrap can mint more than one). Reading the persisted value sidesteps that here. A separate change to share a **single** `SettingsStore` instance would make *all* settings update live via `@Observable` and let this shim be removed — intentionally left out of this PR to keep the app-wide bootstrap change reviewable on its own.

### Files
- `LiveSessionController.swift` — adaptive floor (`SilenceTracking`, `updatedNoiseFloor`, rewritten `automaticSilenceTimeoutEvaluation`); setting-driven timeout resolved from the persisted value; removed manual utterance monitor; os_log at auto-stop.
- `SettingsStore.swift` — `silenceTimeoutSeconds` + display-unit preference + migration + `persistedSilenceTimeoutSeconds`.
- `SettingsView.swift` — "Auto-Stop on Silence" section with sec/min picker.
- `MeetingDetectionController.swift` — auto-detected monitor ported to seconds with finer poll cadence.

## Validation

**Unit tests** (`swift test` — all passing):
- `testSteadyMicNoiseFloorStillAutoStops` — constant `0.06` ambient (6× the old threshold) now auto-stops around the timeout instead of never. Direct regression test for the bug.
- `testLoudConstantNoiseFloorAlsoAutoStops` — a noisy `0.30` mic also stops (proves it's relative, not absolute).
- `testPeriodicSpeechAboveFloorPreventsAutoStop` — periodic speech over 15 min never false-stops an active meeting.
- `testNoiseFloorFallsFasterThanItRises` — EMA asymmetry.
- `testPersistedSilenceTimeoutReflectsExternalWrite` — persisted read reflects a live change while the in-memory cache stays stale (covers the no-restart fix).
- Settings: seconds default, roundtrip, negative clamp, **legacy-minutes migration**, unit roundtrip.

**Live run:** built and signed the app and exercised it end-to-end:
- With a short timeout, a manual recording auto-stopped after going silent — confirmed via the log:

  ```
  [com.openoats.app:MeetingDetection] Auto-stopping after Ns of silence (noise floor 0.082105)
  ```

  The logged noise floor (`0.082` ≈ −50 dBFS) is the smoking gun: ~8× the old `0.01` threshold, which is exactly why the old logic never stopped.
- Reproduced and verified the no-restart fix: changing the timeout in Settings is honored by the running session without relaunching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
