### PR TITLE
Add Requesty as an LLM provider

### DIFF
--- a/OpenOats/Sources/OpenOats/Intelligence/BatchTextCleaner.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/BatchTextCleaner.swift
@@ -67,6 +67,16 @@ final class BatchTextCleaner {
             baseURL = nil
             model = "openai/gpt-4o-mini"
             transport = settings.activeLLMTransport
+        case .requesty:
+            apiKey = settings.activeLLMApiKey
+            guard let requestyURL = OpenRouterClient.chatCompletionsURL(from: settings.requestyBaseURL) else {
+                error = "Invalid Requesty URL: \(settings.requestyBaseURL)"
+                isCleaningUp = false
+                return records
+            }
+            baseURL = requestyURL
+            model = settings.requestyModel
+            transport = settings.activeLLMTransport
         case .openAI:
             apiKey = settings.activeLLMApiKey
             guard let url = settings.activeLLMBaseURL else {

--- a/OpenOats/Sources/OpenOats/Intelligence/LiveTranscriptCleaner.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/LiveTranscriptCleaner.swift
@@ -98,6 +98,9 @@ actor LiveTranscriptCleaner {
         // Read settings on MainActor
         let provider = await MainActor.run { settings.llmProvider }
         let openRouterKey = await MainActor.run { settings.openRouterApiKey }
+        let requestyKey = await MainActor.run { settings.requestyApiKey }
+        let requestyURL = await MainActor.run { settings.requestyBaseURL }
+        let requestyModelName = await MainActor.run { settings.requestyModel }
         let openAIKey = await MainActor.run { settings.openAIApiKey }
         let openAIURL = await MainActor.run { settings.openAIBaseURL }
         let openAIModel = await MainActor.run { settings.openAIModel }
@@ -120,6 +123,15 @@ actor LiveTranscriptCleaner {
             apiKey = openRouterKey.isEmpty ? nil : openRouterKey
             baseURL = nil
             model = cleanupModel
+            transport = .chatCompletions
+        case .requesty:
+            apiKey = requestyKey.isEmpty ? nil : requestyKey
+            guard let url = OpenRouterClient.chatCompletionsURL(from: requestyURL) else {
+                await markFailed(utterance.id)
+                return
+            }
+            baseURL = url
+            model = requestyModelName
             transport = .chatCompletions
         case .openAI:
             apiKey = openAIKey.isEmpty ? nil : openAIKey

--- a/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
@@ -118,6 +118,17 @@ final class NotesEngine {
             baseURL = nil
             model = settings.selectedModel
             transport = settings.activeLLMTransport
+        case .requesty:
+            apiKey = settings.activeLLMApiKey
+            guard let requestyURL = OpenRouterClient.chatCompletionsURL(from: settings.requestyBaseURL) else {
+                error = "Invalid Requesty URL: \(settings.requestyBaseURL)"
+                isGenerating = false
+                onFinished()
+                return
+            }
+            baseURL = requestyURL
+            model = settings.requestyModel
+            transport = settings.activeLLMTransport
         case .openAI:
             apiKey = settings.activeLLMApiKey
             guard let openAIURL = settings.activeLLMBaseURL else {
@@ -327,7 +338,7 @@ final class NotesEngine {
         switch provider {
         case .ollama, .lmStudio, .mlx:
             return true
-        case .openRouter, .openAI, .anthropic:
+        case .openRouter, .requesty, .openAI, .anthropic:
             return allowCloudCalendarContext
         case .openAICompatible:
             if let baseURL, OpenRouterClient.isLocalHost(baseURL) {

--- a/OpenOats/Sources/OpenOats/Intelligence/SidecastEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SidecastEngine.swift
@@ -385,6 +385,8 @@ final class SidecastEngine {
         switch settings.llmProvider {
         case .openRouter:
             return !settings.openRouterApiKey.isEmpty
+        case .requesty:
+            return !settings.requestyApiKey.isEmpty && llmBaseURL != nil
         case .openAI:
             return !settings.openAIApiKey.isEmpty && llmBaseURL != nil
         case .anthropic:
@@ -397,6 +399,8 @@ final class SidecastEngine {
     private var llmApiKey: String? {
         switch settings.llmProvider {
         case .openRouter: settings.openRouterApiKey
+        case .requesty:
+            settings.requestyApiKey.isEmpty ? nil : settings.requestyApiKey
         case .openAI:
             settings.openAIApiKey.isEmpty ? nil : settings.openAIApiKey
         case .anthropic:
@@ -418,6 +422,8 @@ final class SidecastEngine {
     private var llmBaseURL: URL? {
         switch settings.llmProvider {
         case .openRouter: nil
+        case .requesty:
+            OpenRouterClient.chatCompletionsURL(from: settings.requestyBaseURL)
         case .openAI:
             OpenRouterClient.chatCompletionsURL(from: settings.openAIBaseURL)
         case .anthropic:

--- a/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/SuggestionEngine.swift
@@ -223,6 +223,8 @@ final class SuggestionEngine {
         switch settings.llmProvider {
         case .openRouter:
             guard !settings.openRouterApiKey.isEmpty else { return }
+        case .requesty:
+            guard !settings.requestyApiKey.isEmpty, llmBaseURL(forRealtime: true) != nil else { return }
         case .openAI:
             guard !settings.openAIApiKey.isEmpty, llmBaseURL(forRealtime: true) != nil else { return }
         case .anthropic:
@@ -502,6 +504,7 @@ final class SuggestionEngine {
     private var activePrimaryModel: String {
         switch settings.llmProvider {
         case .openRouter: settings.selectedModel
+        case .requesty: settings.requestyModel
         case .openAI: settings.openAIModel
         case .anthropic: settings.anthropicModel
         case .ollama: settings.ollamaLLMModel
@@ -514,6 +517,8 @@ final class SuggestionEngine {
     private var llmApiKey: String? {
         switch settings.llmProvider {
         case .openRouter: settings.openRouterApiKey
+        case .requesty:
+            settings.requestyApiKey.isEmpty ? nil : settings.requestyApiKey
         case .openAI:
             settings.openAIApiKey.isEmpty ? nil : settings.openAIApiKey
         case .anthropic:
@@ -530,6 +535,8 @@ final class SuggestionEngine {
     private func llmBaseURL(forRealtime: Bool) -> URL? {
         switch settings.llmProvider {
         case .openRouter: return nil
+        case .requesty:
+            return OpenRouterClient.chatCompletionsURL(from: settings.requestyBaseURL)
         case .openAI:
             return OpenRouterClient.chatCompletionsURL(from: settings.openAIBaseURL)
         case .anthropic:

--- a/OpenOats/Sources/OpenOats/Models/SidecastPreset.swift
+++ b/OpenOats/Sources/OpenOats/Models/SidecastPreset.swift
@@ -78,6 +78,7 @@ struct SidecastPreset: Decodable {
     /// Maps debug tool provider strings to app LLMProvider enum values.
     private static let providerMap: [String: LLMProvider] = [
         "openrouter": .openRouter,
+        "requesty": .requesty,
         "openai": .openAI,
         "anthropic": .anthropic,
         "ollama": .ollama,
@@ -95,6 +96,8 @@ struct SidecastPreset: Decodable {
                 switch mapped {
                 case .openRouter:
                     settings.openRouterApiKey = apiKey
+                case .requesty:
+                    settings.requestyApiKey = apiKey
                 case .openAI:
                     settings.openAIApiKey = apiKey
                 case .anthropic:
@@ -112,6 +115,8 @@ struct SidecastPreset: Decodable {
                 switch mapped {
                 case .openAI:
                     settings.openAIBaseURL = baseURL
+                case .requesty:
+                    settings.requestyBaseURL = baseURL
                 case .anthropic:
                     settings.anthropicBaseURL = baseURL
                 case .ollama:
@@ -129,6 +134,8 @@ struct SidecastPreset: Decodable {
                 switch mapped {
                 case .openRouter:
                     settings.realtimeModel = model
+                case .requesty:
+                    settings.requestyModel = model
                 case .openAI:
                     settings.openAIModel = model
                 case .anthropic:

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -81,6 +81,46 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _requestyApiKey: String
+    var requestyApiKey: String {
+        get {
+            access(keyPath: \.requestyApiKey)
+            return loadSecretIfNeeded(key: "requestyApiKey", currentValue: _requestyApiKey) {
+                _requestyApiKey = $0
+            }
+        }
+        set {
+            withMutation(keyPath: \.requestyApiKey) {
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                _requestyApiKey = trimmed
+                markSecretLoaded("requestyApiKey")
+                secretStore.save(key: "requestyApiKey", value: trimmed)
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _requestyBaseURL: String
+    var requestyBaseURL: String {
+        get { access(keyPath: \.requestyBaseURL); return _requestyBaseURL }
+        set {
+            withMutation(keyPath: \.requestyBaseURL) {
+                _requestyBaseURL = newValue
+                defaults.set(newValue, forKey: "requestyBaseURL")
+            }
+        }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _requestyModel: String
+    var requestyModel: String {
+        get { access(keyPath: \.requestyModel); return _requestyModel }
+        set {
+            withMutation(keyPath: \.requestyModel) {
+                _requestyModel = newValue
+                defaults.set(newValue, forKey: "requestyModel")
+            }
+        }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _openAIApiKey: String
     var openAIApiKey: String {
         get {
@@ -1351,6 +1391,9 @@ final class SettingsStore {
         // AI Settings
         self._llmProvider = LLMProvider(rawValue: defaults.string(forKey: "llmProvider") ?? "") ?? .openRouter
         self._openRouterApiKey = ""
+        self._requestyApiKey = ""
+        self._requestyBaseURL = defaults.string(forKey: "requestyBaseURL") ?? "https://router.requesty.ai/v1"
+        self._requestyModel = defaults.string(forKey: "requestyModel") ?? "openai/gpt-4o-mini"
         self._openAIApiKey = ""
         self._openAIBaseURL = defaults.string(forKey: "openAIBaseURL") ?? "https://api.openai.com"
         self._openAIModel = defaults.string(forKey: "openAIModel") ?? "gpt-4.1-mini"
@@ -1575,6 +1618,8 @@ final class SettingsStore {
         switch llmProvider {
         case .openRouter:
             selectedModel
+        case .requesty:
+            requestyModel
         case .openAI:
             openAIModel
         case .anthropic:
@@ -1599,6 +1644,8 @@ final class SettingsStore {
         switch llmProvider {
         case .openRouter:
             return !openRouterApiKey.isEmpty
+        case .requesty:
+            return !requestyApiKey.isEmpty && OpenRouterClient.chatCompletionsURL(from: requestyBaseURL) != nil
         case .openAI:
             return !openAIApiKey.isEmpty && OpenRouterClient.chatCompletionsURL(from: openAIBaseURL) != nil
         case .anthropic:
@@ -1624,6 +1671,7 @@ final class SettingsStore {
     var activeRealtimeModel: String {
         switch llmProvider {
         case .openRouter: return realtimeModel
+        case .requesty: return requestyModel
         case .openAI: return openAIModel
         case .anthropic: return anthropicModel
         case .ollama: return realtimeOllamaModel.isEmpty ? ollamaLLMModel : realtimeOllamaModel
@@ -1641,6 +1689,8 @@ final class SettingsStore {
         switch llmProvider {
         case .openRouter:
             openRouterApiKey.isEmpty ? nil : openRouterApiKey
+        case .requesty:
+            requestyApiKey.isEmpty ? nil : requestyApiKey
         case .openAI:
             openAIApiKey.isEmpty ? nil : openAIApiKey
         case .anthropic:
@@ -1658,6 +1708,8 @@ final class SettingsStore {
         switch llmProvider {
         case .openRouter:
             nil
+        case .requesty:
+            OpenRouterClient.chatCompletionsURL(from: requestyBaseURL)
         case .openAI:
             OpenRouterClient.chatCompletionsURL(from: openAIBaseURL)
         case .anthropic:

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -294,6 +294,7 @@ enum PersonaAvatarTint: String, CaseIterable, Identifiable, Codable {
 
 enum LLMProvider: String, CaseIterable, Identifiable {
     case openRouter
+    case requesty
     case openAI
     case anthropic
     case ollama
@@ -306,6 +307,7 @@ enum LLMProvider: String, CaseIterable, Identifiable {
     var displayName: String {
         switch self {
         case .openRouter: "OpenRouter"
+        case .requesty: "Requesty"
         case .openAI: "OpenAI"
         case .anthropic: "Anthropic"
         case .ollama: "Ollama"

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -722,6 +722,18 @@ private struct IntelligenceSettingsTab: View {
 
                         TextField("Model", text: $settings.selectedModel, prompt: Text("e.g. google/gemini-3-flash-preview"))
                             .font(.system(size: 12, design: .monospaced))
+                    case .requesty:
+                        TextField("Requesty URL", text: $settings.requestyBaseURL, prompt: Text("https://router.requesty.ai/v1"))
+                            .font(.system(size: 12, design: .monospaced))
+
+                        SecureField("Requesty API Key", text: $settings.requestyApiKey)
+                            .font(.system(size: 12, design: .monospaced))
+
+                        TextField("Model", text: $settings.requestyModel, prompt: Text("e.g. openai/gpt-4o-mini"))
+                            .font(.system(size: 12, design: .monospaced))
+
+                        Link("Get API key", destination: URL(string: "https://app.requesty.ai/api-keys")!)
+                            .font(.system(size: 11))
                     case .openAI:
                         TextField("OpenAI URL", text: $settings.openAIBaseURL, prompt: Text("https://api.openai.com"))
                             .font(.system(size: 12, design: .monospaced))
@@ -853,6 +865,12 @@ private struct IntelligenceSettingsTab: View {
                     switch settings.llmProvider {
                     case .openRouter:
                         TextField("Speed Model", text: $settings.realtimeModel, prompt: Text("e.g. google/gemini-2.0-flash-001"))
+                            .font(.system(size: 12, design: .monospaced))
+                        Text("A fast model used for real-time suggestion synthesis. Separate from your main model.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    case .requesty:
+                        TextField("Speed Model", text: $settings.requestyModel, prompt: Text("e.g. openai/gpt-4o-mini"))
                             .font(.system(size: 12, design: .monospaced))
                         Text("A fast model used for real-time suggestion synthesis. Separate from your main model.")
                             .font(.system(size: 11))

--- a/OpenOats/Sources/OpenOats/Wizard/WizardViewModel.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/WizardViewModel.swift
@@ -644,6 +644,8 @@ final class WizardViewModel {
         switch settings.llmProvider {
         case .openRouter:
             hasConfiguredLLM = !settings.openRouterApiKey.isEmpty
+        case .requesty:
+            hasConfiguredLLM = !settings.requestyApiKey.isEmpty
         case .openAI:
             hasConfiguredLLM = !settings.openAIApiKey.isEmpty
         case .anthropic:
@@ -666,7 +668,7 @@ final class WizardViewModel {
         switch settings.llmProvider {
         case .ollama, .lmStudio:
             privacy = .local
-        case .openRouter, .openAI, .anthropic, .mlx, .openAICompatible:
+        case .openRouter, .requesty, .openAI, .anthropic, .mlx, .openAICompatible:
             privacy = .cloud
         }
     }

--- a/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
@@ -22,8 +22,9 @@ final class AppSettingsTests: XCTestCase {
 
     func testLLMProviderAllCases() {
         let cases = LLMProvider.allCases
-        XCTAssertEqual(cases.count, 7)
+        XCTAssertEqual(cases.count, 8)
         XCTAssertTrue(cases.contains(.openRouter))
+        XCTAssertTrue(cases.contains(.requesty))
         XCTAssertTrue(cases.contains(.openAI))
         XCTAssertTrue(cases.contains(.anthropic))
         XCTAssertTrue(cases.contains(.ollama))


### PR DESCRIPTION
Adds `LLMProvider.requesty` as a first-class OpenAI-compatible provider, mirroring the existing OpenRouter provider.

Requesty (https://requesty.ai) is an OpenAI-compatible LLM router — base URL `https://router.requesty.ai/v1`, `provider/model` naming, `Authorization: Bearer` auth.

Changes:
- `Settings/SettingsTypes.swift`: `case requesty` + displayName, plus a `.requesty` arm in every switch over `LLMProvider` (all switches kept exhaustive).
- `Settings/SettingsStore.swift`: keychain-backed `requestyApiKey` (+ base URL / model), mirroring `openRouterApiKey`.
- `Intelligence/*` (SuggestionEngine, SidecastEngine, BatchTextCleaner, LiveTranscriptCleaner, NotesEngine): `.requesty` arms routing through the existing OpenAI-compatible `OpenRouterClient` with the Requesty base URL, default model `openai/gpt-4o-mini` (verified live).
- `Wizard/WizardViewModel.swift`, `Models/SidecastPreset.swift`: provider maps/grouping.
- `Views/SettingsView.swift`: Requesty API-key/URL/model fields + a "Get API key" link to https://app.requesty.ai/api-keys.

Note: I couldn't run `swift build` locally (the package needs Swift 6.2 / a newer SDK than this machine has), so please give it a build — I verified every `switch LLMProvider` now has a `.requesty` arm (exhaustiveness) and the new SettingsStore property mirrors `openRouterApiKey` exactly.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.