### PR TITLE
Fix notification-triggered recording startup

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -593,6 +593,9 @@ final class LiveSessionController {
     // MARK: - Transcription Lifecycle (migrated from AppCoordinator)
 
     func startTranscription(metadata: MeetingMetadata, settings: AppSettings?) async {
+        if let settings {
+            container.ensureMeetingServicesInitialized(settings: settings, coordinator: coordinator)
+        }
         if let batchAudioTranscriber = coordinator.batchAudioTranscriber {
             await batchAudioTranscriber.cancel()
         }

--- a/OpenOats/Sources/OpenOats/Info.plist
+++ b/OpenOats/Sources/OpenOats/Info.plist
@@ -41,6 +41,8 @@
     <string>OpenOats uses Apple Notes to export your meeting notes.</string>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.productivity</string>
+    <key>LSMultipleInstancesProhibited</key>
+    <true/>
     <key>SUFeedURL</key>
     <string>https://raw.githubusercontent.com/yazinsai/OpenOats/gh-pages/appcast.xml</string>
     <key>SUEnableAutomaticChecks</key>


### PR DESCRIPTION
## Summary
- Initialize meeting/recording services inside the transcription start path so notification-triggered starts don't enter recording without an audio engine.
- Mark the app bundle as single-instance to prevent stale installed bundles from launching alongside local builds when notification activation occurs.

## Runtime evidence
- Before fix: camera notification start logged coordinator recording transition with `hasTranscriptionEngine:false`, then `startTranscription` also saw no transcription engine.
- After fix: same path logged `hasTranscriptionEngine:true`, and manual verification confirmed notification-started recording transcribes correctly.
- Duplicate process repro was confirmed with `dist/OpenOats.app` and `/Applications/OpenOats.app`; after `LSMultipleInstancesProhibited`, manual verification confirmed only one process remains.

## Test plan
- `SKIP_INSTALL=1 ./scripts/build_swift_app.sh`
- Manual camera-active notification repro verified: one OpenOats process, recording transcribes.