### PR TITLE
Update Homebrew cask for 1.84.1

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.83.1"
-  sha256 "688daddddc66e9a66506ec11886cf6fc5ff24fc2e05df9a0ad19b9da109ae8f3"
+  version "1.84.1"
+  sha256 "edc88a2f28975ed893af0b5f4fc01098c11bd8cd965263ca8d25bb5d072d3488"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"


### PR DESCRIPTION
Automated follow-up from the v1.84.1 release workflow.

Updates `Casks/openoats.rb` to point Homebrew users at the new `v1.84.1` DMG and checksum.

Release: https://github.com/yazinsai/OpenOats/releases/tag/v1.84.1
Workflow: https://github.com/yazinsai/OpenOats/actions/runs/28935545507