### PR TITLE
Add Cohere Arabic transcription support

### DIFF
--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -237,6 +237,24 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _cohereApiKey: String
+    var cohereApiKey: String {
+        get {
+            access(keyPath: \.cohereApiKey)
+            return loadSecretIfNeeded(key: "cohereApiKey", currentValue: _cohereApiKey) {
+                _cohereApiKey = $0
+            }
+        }
+        set {
+            withMutation(keyPath: \.cohereApiKey) {
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                _cohereApiKey = trimmed
+                markSecretLoaded("cohereApiKey")
+                secretStore.save(key: "cohereApiKey", value: trimmed)
+            }
+        }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _ollamaBaseURL: String
     var ollamaBaseURL: String {
         get { access(keyPath: \.ollamaBaseURL); return _ollamaBaseURL }
@@ -1402,6 +1420,7 @@ final class SettingsStore {
         self._anthropicModel = defaults.string(forKey: "anthropicModel") ?? "claude-sonnet-4-5-20250929"
         self._assemblyAIApiKey = ""
         self._elevenLabsApiKey = ""
+        self._cohereApiKey = ""
         self._ollamaBaseURL = defaults.string(forKey: "ollamaBaseURL") ?? "http://localhost:11434"
         self._ollamaLLMModel = defaults.string(forKey: "ollamaLLMModel") ?? "qwen3:8b"
         self._ollamaEmbedModel = defaults.string(forKey: "ollamaEmbedModel") ?? "nomic-embed-text"
@@ -1596,6 +1615,7 @@ final class SettingsStore {
         switch transcriptionModel {
         case .assemblyAI: assemblyAIApiKey
         case .elevenLabsScribe: elevenLabsApiKey
+        case .cohereTranscribeArabic: cohereApiKey
         default: ""
         }
     }

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -344,12 +344,13 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
     case whisperLargeV3Turbo
     case assemblyAI
     case elevenLabsScribe
+    case cohereTranscribeArabic
 
     var id: String { rawValue }
 
     var isCloud: Bool {
         switch self {
-        case .assemblyAI, .elevenLabsScribe: true
+        case .assemblyAI, .elevenLabsScribe, .cohereTranscribeArabic: true
         default: false
         }
     }
@@ -364,6 +365,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         case .whisperLargeV3Turbo: "Whisper Large v3 Turbo"
         case .assemblyAI: "AssemblyAI"
         case .elevenLabsScribe: "ElevenLabs Scribe"
+        case .cohereTranscribeArabic: "Cohere Transcribe Arabic"
         }
     }
 
@@ -381,6 +383,8 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
             "Whisper Large v3 Turbo requires a one-time model download (~800 MB)."
         case .assemblyAI, .elevenLabsScribe:
             "Requires an API key. Enter it in Settings > Transcription."
+        case .cohereTranscribeArabic:
+            "Requires a Cohere API key. Enter it in Settings > Transcription."
         }
     }
 
@@ -392,7 +396,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         case .whisperSmall: 244_000_000
         case .whisperLargeV3Turbo: 800_000_000
         case .parakeetV2, .parakeetV3, .qwen3ASR06B: nil
-        case .assemblyAI, .elevenLabsScribe: nil
+        case .assemblyAI, .elevenLabsScribe, .cohereTranscribeArabic: nil
         }
     }
 
@@ -406,7 +410,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
             "Language Hint"
         case .parakeetV2, .parakeetV3, .whisperBase, .whisperSmall, .whisperLargeV3Turbo:
             "Locale"
-        case .assemblyAI, .elevenLabsScribe:
+        case .assemblyAI, .elevenLabsScribe, .cohereTranscribeArabic:
             "Language Hint"
         }
     }
@@ -427,6 +431,8 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
             "Optional language hint for AssemblyAI. Leave as en-US for English or set to your expected meeting language."
         case .elevenLabsScribe:
             "Optional language hint for ElevenLabs Scribe. Leave empty for auto-detection (recommended for multilingual meetings), or set to a language code like en, fr, de."
+        case .cohereTranscribeArabic:
+            "Use ar for Arabic and Arabic-English code-switching. Use en for English speech with Arabic accents."
         }
     }
 
@@ -450,6 +456,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         case .whisperLargeV3Turbo: return WhisperKitBackend(variant: .largeV3Turbo)
         case .assemblyAI: return AssemblyAIBackend(apiKey: apiKey, customVocabulary: customVocabulary)
         case .elevenLabsScribe: return ElevenLabsScribeBackend(apiKey: apiKey, customVocabulary: customVocabulary, removeFillerWords: removeFillerWords)
+        case .cohereTranscribeArabic: return CohereTranscribeArabicBackend(apiKey: apiKey, customVocabulary: customVocabulary)
         }
     }
 
@@ -461,7 +468,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
             10 * 16_000
         case .parakeetV2, .parakeetV3, .qwen3ASR06B:
             5 * 16_000
-        case .assemblyAI, .elevenLabsScribe:
+        case .assemblyAI, .elevenLabsScribe, .cohereTranscribeArabic:
             10 * 16_000  // 10s - fewer API calls, better accuracy per segment
         }
     }

--- a/OpenOats/Sources/OpenOats/Transcription/CohereTranscribeArabicBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/CohereTranscribeArabicBackend.swift
@@ -1,0 +1,220 @@
+import Foundation
+import os
+
+// MARK: - Cohere Transcribe Arabic Backend
+
+/// Cloud transcription backend using Cohere's audio transcription REST API.
+/// @unchecked Sendable: session and prepared are written once in prepare() before any transcribe() calls.
+final class CohereTranscribeArabicBackend: TranscriptionBackend, @unchecked Sendable {
+    let displayName = "Cohere Transcribe Arabic"
+
+    private struct TranscriptionResponse: Decodable {
+        struct Results: Decodable {
+            struct Transcript: Decodable {
+                let text: String
+            }
+
+            let transcripts: [Transcript]
+        }
+
+        let results: Results
+    }
+
+    private let apiKey: String
+    private let promptTerms: [String]
+    private let session: URLSession
+    private var prepared = false
+
+    private static let modelID = "cohere-transcribe-arabic-07-2026"
+    private static let log = Logger(subsystem: "com.openoats.app", category: "CohereTranscribeArabic")
+
+    // MARK: - Init
+
+    init(apiKey: String, customVocabulary: String = "") {
+        self.apiKey = apiKey
+        self.promptTerms = Self.parsePromptTerms(customVocabulary)
+        self.session = URLSession(configuration: .ephemeral)
+    }
+
+    // MARK: - TranscriptionBackend
+
+    func checkStatus() -> BackendStatus {
+        .ready
+    }
+
+    func prepare(
+        onStatus: @Sendable (String) -> Void,
+        onProgress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+        guard !apiKey.isEmpty else {
+            throw CloudASRError.invalidAPIKey(backend: "Cohere")
+        }
+
+        onStatus("Validating Cohere API key...")
+
+        var request = URLRequest(url: URL(string: "https://api.cohere.com/v1/models")!)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        let (_, response) = try await session.data(for: request)
+        try Self.checkHTTPStatus(response)
+
+        prepared = true
+        Self.log.info("Cohere Transcribe Arabic backend prepared successfully")
+    }
+
+    func transcribe(
+        _ samples: [Float],
+        locale: Locale,
+        previousContext: String? = nil
+    ) async throws -> String {
+        guard prepared else { throw TranscriptionBackendError.notPrepared }
+
+        let wavData = WAVEncoder.encode(samples: samples)
+        let boundary = UUID().uuidString
+        let languageCode = Self.languageCode(for: locale)
+        let prompt = Self.prompt(previousContext: previousContext, terms: promptTerms)
+        let body = Self.buildMultipartBody(
+            boundary: boundary,
+            wavData: wavData,
+            languageCode: languageCode,
+            prompt: prompt
+        )
+
+        var request = URLRequest(url: URL(string: "https://api.cohere.com/v2/audio/transcriptions")!)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+        request.timeoutInterval = 30
+
+        let text: String = try await withTransientRetry { [session] in
+            let (responseData, response) = try await session.data(for: request)
+            try Self.checkHTTPStatus(response)
+            return try Self.parseTranscriptResponse(responseData)
+        }
+
+        Self.log.info("Cohere Transcribe Arabic transcription completed")
+        return text
+    }
+
+    // MARK: - Internal for tests
+
+    static func buildMultipartBody(
+        boundary: String,
+        wavData: Data,
+        languageCode: String,
+        prompt: String?
+    ) -> Data {
+        var body = Data()
+        body.appendMultipart(boundary: boundary, name: "model", value: modelID)
+        body.appendMultipart(boundary: boundary, name: "language", value: languageCode)
+
+        if let prompt,
+           !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            body.appendMultipart(boundary: boundary, name: "prompt", value: prompt)
+        }
+
+        body.appendMultipart(
+            boundary: boundary,
+            name: "file",
+            filename: "audio.wav",
+            contentType: "audio/wav",
+            data: wavData
+        )
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        return body
+    }
+
+    static func parseTranscriptResponse(_ data: Data) throws -> String {
+        let response = try JSONDecoder().decode(TranscriptionResponse.self, from: data)
+        return response.results.transcripts
+            .map { $0.text.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    // MARK: - Private
+
+    private static func checkHTTPStatus(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse,
+              !(200 ..< 300).contains(http.statusCode)
+        else { return }
+
+        if http.statusCode == 401 || http.statusCode == 403 {
+            throw CloudASRError.invalidAPIKey(backend: "Cohere")
+        }
+        throw CloudASRError.httpError(statusCode: http.statusCode)
+    }
+
+    private static func languageCode(for locale: Locale) -> String {
+        let code = locale.language.languageCode?.identifier ?? ""
+        return code.isEmpty ? "ar" : code
+    }
+
+    private static func prompt(previousContext: String?, terms: [String]) -> String? {
+        var parts: [String] = []
+
+        if let previousContext = previousContext?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !previousContext.isEmpty {
+            parts.append("Previous context: \(previousContext)")
+        }
+
+        if !terms.isEmpty {
+            parts.append("Vocabulary: \(terms.joined(separator: ", "))")
+        }
+
+        return parts.isEmpty ? nil : parts.joined(separator: "\n")
+    }
+
+    private static func parsePromptTerms(_ vocabulary: String) -> [String] {
+        let lines = vocabulary.split(separator: "\n", omittingEmptySubsequences: true)
+        var result: [String] = []
+
+        for line in lines {
+            guard result.count < 100 else { break }
+
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { continue }
+
+            if trimmed.contains(":") {
+                let parts = trimmed.split(separator: ":", maxSplits: 1)
+                if let preferred = parts.first?.trimmingCharacters(in: .whitespaces),
+                   !preferred.isEmpty {
+                    result.append(preferred)
+                }
+            } else {
+                result.append(trimmed)
+            }
+        }
+
+        return result
+    }
+}
+
+// MARK: - Multipart Form Data Helpers
+
+private extension Data {
+    mutating func appendMultipart(boundary: String, name: String, value: String) {
+        append("--\(boundary)\r\n".data(using: .utf8)!)
+        append("Content-Disposition: form-data; name=\"\(name)\"\r\n".data(using: .utf8)!)
+        append("\r\n".data(using: .utf8)!)
+        append("\(value)\r\n".data(using: .utf8)!)
+    }
+
+    mutating func appendMultipart(
+        boundary: String,
+        name: String,
+        filename: String,
+        contentType: String,
+        data: Data
+    ) {
+        append("--\(boundary)\r\n".data(using: .utf8)!)
+        append("Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n".data(using: .utf8)!)
+        append("Content-Type: \(contentType)\r\n".data(using: .utf8)!)
+        append("\r\n".data(using: .utf8)!)
+        append(data)
+        append("\r\n".data(using: .utf8)!)
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -382,6 +382,9 @@ private struct TranscriptionSettingsTab: View {
     @State private var isValidatingElevenLabsKey = false
     @State private var elevenLabsValidation: APIKeyValidator.ValidationResult?
     @State private var elevenLabsValidationTask: Task<Void, Never>?
+    @State private var isValidatingCohereKey = false
+    @State private var cohereValidation: APIKeyValidator.ValidationResult?
+    @State private var cohereValidationTask: Task<Void, Never>?
 
     var body: some View {
         ScrollView {
@@ -476,7 +479,7 @@ private struct TranscriptionSettingsTab: View {
                                 scheduleElevenLabsValidation(for: newValue)
                             }
 
-                            apiKeyValidationMessage(result: elevenLabsValidation)
+                            apiKeyValidationMessage(result: elevenLabsValidation, providerName: "ElevenLabs")
 
                             Text("Audio segments are sent to ElevenLabs for transcription. Review their privacy policy at elevenlabs.io/privacy.")
                                 .font(.system(size: 11))
@@ -487,6 +490,30 @@ private struct TranscriptionSettingsTab: View {
                             Text("Strips filler words, false starts, and non-speech sounds server-side before returning the transcript.")
                                 .font(.system(size: 11))
                                 .foregroundStyle(.secondary)
+                        case .cohereTranscribeArabic:
+                            HStack(spacing: 8) {
+                                SecureField("Cohere API Key", text: $settings.cohereApiKey)
+                                    .font(.system(size: 12, design: .monospaced))
+                                    .accessibilityIdentifier("settings.cohereApiKeyField")
+
+                                apiKeyValidationIndicator(
+                                    isValidating: isValidatingCohereKey,
+                                    result: cohereValidation
+                                )
+                            }
+                            .onAppear {
+                                scheduleCohereValidation(for: settings.cohereApiKey)
+                            }
+                            .onChange(of: settings.cohereApiKey) { _, newValue in
+                                scheduleCohereValidation(for: newValue)
+                            }
+
+                            apiKeyValidationMessage(result: cohereValidation, providerName: "Cohere")
+
+                            Text("Audio segments are sent to Cohere for transcription. Cohere Transcribe Arabic does not return provider timestamps or speaker diarization; OpenOats still uses local stream separation and diarization where available.")
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
                         default:
                             EmptyView()
                         }
@@ -542,7 +569,7 @@ private struct TranscriptionSettingsTab: View {
                         )
 
                         Text(
-                            "Boost meeting-specific jargon, names, and product terms. Enter one term per line, or use `Preferred Term: alias one, alias two`. Parakeet: full alias support. AssemblyAI: aliases map to custom spelling. ElevenLabs: terms boost recognition."
+                            "Boost meeting-specific jargon, names, and product terms. Enter one term per line, or use `Preferred Term: alias one, alias two`. Parakeet: full alias support. AssemblyAI: aliases map to custom spelling. ElevenLabs: terms boost recognition. Cohere: preferred terms are sent as prompt guidance."
                         )
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
@@ -605,6 +632,7 @@ private struct TranscriptionSettingsTab: View {
         }
         .onDisappear {
             cancelElevenLabsValidation()
+            cancelCohereValidation()
         }
     }
 
@@ -638,11 +666,11 @@ private struct TranscriptionSettingsTab: View {
     }
 
     @ViewBuilder
-    private func apiKeyValidationMessage(result: APIKeyValidator.ValidationResult?) -> some View {
+    private func apiKeyValidationMessage(result: APIKeyValidator.ValidationResult?, providerName: String) -> some View {
         if let result {
             switch result {
             case .valid:
-                Text("Connected to ElevenLabs")
+                Text("Connected to \(providerName)")
                     .font(.system(size: 11))
                     .foregroundStyle(.green)
             case .invalid(let message):
@@ -687,6 +715,38 @@ private struct TranscriptionSettingsTab: View {
         elevenLabsValidationTask?.cancel()
         elevenLabsValidationTask = nil
         isValidatingElevenLabsKey = false
+    }
+
+    private func scheduleCohereValidation(for key: String) {
+        cohereValidationTask?.cancel()
+
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            cohereValidation = nil
+            isValidatingCohereKey = false
+            return
+        }
+
+        isValidatingCohereKey = true
+        cohereValidation = nil
+        cohereValidationTask = Task {
+            try? await Task.sleep(for: .milliseconds(400))
+            guard !Task.isCancelled else { return }
+
+            let result = await APIKeyValidator.validateCohereKey(trimmed)
+            guard !Task.isCancelled else { return }
+
+            await MainActor.run {
+                cohereValidation = result
+                isValidatingCohereKey = false
+            }
+        }
+    }
+
+    private func cancelCohereValidation() {
+        cohereValidationTask?.cancel()
+        cohereValidationTask = nil
+        isValidatingCohereKey = false
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Wizard/APIKeyValidator.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/APIKeyValidator.swift
@@ -66,6 +66,33 @@ enum APIKeyValidator {
         }
     }
 
+    /// Validate a Cohere API key by hitting the read-only models endpoint.
+    static func validateCohereKey(_ key: String) async -> ValidationResult {
+        let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .invalid(message: "API key is empty")
+        }
+
+        guard let url = URL(string: "https://api.cohere.com/v1/models") else {
+            return .networkError(message: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(trimmed)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 5
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            return validationResult(
+                for: response,
+                authFailureMessage: "This key didn't work - double-check it on dashboard.cohere.com"
+            )
+        } catch {
+            return .networkError(message: "Could not verify - will test when you go online")
+        }
+    }
+
     /// Validate an OpenRouter API key by hitting the models list endpoint.
     static func validateOpenRouterKey(_ key: String) async -> ValidationResult {
         let trimmed = key.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/OpenOats/Sources/OpenOats/Wizard/LanguagePrivacyStepView.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/LanguagePrivacyStepView.swift
@@ -85,7 +85,7 @@ struct LanguagePrivacyStepView: View {
                         )
 
                         if viewModel.privacy == .cloud {
-                            Text("Transcription always stays on your Mac. Cloud notes and summaries send text only. Calendar titles and participant names are included only if you separately enable calendar context for cloud-generated notes.")
+                            Text("Cloud setup may send audio segments for transcription and text to AI services for notes. Calendar titles and participant names are included only if you separately enable calendar context for cloud-generated notes.")
                                 .font(.system(size: 10))
                                 .foregroundStyle(.tertiary)
                                 .padding(.horizontal, 14)

--- a/OpenOats/Sources/OpenOats/Wizard/ProviderSetupStepView.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/ProviderSetupStepView.swift
@@ -210,6 +210,36 @@ struct ProviderSetupStepView: View {
                 .foregroundStyle(Color.accentTeal)
             }
 
+        case .cohereTranscribeArabic?:
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Cohere API key")
+                    .font(.system(size: 12, weight: .medium))
+
+                Text("Required for the recommended Arabic cloud transcription model.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 8) {
+                    TextField("Cohere API key", text: $viewModel.cohereKeyInput)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(size: 12, design: .monospaced))
+
+                    validationIndicator(
+                        isValidating: viewModel.isValidatingCohere,
+                        result: viewModel.cohereValidation
+                    )
+                }
+
+                validationMessage(result: viewModel.cohereValidation)
+
+                Link(
+                    "Don't have a key? Create one on Cohere",
+                    destination: URL(string: "https://dashboard.cohere.com/api-keys")!
+                )
+                .font(.system(size: 11))
+                .foregroundStyle(Color.accentTeal)
+            }
+
         default:
             EmptyView()
         }

--- a/OpenOats/Sources/OpenOats/Wizard/RecommendationEngine.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/RecommendationEngine.swift
@@ -105,7 +105,7 @@ enum RecommendationEngine {
         case .transcriptMulti:
             return TranscriptionConfig(model: .parakeetV3, locale: "")
         case .cloudMulti:
-            return TranscriptionConfig(model: .elevenLabsScribe, locale: "")
+            return TranscriptionConfig(model: .cohereTranscribeArabic, locale: "ar")
         case .localMultiLight:
             return TranscriptionConfig(model: .whisperSmall, locale: "")
         case .localMultiFull:

--- a/OpenOats/Sources/OpenOats/Wizard/SetupDetector.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/SetupDetector.swift
@@ -16,6 +16,7 @@ actor SetupDetector {
         func existingVoyageKey() async -> String
         func existingAssemblyAIKey() async -> String
         func existingElevenLabsKey() async -> String
+        func existingCohereKey() async -> String
         func fetchOllamaModels() async -> Result<[String], OllamaModelFetcher.FetchError>
     }
 
@@ -74,6 +75,10 @@ actor SetupDetector {
             await MainActor.run { settings.elevenLabsApiKey }
         }
 
+        func existingCohereKey() async -> String {
+            await MainActor.run { settings.cohereApiKey }
+        }
+
         nonisolated func fetchOllamaModels() async -> Result<[String], OllamaModelFetcher.FetchError> {
             await OllamaModelFetcher.fetchModels(baseURL: "http://localhost:11434")
         }
@@ -97,6 +102,7 @@ actor SetupDetector {
         async let voyageKey = deps.existingVoyageKey()
         async let assemblyAIKey = deps.existingAssemblyAIKey()
         async let elevenLabsKey = deps.existingElevenLabsKey()
+        async let cohereKey = deps.existingCohereKey()
         let ollamaResult = await withTimeoutResult(seconds: 3.0) {
             await self.deps.fetchOllamaModels()
         }
@@ -105,6 +111,7 @@ actor SetupDetector {
         let resolvedVoyageKey = await voyageKey
         let resolvedAssemblyAIKey = await assemblyAIKey
         let resolvedElevenLabsKey = await elevenLabsKey
+        let resolvedCohereKey = await cohereKey
 
         return SetupSnapshot(
             physicalMemoryBytes: ram,
@@ -116,10 +123,12 @@ actor SetupDetector {
             hasVoyageKey: !resolvedVoyageKey.isEmpty,
             hasAssemblyAIKey: !resolvedAssemblyAIKey.isEmpty,
             hasElevenLabsKey: !resolvedElevenLabsKey.isEmpty,
+            hasCohereKey: !resolvedCohereKey.isEmpty,
             existingOpenRouterKey: resolvedOpenRouterKey,
             existingVoyageKey: resolvedVoyageKey,
             existingAssemblyAIKey: resolvedAssemblyAIKey,
             existingElevenLabsKey: resolvedElevenLabsKey,
+            existingCohereKey: resolvedCohereKey,
             ollamaResult: ollamaResult
         )
     }

--- a/OpenOats/Sources/OpenOats/Wizard/SetupSnapshot.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/SetupSnapshot.swift
@@ -41,6 +41,9 @@ struct SetupSnapshot: Sendable {
     /// Whether an ElevenLabs API key was found in existing settings.
     let hasElevenLabsKey: Bool
 
+    /// Whether a Cohere API key was found in existing settings.
+    let hasCohereKey: Bool
+
     /// Existing OpenRouter API key value for pre-populating fields.
     let existingOpenRouterKey: String
 
@@ -52,6 +55,9 @@ struct SetupSnapshot: Sendable {
 
     /// Existing ElevenLabs API key value for pre-populating fields.
     let existingElevenLabsKey: String
+
+    /// Existing Cohere API key value for pre-populating fields.
+    let existingCohereKey: String
 
     /// Ollama probe result.
     let ollamaResult: Result<[String], OllamaModelFetcher.FetchError>
@@ -112,10 +118,12 @@ struct SetupSnapshot: Sendable {
         hasVoyageKey: false,
         hasAssemblyAIKey: false,
         hasElevenLabsKey: false,
+        hasCohereKey: false,
         existingOpenRouterKey: "",
         existingVoyageKey: "",
         existingAssemblyAIKey: "",
         existingElevenLabsKey: "",
+        existingCohereKey: "",
         ollamaResult: .failure(.networkError("not probed"))
     )
 }

--- a/OpenOats/Sources/OpenOats/Wizard/WizardViewModel.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/WizardViewModel.swift
@@ -111,6 +111,21 @@ final class WizardViewModel {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _cohereKeyInput = ""
+    var cohereKeyInput: String {
+        get { access(keyPath: \.cohereKeyInput); return _cohereKeyInput }
+        set {
+            withMutation(keyPath: \.cohereKeyInput) { _cohereKeyInput = newValue }
+            if !newValue.isEmpty {
+                validateCohereKey()
+            } else {
+                cohereValidationTask?.cancel()
+                cohereValidation = nil
+                isValidatingCohere = false
+            }
+        }
+    }
+
     // MARK: - Validation State
 
     @ObservationIgnored nonisolated(unsafe) private var _openRouterValidation: APIKeyValidator.ValidationResult?
@@ -137,6 +152,12 @@ final class WizardViewModel {
         set { withMutation(keyPath: \.elevenLabsValidation) { _elevenLabsValidation = newValue } }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _cohereValidation: APIKeyValidator.ValidationResult?
+    var cohereValidation: APIKeyValidator.ValidationResult? {
+        get { access(keyPath: \.cohereValidation); return _cohereValidation }
+        set { withMutation(keyPath: \.cohereValidation) { _cohereValidation = newValue } }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _isValidatingOpenRouter = false
     var isValidatingOpenRouter: Bool {
         get { access(keyPath: \.isValidatingOpenRouter); return _isValidatingOpenRouter }
@@ -159,6 +180,12 @@ final class WizardViewModel {
     var isValidatingElevenLabs: Bool {
         get { access(keyPath: \.isValidatingElevenLabs); return _isValidatingElevenLabs }
         set { withMutation(keyPath: \.isValidatingElevenLabs) { _isValidatingElevenLabs = newValue } }
+    }
+
+    @ObservationIgnored nonisolated(unsafe) private var _isValidatingCohere = false
+    var isValidatingCohere: Bool {
+        get { access(keyPath: \.isValidatingCohere); return _isValidatingCohere }
+        set { withMutation(keyPath: \.isValidatingCohere) { _isValidatingCohere = newValue } }
     }
 
     // MARK: - Ollama State
@@ -245,6 +272,7 @@ final class WizardViewModel {
     private var voyageValidationTask: Task<Void, Never>?
     private var assemblyAIValidationTask: Task<Void, Never>?
     private var elevenLabsValidationTask: Task<Void, Never>?
+    private var cohereValidationTask: Task<Void, Never>?
 
     // MARK: - Initialization
 
@@ -270,6 +298,9 @@ final class WizardViewModel {
         }
         if !snapshot.existingElevenLabsKey.isEmpty {
             elevenLabsKeyInput = snapshot.existingElevenLabsKey
+        }
+        if !snapshot.existingCohereKey.isEmpty {
+            cohereKeyInput = snapshot.existingCohereKey
         }
 
         if isReconfiguration, let currentSettings {
@@ -395,6 +426,8 @@ final class WizardViewModel {
             return "AssemblyAI"
         case .elevenLabsScribe?:
             return "ElevenLabs"
+        case .cohereTranscribeArabic?:
+            return "Cohere"
         default:
             return nil
         }
@@ -406,6 +439,8 @@ final class WizardViewModel {
             return assemblyAIKeyInput
         case .elevenLabsScribe?:
             return elevenLabsKeyInput
+        case .cohereTranscribeArabic?:
+            return cohereKeyInput
         default:
             return ""
         }
@@ -417,6 +452,8 @@ final class WizardViewModel {
             return assemblyAIValidation
         case .elevenLabsScribe?:
             return elevenLabsValidation
+        case .cohereTranscribeArabic?:
+            return cohereValidation
         default:
             return nil
         }
@@ -489,6 +526,23 @@ final class WizardViewModel {
 
             self.elevenLabsValidation = result
             self.isValidatingElevenLabs = false
+        }
+    }
+
+    private func validateCohereKey() {
+        cohereValidationTask?.cancel()
+        isValidatingCohere = true
+        cohereValidation = nil
+
+        cohereValidationTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled, let self else { return }
+
+            let result = await APIKeyValidator.validateCohereKey(self.cohereKeyInput)
+            guard !Task.isCancelled else { return }
+
+            self.cohereValidation = result
+            self.isValidatingCohere = false
         }
     }
 
@@ -594,9 +648,15 @@ final class WizardViewModel {
         case .assemblyAI:
             settings.assemblyAIApiKey = assemblyAIKeyInput
             settings.elevenLabsApiKey = ""
+            settings.cohereApiKey = ""
         case .elevenLabsScribe:
             settings.elevenLabsApiKey = elevenLabsKeyInput
             settings.assemblyAIApiKey = ""
+            settings.cohereApiKey = ""
+        case .cohereTranscribeArabic:
+            settings.cohereApiKey = cohereKeyInput
+            settings.assemblyAIApiKey = ""
+            settings.elevenLabsApiKey = ""
         default:
             break
         }
@@ -626,6 +686,7 @@ final class WizardViewModel {
         if !profile.isCloud {
             settings.assemblyAIApiKey = ""
             settings.elevenLabsApiKey = ""
+            settings.cohereApiKey = ""
         }
 
         if !profile.isLocal {

--- a/OpenOats/Tests/OpenOatsTests/APIKeyValidatorTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/APIKeyValidatorTests.swift
@@ -8,6 +8,12 @@ final class APIKeyValidatorTests: XCTestCase {
         XCTAssertEqual(result, .invalid(message: "API key is empty"))
     }
 
+    func testValidateCohereKeyRejectsEmptyKey() async {
+        let result = await APIKeyValidator.validateCohereKey(" \n ")
+
+        XCTAssertEqual(result, .invalid(message: "API key is empty"))
+    }
+
     func testValidationResultTreatsSuccessAsValid() {
         let response = makeResponse(statusCode: 200)
 

--- a/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
@@ -70,7 +70,7 @@ final class AppSettingsTests: XCTestCase {
 
     func testTranscriptionModelAllCases() {
         let cases = TranscriptionModel.allCases
-        XCTAssertEqual(cases.count, 8)
+        XCTAssertEqual(cases.count, 9)
     }
 
     func testTranscriptionModelDisplayNames() {
@@ -79,6 +79,7 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(TranscriptionModel.qwen3ASR06B.displayName, "Qwen3 ASR 0.6B")
         XCTAssertEqual(TranscriptionModel.whisperBase.displayName, "Whisper Base")
         XCTAssertEqual(TranscriptionModel.whisperSmall.displayName, "Whisper Small")
+        XCTAssertEqual(TranscriptionModel.cohereTranscribeArabic.displayName, "Cohere Transcribe Arabic")
     }
 
     func testTranscriptionModelRoundTripFromRawValue() {
@@ -95,6 +96,7 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertTrue(TranscriptionModel.whisperBase.supportsExplicitLanguageHint)
         XCTAssertTrue(TranscriptionModel.whisperSmall.supportsExplicitLanguageHint)
         XCTAssertTrue(TranscriptionModel.whisperLargeV3Turbo.supportsExplicitLanguageHint)
+        XCTAssertTrue(TranscriptionModel.cohereTranscribeArabic.supportsExplicitLanguageHint)
     }
 
     func testTranscriptionModelWhisperVariant() {
@@ -115,6 +117,7 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(TranscriptionModel.qwen3ASR06B.localeFieldTitle, "Language Hint")
         XCTAssertEqual(TranscriptionModel.parakeetV2.localeFieldTitle, "Locale")
         XCTAssertEqual(TranscriptionModel.whisperBase.localeFieldTitle, "Locale")
+        XCTAssertEqual(TranscriptionModel.cohereTranscribeArabic.localeFieldTitle, "Language Hint")
     }
 
     // MARK: - EmbeddingProvider

--- a/OpenOats/Tests/OpenOatsTests/RecommendationEngineTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/RecommendationEngineTests.swift
@@ -8,6 +8,7 @@ final class RecommendationEngineTests: XCTestCase {
         hasOpenRouterKey: Bool = false,
         hasAssemblyAIKey: Bool = false,
         hasElevenLabsKey: Bool = false,
+        hasCohereKey: Bool = false,
         hasVoyageKey: Bool = false,
         ollamaModels: Result<[String], OllamaModelFetcher.FetchError> = .failure(.networkError("not probed"))
     ) -> SetupSnapshot {
@@ -21,10 +22,12 @@ final class RecommendationEngineTests: XCTestCase {
             hasVoyageKey: hasVoyageKey,
             hasAssemblyAIKey: hasAssemblyAIKey,
             hasElevenLabsKey: hasElevenLabsKey,
+            hasCohereKey: hasCohereKey,
             existingOpenRouterKey: hasOpenRouterKey ? "sk-test" : "",
             existingVoyageKey: hasVoyageKey ? "pa-test" : "",
             existingAssemblyAIKey: hasAssemblyAIKey ? "aai-test" : "",
             existingElevenLabsKey: hasElevenLabsKey ? "xi-test" : "",
+            existingCohereKey: hasCohereKey ? "co-test" : "",
             ollamaResult: ollamaModels
         )
     }
@@ -101,7 +104,7 @@ final class RecommendationEngineTests: XCTestCase {
         )
 
         XCTAssertEqual(recommendation.profile, .cloudMulti)
-        XCTAssertEqual(recommendation.transcriptionModel, .elevenLabsScribe)
+        XCTAssertEqual(recommendation.transcriptionModel, .cohereTranscribeArabic)
     }
 
     func testCloudMultiHighRAM() {
@@ -113,7 +116,7 @@ final class RecommendationEngineTests: XCTestCase {
         )
 
         XCTAssertEqual(recommendation.profile, .cloudMulti)
-        XCTAssertEqual(recommendation.transcriptionModel, .elevenLabsScribe)
+        XCTAssertEqual(recommendation.transcriptionModel, .cohereTranscribeArabic)
     }
 
     func testLocalEnglishLowRAM() {

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -901,6 +901,11 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.elevenLabsApiKey, "")
     }
 
+    func testCohereApiKeyDefaultsToEmpty() {
+        let store = makeStore()
+        XCTAssertEqual(store.cohereApiKey, "")
+    }
+
     func testAssemblyAIApiKeyAutoTrimsWhitespace() {
         let store = makeStore()
         store.assemblyAIApiKey = "  sk-test-abc123  \n"
@@ -913,16 +918,26 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.elevenLabsApiKey, "xi-test-abc123")
     }
 
+    func testCohereApiKeyAutoTrimsWhitespace() {
+        let store = makeStore()
+        store.cohereApiKey = "  co-test-abc123  \n"
+        XCTAssertEqual(store.cohereApiKey, "co-test-abc123")
+    }
+
     func testCloudASRApiKeyRoutesCorrectly() {
         let store = makeStore()
         store.assemblyAIApiKey = "aai-key"
         store.elevenLabsApiKey = "el-key"
+        store.cohereApiKey = "co-key"
 
         store.transcriptionModel = .assemblyAI
         XCTAssertEqual(store.cloudASRApiKey, "aai-key")
 
         store.transcriptionModel = .elevenLabsScribe
         XCTAssertEqual(store.cloudASRApiKey, "el-key")
+
+        store.transcriptionModel = .cohereTranscribeArabic
+        XCTAssertEqual(store.cloudASRApiKey, "co-key")
 
         store.transcriptionModel = .parakeetV2
         XCTAssertEqual(store.cloudASRApiKey, "")

--- a/OpenOats/Tests/OpenOatsTests/SetupDetectorTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SetupDetectorTests.swift
@@ -13,6 +13,7 @@ final class SetupDetectorTests: XCTestCase {
         var voyageKey = ""
         var assemblyAIKey = ""
         var elevenLabsKey = ""
+        var cohereKey = ""
         var ollamaFetchResult: Result<[String], OllamaModelFetcher.FetchError> = .failure(.networkError("not probed"))
 
         func availableInputDevices() -> [(id: AudioDeviceID, name: String)] {
@@ -41,6 +42,10 @@ final class SetupDetectorTests: XCTestCase {
 
         func existingElevenLabsKey() async -> String {
             elevenLabsKey
+        }
+
+        func existingCohereKey() async -> String {
+            cohereKey
         }
 
         func fetchOllamaModels() async -> Result<[String], OllamaModelFetcher.FetchError> {
@@ -76,6 +81,7 @@ final class SetupDetectorTests: XCTestCase {
         deps.voyageKey = "pa-test"
         deps.assemblyAIKey = "aai-test"
         deps.elevenLabsKey = "xi-test"
+        deps.cohereKey = "co-test"
 
         let detector = SetupDetector(dependencies: deps)
         let snapshot = await detector.detect()
@@ -84,10 +90,12 @@ final class SetupDetectorTests: XCTestCase {
         XCTAssertTrue(snapshot.hasVoyageKey)
         XCTAssertTrue(snapshot.hasAssemblyAIKey)
         XCTAssertTrue(snapshot.hasElevenLabsKey)
+        XCTAssertTrue(snapshot.hasCohereKey)
         XCTAssertEqual(snapshot.existingOpenRouterKey, "sk-or-test")
         XCTAssertEqual(snapshot.existingVoyageKey, "pa-test")
         XCTAssertEqual(snapshot.existingAssemblyAIKey, "aai-test")
         XCTAssertEqual(snapshot.existingElevenLabsKey, "xi-test")
+        XCTAssertEqual(snapshot.existingCohereKey, "co-test")
     }
 
     func testDetectReturnsOllamaSuccess() async {

--- a/OpenOats/Tests/OpenOatsTests/TranscriptionBackendTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/TranscriptionBackendTests.swift
@@ -226,6 +226,74 @@ final class TranscriptionBackendTests: XCTestCase {
         }
     }
 
+    // MARK: - CohereTranscribeArabicBackend
+
+    func testCohereTranscribeArabicDisplayName() {
+        let backend = CohereTranscribeArabicBackend(apiKey: "test-key")
+        XCTAssertEqual(backend.displayName, "Cohere Transcribe Arabic")
+    }
+
+    func testCohereTranscribeArabicCheckStatusAlwaysReady() {
+        let withKey = CohereTranscribeArabicBackend(apiKey: "test-key")
+        XCTAssertEqual(withKey.checkStatus(), .ready)
+
+        let withoutKey = CohereTranscribeArabicBackend(apiKey: "")
+        XCTAssertEqual(withoutKey.checkStatus(), .ready)
+    }
+
+    func testCohereTranscribeArabicTranscribeWithoutPrepareThrows() async {
+        let backend = CohereTranscribeArabicBackend(apiKey: "test-key")
+        do {
+            _ = try await backend.transcribe([0.0, 0.1, 0.2], locale: Locale(identifier: "ar-SA"))
+            XCTFail("Expected error")
+        } catch is TranscriptionBackendError {
+            // Expected: notPrepared
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testCohereTranscribeArabicParsesTranscriptResponse() throws {
+        let json = """
+        {
+          "id": "tr-123",
+          "status": "completed",
+          "results": {
+            "transcripts": [
+              { "language": "ar", "text": "مرحبا يا فريق", "duration": 1.2, "offset": 0 },
+              { "language": "ar", "text": "كيف الحال", "duration": 1.0, "offset": 1.2 }
+            ]
+          }
+        }
+        """
+
+        let text = try CohereTranscribeArabicBackend.parseTranscriptResponse(Data(json.utf8))
+
+        XCTAssertEqual(text, "مرحبا يا فريق كيف الحال")
+    }
+
+    func testCohereTranscribeArabicMultipartUsesModelLanguagePromptAndFileLast() throws {
+        let body = CohereTranscribeArabicBackend.buildMultipartBody(
+            boundary: "Boundary-Test",
+            wavData: Data("wav-data".utf8),
+            languageCode: "ar",
+            prompt: "OpenOats فريق المنتج"
+        )
+        let bodyText = String(data: body, encoding: .utf8) ?? ""
+
+        XCTAssertTrue(bodyText.contains("name=\"model\""))
+        XCTAssertTrue(bodyText.contains("cohere-transcribe-arabic-07-2026"))
+        XCTAssertTrue(bodyText.contains("name=\"language\""))
+        XCTAssertTrue(bodyText.contains("\r\nar\r\n"))
+        XCTAssertTrue(bodyText.contains("name=\"prompt\""))
+        XCTAssertTrue(bodyText.contains("OpenOats فريق المنتج"))
+
+        let fileRange = try XCTUnwrap(bodyText.range(of: "name=\"file\""))
+        XCTAssertNil(bodyText.range(of: "name=\"model\"", range: fileRange.upperBound..<bodyText.endIndex))
+        XCTAssertNil(bodyText.range(of: "name=\"language\"", range: fileRange.upperBound..<bodyText.endIndex))
+        XCTAssertNil(bodyText.range(of: "name=\"prompt\"", range: fileRange.upperBound..<bodyText.endIndex))
+    }
+
     // MARK: - TranscriptionModel cloud factory
 
     func testMakeBackendAssemblyAI() {
@@ -238,16 +306,23 @@ final class TranscriptionBackendTests: XCTestCase {
         XCTAssertEqual(backend.displayName, "ElevenLabs Scribe")
     }
 
+    func testMakeBackendCohereTranscribeArabic() {
+        let backend = TranscriptionModel.cohereTranscribeArabic.makeBackend(apiKey: "test")
+        XCTAssertEqual(backend.displayName, "Cohere Transcribe Arabic")
+    }
+
     func testCloudModelsNotInBatchSuitable() {
         let batchModels = TranscriptionModel.batchSuitableModels
         XCTAssertFalse(batchModels.contains(.assemblyAI))
         XCTAssertFalse(batchModels.contains(.elevenLabsScribe))
+        XCTAssertFalse(batchModels.contains(.cohereTranscribeArabic))
     }
 
     func testIsCloudProperty() {
         // Cloud models
         XCTAssertTrue(TranscriptionModel.assemblyAI.isCloud)
         XCTAssertTrue(TranscriptionModel.elevenLabsScribe.isCloud)
+        XCTAssertTrue(TranscriptionModel.cohereTranscribeArabic.isCloud)
         // Local models
         XCTAssertFalse(TranscriptionModel.parakeetV2.isCloud)
         XCTAssertFalse(TranscriptionModel.parakeetV3.isCloud)

--- a/OpenOats/Tests/OpenOatsTests/WizardViewModelTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/WizardViewModelTests.swift
@@ -9,6 +9,7 @@ final class WizardViewModelTests: XCTestCase {
         hasOpenRouterKey: Bool = false,
         hasAssemblyAIKey: Bool = false,
         hasElevenLabsKey: Bool = false,
+        hasCohereKey: Bool = false,
         hasVoyageKey: Bool = false,
         ollamaModels: Result<[String], OllamaModelFetcher.FetchError> = .failure(.networkError("no"))
     ) -> SetupSnapshot {
@@ -22,10 +23,12 @@ final class WizardViewModelTests: XCTestCase {
             hasVoyageKey: hasVoyageKey,
             hasAssemblyAIKey: hasAssemblyAIKey,
             hasElevenLabsKey: hasElevenLabsKey,
+            hasCohereKey: hasCohereKey,
             existingOpenRouterKey: hasOpenRouterKey ? "sk-or-test" : "",
             existingVoyageKey: hasVoyageKey ? "pa-test" : "",
             existingAssemblyAIKey: hasAssemblyAIKey ? "aai-test" : "",
             existingElevenLabsKey: hasElevenLabsKey ? "xi-test" : "",
+            existingCohereKey: hasCohereKey ? "co-test" : "",
             ollamaResult: ollamaModels
         )
     }
@@ -137,6 +140,7 @@ final class WizardViewModelTests: XCTestCase {
             hasOpenRouterKey: true,
             hasAssemblyAIKey: true,
             hasElevenLabsKey: true,
+            hasCohereKey: true,
             hasVoyageKey: true
         ))
 
@@ -144,6 +148,7 @@ final class WizardViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.voyageKeyInput, "pa-test")
         XCTAssertEqual(viewModel.assemblyAIKeyInput, "aai-test")
         XCTAssertEqual(viewModel.elevenLabsKeyInput, "xi-test")
+        XCTAssertEqual(viewModel.cohereKeyInput, "co-test")
     }
 
     func testApplySettingsWritesCloudProfile() {
@@ -167,6 +172,23 @@ final class WizardViewModelTests: XCTestCase {
         XCTAssertTrue(store.meetingAutoDetectEnabled)
         XCTAssertTrue(store.hasShownAutoDetectExplanation)
         XCTAssertTrue(viewModel.isComplete)
+    }
+
+    func testApplySettingsWritesCohereForCloudMultilingualProfile() {
+        let store = makeStore()
+        let viewModel = makeConfiguredVM()
+        viewModel.intent = .notes
+        viewModel.language = .multilingual
+        viewModel.privacy = .cloud
+        viewModel.cohereKeyInput = "co-new"
+
+        viewModel.applySettings(to: store)
+
+        XCTAssertEqual(store.transcriptionModel, .cohereTranscribeArabic)
+        XCTAssertEqual(store.transcriptionLocale, "ar")
+        XCTAssertEqual(store.cohereApiKey, "co-new")
+        XCTAssertEqual(store.assemblyAIApiKey, "")
+        XCTAssertEqual(store.elevenLabsApiKey, "")
     }
 
     func testApplySettingsLocalProfile() {
@@ -205,6 +227,7 @@ final class WizardViewModelTests: XCTestCase {
         store.voyageApiKey = "old-voyage"
         store.assemblyAIApiKey = "old-aai"
         store.elevenLabsApiKey = "old-xi"
+        store.cohereApiKey = "old-co"
 
         let viewModel = makeConfiguredVM()
         viewModel.intent = .notes
@@ -217,6 +240,7 @@ final class WizardViewModelTests: XCTestCase {
         XCTAssertEqual(store.voyageApiKey, "")
         XCTAssertEqual(store.assemblyAIApiKey, "")
         XCTAssertEqual(store.elevenLabsApiKey, "")
+        XCTAssertEqual(store.cohereApiKey, "")
     }
 
     func testReconfigurationSeedsCurrentSettings() {


### PR DESCRIPTION
## Summary
- Add native support for Cohere Transcribe Arabic via `cohere-transcribe-arabic-07-2026` on Cohere's hosted audio transcription API.
- Expose Cohere as a first-class cloud transcription model in Settings, including Cohere API key storage and validation.
- Recommend Cohere for multilingual/Arabic cloud onboarding, with wizard key collection and an Arabic language hint by default.

## Why This Belongs Natively
Cohere Transcribe Arabic is a strong fit for OpenOats because Arabic meetings are exactly where generic ASR often falls down: dialect variety, Arabic-English code switching, and English spoken with Arabic accents. The model is purpose-built for that surface area, and Cohere positions it as an open-source Arabic ASR model optimized across dialects and mixed Arabic/English speech.

Native support also makes the product experience much simpler. Users do not need to run a local Hugging Face pipeline, bridge Python into the app, or configure an OpenAI-compatible proxy. They can pick `Cohere Transcribe Arabic`, paste a Cohere API key, and start transcribing Arabic-heavy meetings from the same OpenOats transcription flow.

Model reference: https://huggingface.co/CohereLabs/cohere-transcribe-arabic-07-2026

## UI Changes
- Settings > Transcription now includes `Cohere Transcribe Arabic` in the Cloud model section.
- Selecting it shows a `Cohere API Key` field with live validation.
- The setup wizard now asks for a Cohere key when recommending the Arabic/multilingual cloud path.

Screenshots were not embedded from this CLI run because GitHub's PR API/CLI path does not provide a reliable way to upload local screenshot assets into the PR body, and the non-interactive macOS screenshot attempt did not produce a usable app-window capture.

## Test plan
- `swift test` - 700 tests, 0 failures.
- `./scripts/build_swift_app.sh` - release build, signing, bundle verification, and install completed.