### PR TITLE
Add on-device SpeechAnalyzer transcription engine (macOS 26+)

### DIFF
--- a/OpenOats/Sources/OpenOats/Info.plist
+++ b/OpenOats/Sources/OpenOats/Info.plist
@@ -33,6 +33,8 @@
     <string>15.0</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>OpenOats needs microphone access to transcribe your voice in real-time during conversations.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>OpenOats uses on-device speech recognition to transcribe meetings with Apple SpeechAnalyzer.</string>
     <key>NSAudioCaptureUsageDescription</key>
     <string>OpenOats needs system audio recording access to transcribe other participants in real time.</string>
     <key>NSCalendarsFullAccessUsageDescription</key>

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -711,8 +711,9 @@ final class SettingsStore {
         get { access(keyPath: \.transcriptionModel); return _transcriptionModel }
         set {
             withMutation(keyPath: \.transcriptionModel) {
-                _transcriptionModel = newValue
-                defaults.set(newValue.rawValue, forKey: "transcriptionModel")
+                let model = newValue.isSelectableOnCurrentOS ? newValue : .parakeetV3
+                _transcriptionModel = model
+                defaults.set(model.rawValue, forKey: "transcriptionModel")
             }
         }
     }
@@ -789,8 +790,9 @@ final class SettingsStore {
         get { access(keyPath: \.batchTranscriptionModel); return _batchTranscriptionModel }
         set {
             withMutation(keyPath: \.batchTranscriptionModel) {
-                _batchTranscriptionModel = newValue
-                defaults.set(newValue.rawValue, forKey: "batchTranscriptionModel")
+                let model = newValue.isSelectableOnCurrentOS ? newValue : .parakeetV3
+                _batchTranscriptionModel = model
+                defaults.set(model.rawValue, forKey: "batchTranscriptionModel")
             }
         }
     }
@@ -1491,6 +1493,10 @@ final class SettingsStore {
         self._transcriptionModel = TranscriptionModel(
             rawValue: defaults.string(forKey: "transcriptionModel") ?? ""
         ) ?? .parakeetV2
+        if !_transcriptionModel.isSelectableOnCurrentOS {
+            _transcriptionModel = .parakeetV3
+            defaults.set(TranscriptionModel.parakeetV3.rawValue, forKey: "transcriptionModel")
+        }
         self._transcriptionLocale = defaults.string(forKey: "transcriptionLocale") ?? "en-US"
         self._transcriptionCustomVocabulary = defaults.string(forKey: "transcriptionCustomVocabulary") ?? ""
         self._removeFillerWords = defaults.bool(forKey: "removeFillerWords")
@@ -1510,6 +1516,10 @@ final class SettingsStore {
         self._batchTranscriptionModel = TranscriptionModel(
             rawValue: defaults.string(forKey: "batchTranscriptionModel") ?? ""
         ) ?? .whisperLargeV3Turbo
+        if !_batchTranscriptionModel.isSelectableOnCurrentOS {
+            _batchTranscriptionModel = .parakeetV3
+            defaults.set(TranscriptionModel.parakeetV3.rawValue, forKey: "batchTranscriptionModel")
+        }
         self._enableDiarization = defaults.bool(forKey: "enableDiarization")
         self._diarizationVariant = defaults.string(forKey: "diarizationVariant") ?? DiarizationVariant.dihard3.rawValue
 

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -342,6 +342,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
     case whisperBase
     case whisperSmall
     case whisperLargeV3Turbo
+    case speechAnalyzer
     case assemblyAI
     case elevenLabsScribe
     case cohereTranscribeArabic
@@ -355,6 +356,22 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         }
     }
 
+    var usesStreamingSession: Bool {
+        self == .speechAnalyzer
+    }
+
+    var isSelectableOnCurrentOS: Bool {
+        switch self {
+        case .speechAnalyzer:
+            if #available(macOS 26, *) {
+                return true
+            }
+            return false
+        default:
+            return true
+        }
+    }
+
     var displayName: String {
         switch self {
         case .parakeetV2: "Parakeet TDT v2"
@@ -363,6 +380,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         case .whisperBase: "Whisper Base"
         case .whisperSmall: "Whisper Small"
         case .whisperLargeV3Turbo: "Whisper Large v3 Turbo"
+        case .speechAnalyzer: "Apple SpeechAnalyzer"
         case .assemblyAI: "AssemblyAI"
         case .elevenLabsScribe: "ElevenLabs Scribe"
         case .cohereTranscribeArabic: "Cohere Transcribe Arabic"
@@ -381,6 +399,8 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
             "Whisper Small requires a one-time model download (~244 MB)."
         case .whisperLargeV3Turbo:
             "Whisper Large v3 Turbo requires a one-time model download (~800 MB)."
+        case .speechAnalyzer:
+            "Apple SpeechAnalyzer may download on-device speech assets for your locale."
         case .assemblyAI, .elevenLabsScribe:
             "Requires an API key. Enter it in Settings > Transcription."
         case .cohereTranscribeArabic:
@@ -395,6 +415,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         case .whisperBase: 142_000_000
         case .whisperSmall: 244_000_000
         case .whisperLargeV3Turbo: 800_000_000
+        case .speechAnalyzer: 150_000_000
         case .parakeetV2, .parakeetV3, .qwen3ASR06B: nil
         case .assemblyAI, .elevenLabsScribe, .cohereTranscribeArabic: nil
         }
@@ -408,7 +429,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         switch self {
         case .qwen3ASR06B:
             "Language Hint"
-        case .parakeetV2, .parakeetV3, .whisperBase, .whisperSmall, .whisperLargeV3Turbo:
+        case .parakeetV2, .parakeetV3, .whisperBase, .whisperSmall, .whisperLargeV3Turbo, .speechAnalyzer:
             "Locale"
         case .assemblyAI, .elevenLabsScribe, .cohereTranscribeArabic:
             "Language Hint"
@@ -427,6 +448,8 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
             "Whisper auto-detects speech language. This setting is still saved with the session and markdown export."
         case .whisperLargeV3Turbo:
             "Whisper Large v3 Turbo auto-detects speech language. This setting is saved with session metadata and markdown export."
+        case .speechAnalyzer:
+            "SpeechAnalyzer requires a supported Apple speech locale. Change locale in Settings or pick Parakeet if unsupported."
         case .assemblyAI:
             "Optional language hint for AssemblyAI. Leave as en-US for English or set to your expected meeting language."
         case .elevenLabsScribe:
@@ -454,10 +477,18 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         case .whisperBase: return WhisperKitBackend(variant: .base)
         case .whisperSmall: return WhisperKitBackend(variant: .small)
         case .whisperLargeV3Turbo: return WhisperKitBackend(variant: .largeV3Turbo)
+        case .speechAnalyzer:
+            preconditionFailure("SpeechAnalyzer uses streaming sessions; call makeStreamingProvider() instead of makeBackend()")
         case .assemblyAI: return AssemblyAIBackend(apiKey: apiKey, customVocabulary: customVocabulary)
         case .elevenLabsScribe: return ElevenLabsScribeBackend(apiKey: apiKey, customVocabulary: customVocabulary, removeFillerWords: removeFillerWords)
         case .cohereTranscribeArabic: return CohereTranscribeArabicBackend(apiKey: apiKey, customVocabulary: customVocabulary)
         }
+    }
+
+    func makeStreamingProvider() -> (any StreamingTranscriptionProvider)? {
+        guard usesStreamingSession else { return nil }
+        guard #available(macOS 26, *) else { return nil }
+        return SpeechAnalyzerProvider()
     }
 
     /// Flush interval in 16kHz samples for streaming transcription.
@@ -466,7 +497,7 @@ enum TranscriptionModel: String, CaseIterable, Identifiable {
         switch self {
         case .whisperBase, .whisperSmall, .whisperLargeV3Turbo:
             10 * 16_000
-        case .parakeetV2, .parakeetV3, .qwen3ASR06B:
+        case .parakeetV2, .parakeetV3, .qwen3ASR06B, .speechAnalyzer:
             5 * 16_000
         case .assemblyAI, .elevenLabsScribe, .cohereTranscribeArabic:
             10 * 16_000  // 10s - fewer API calls, better accuracy per segment

--- a/OpenOats/Sources/OpenOats/Transcription/SpeechAnalyzerProvider.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/SpeechAnalyzerProvider.swift
@@ -1,0 +1,407 @@
+@preconcurrency import AVFoundation
+import CoreMedia
+import Foundation
+import os
+import Speech
+
+// MARK: - Asset-checking seam
+
+@available(macOS 26, *)
+protocol SpeechAssetChecking: Sendable {
+    func supportedLocales() async -> [Locale]
+    func installedLocales() async -> [Locale]
+    func supportedLocale(equivalentTo locale: Locale) async -> Locale?
+    func status(for modules: [any SpeechModule]) async -> AssetInventory.Status
+    func assetInstallationRequest(supporting modules: [any SpeechModule]) async throws -> AssetInstallationRequest?
+    func reservedLocales() async -> [Locale]
+    func release(reservedLocale: Locale) async -> Bool
+}
+
+@available(macOS 26, *)
+struct DefaultSpeechAssetChecker: SpeechAssetChecking {
+    func supportedLocales() async -> [Locale] {
+        await SpeechTranscriber.supportedLocales
+    }
+
+    func installedLocales() async -> [Locale] {
+        await SpeechTranscriber.installedLocales
+    }
+
+    func supportedLocale(equivalentTo locale: Locale) async -> Locale? {
+        await SpeechTranscriber.supportedLocale(equivalentTo: locale)
+    }
+
+    func status(for modules: [any SpeechModule]) async -> AssetInventory.Status {
+        await AssetInventory.status(forModules: modules)
+    }
+
+    func assetInstallationRequest(supporting modules: [any SpeechModule]) async throws -> AssetInstallationRequest? {
+        try await AssetInventory.assetInstallationRequest(supporting: modules)
+    }
+
+    func reservedLocales() async -> [Locale] {
+        await AssetInventory.reservedLocales
+    }
+
+    func release(reservedLocale: Locale) async -> Bool {
+        await AssetInventory.release(reservedLocale: reservedLocale)
+    }
+}
+
+// MARK: - Provider
+
+@available(macOS 26, *)
+final class SpeechAnalyzerProvider: StreamingTranscriptionProvider, @unchecked Sendable {
+    let displayName = "Apple SpeechAnalyzer"
+
+    private let assets: any SpeechAssetChecking
+    private let preparedLocaleIdentifiers = OSAllocatedUnfairLock(initialState: Set<String>())
+
+    init(assets: any SpeechAssetChecking = DefaultSpeechAssetChecker()) {
+        self.assets = assets
+    }
+
+    func checkStatus(locale: Locale) async -> BackendStatus {
+        guard let resolved = await assets.supportedLocale(equivalentTo: locale) else {
+            return .error(
+                reason: "SpeechAnalyzer does not support locale \"\(locale.identifier)\". Choose a supported locale in Settings or switch to Parakeet."
+            )
+        }
+
+        if await isInstalled(resolved) {
+            return .ready
+        }
+
+        return .needsDownload(prompt: TranscriptionModel.speechAnalyzer.downloadPrompt)
+    }
+
+    func prepare(
+        locale: Locale,
+        onStatus: @Sendable (String) -> Void,
+        onProgress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+        guard let resolved = await assets.supportedLocale(equivalentTo: locale) else {
+            throw StreamingTranscriptionError.unsupportedLocale(locale.identifier)
+        }
+
+        let probe = makeTranscriber(locale: resolved)
+        let modules: [any SpeechModule] = [probe]
+
+        let status = await assets.status(for: modules)
+        if status != .installed {
+            onStatus("Downloading Apple speech assets…")
+            try await downloadAssets(modules: modules, keeping: resolved, onProgress: onProgress)
+        }
+
+        onStatus("Apple SpeechAnalyzer ready")
+        onProgress(1.0)
+        markPrepared(resolved)
+    }
+
+    func makeSession(locale: Locale) async throws -> any StreamingTranscriptionSession {
+        guard let resolved = await assets.supportedLocale(equivalentTo: locale) else {
+            throw StreamingTranscriptionError.unsupportedLocale(locale.identifier)
+        }
+
+        let alreadyPrepared = preparedLocaleIdentifiers.withLock {
+            $0.contains(Self.localeKey(resolved))
+        }
+        if !alreadyPrepared {
+            guard await isInstalled(resolved) else {
+                throw StreamingTranscriptionError.notPrepared
+            }
+            markPrepared(resolved)
+        }
+
+        return SpeechAnalyzerSession(locale: resolved)
+    }
+
+    // MARK: - Private
+
+    private func makeTranscriber(locale: Locale) -> SpeechTranscriber {
+        SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [.volatileResults],
+            attributeOptions: [.audioTimeRange]
+        )
+    }
+
+    private func isInstalled(_ locale: Locale) async -> Bool {
+        let installed = await assets.installedLocales()
+        for candidate in installed {
+            if candidate == locale {
+                return true
+            }
+            if let equiv = await assets.supportedLocale(equivalentTo: candidate), equiv == locale {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func markPrepared(_ locale: Locale) {
+        _ = preparedLocaleIdentifiers.withLock { state in
+            state.insert(Self.localeKey(locale))
+        }
+    }
+
+    private static func localeKey(_ locale: Locale) -> String {
+        locale.identifier(.bcp47)
+    }
+
+    private func downloadAssets(
+        modules: [any SpeechModule],
+        keeping locale: Locale,
+        onProgress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+        do {
+            try await performDownload(modules: modules, onProgress: onProgress)
+        } catch {
+            await releaseOtherReservedLocales(keeping: locale)
+            do {
+                try await performDownload(modules: modules, onProgress: onProgress)
+            } catch {
+                throw StreamingTranscriptionError.assetInstallFailed(error.localizedDescription)
+            }
+        }
+    }
+
+    private func performDownload(
+        modules: [any SpeechModule],
+        onProgress: @escaping @Sendable (Double) -> Void
+    ) async throws {
+        guard let request = try await assets.assetInstallationRequest(supporting: modules) else {
+            // No install request usually means assets are already present / not needed.
+            onProgress(1.0)
+            return
+        }
+
+        let observation = request.progress.observe(\.fractionCompleted, options: [.initial, .new]) { progress, _ in
+            onProgress(progress.fractionCompleted)
+        }
+        defer { observation.invalidate() }
+
+        try await request.downloadAndInstall()
+        onProgress(1.0)
+    }
+
+    private func releaseOtherReservedLocales(keeping locale: Locale) async {
+        let reserved = await assets.reservedLocales()
+        for reservedLocale in reserved where reservedLocale != locale {
+            _ = await assets.release(reservedLocale: reservedLocale)
+        }
+    }
+}
+
+// MARK: - Session
+
+@available(macOS 26, *)
+actor SpeechAnalyzerSession: StreamingTranscriptionSession {
+    private let locale: Locale
+
+    private var analyzer: SpeechAnalyzer?
+    private var inputContinuation: AsyncStream<AnalyzerInput>.Continuation?
+    private var resultsTask: Task<Void, Never>?
+    private var startTask: Task<Void, Never>?
+    private var converter: AVAudioConverter?
+    private var converterInputFormat: AVAudioFormat?
+    private var targetFormat: AVAudioFormat?
+    private var didFinish = false
+
+    init(locale: Locale) {
+        self.locale = locale
+    }
+
+    /// AVAudioPCMBuffer is not Sendable; box the stream so the protocol entry point can hop into the actor.
+    private struct PCMStreamBox: @unchecked Sendable {
+        let stream: AsyncStream<AVAudioPCMBuffer>
+    }
+
+    nonisolated func run(
+        stream: AsyncStream<AVAudioPCMBuffer>,
+        onPartial: @escaping @Sendable (String) -> Void,
+        onFinal: @escaping @Sendable (StreamingTranscriber.FinalSegment) -> Void
+    ) async {
+        await runIsolated(
+            stream: PCMStreamBox(stream: stream),
+            onPartial: onPartial,
+            onFinal: onFinal
+        )
+    }
+
+    private func runIsolated(
+        stream: PCMStreamBox,
+        onPartial: @escaping @Sendable (String) -> Void,
+        onFinal: @escaping @Sendable (StreamingTranscriber.FinalSegment) -> Void
+    ) async {
+        let transcriber = SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [.volatileResults],
+            attributeOptions: [.audioTimeRange]
+        )
+
+        guard let format = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
+            onPartial("")
+            return
+        }
+        targetFormat = format
+
+        let analyzer = SpeechAnalyzer(modules: [transcriber])
+        self.analyzer = analyzer
+
+        let (inputStream, continuation) = AsyncStream<AnalyzerInput>.makeStream()
+        self.inputContinuation = continuation
+
+        resultsTask = Task {
+            do {
+                for try await result in transcriber.results {
+                    let text = String(result.text.characters)
+                    if result.isFinal {
+                        let timing = Self.timing(from: result)
+                        onPartial("")
+                        onFinal(
+                            StreamingTranscriber.FinalSegment(
+                                text: text,
+                                startTime: timing.start,
+                                endTime: timing.end
+                            )
+                        )
+                    } else {
+                        onPartial(text)
+                    }
+                }
+            } catch is CancellationError {
+                // Expected during teardown.
+            } catch {
+                // Analyzer/results failures surface via empty partials; finish() still tears down.
+            }
+        }
+
+        startTask = Task {
+            do {
+                try await analyzer.start(inputSequence: inputStream)
+            } catch is CancellationError {
+                // Expected during teardown.
+            } catch {
+                // Surface via finish path; keep run() from throwing across actor boundary.
+            }
+        }
+
+        for await buffer in stream.stream {
+            if Task.isCancelled || didFinish { break }
+            guard let converted = convert(buffer) else { continue }
+            continuation.yield(AnalyzerInput(buffer: converted))
+        }
+
+        continuation.finish()
+    }
+
+    func finish() async {
+        guard !didFinish else { return }
+        didFinish = true
+
+        inputContinuation?.finish()
+        inputContinuation = nil
+
+        if let analyzer {
+            do {
+                try await analyzer.finalizeAndFinishThroughEndOfInput()
+            } catch {
+                await analyzer.cancelAndFinishNow()
+            }
+        }
+
+        await resultsTask?.value
+        await startTask?.value
+
+        resultsTask = nil
+        startTask = nil
+        analyzer = nil
+        converter = nil
+        converterInputFormat = nil
+        targetFormat = nil
+    }
+
+    // MARK: - Audio conversion
+
+    private func convert(_ buffer: AVAudioPCMBuffer) -> AVAudioPCMBuffer? {
+        guard buffer.frameLength > 0, let targetFormat else { return nil }
+
+        let inputFormat = buffer.format
+        if formatsMatch(inputFormat, targetFormat) {
+            return buffer
+        }
+
+        if converter == nil || converterInputFormat != inputFormat {
+            converter = AVAudioConverter(from: inputFormat, to: targetFormat)
+            converterInputFormat = inputFormat
+        }
+        guard let converter else { return nil }
+
+        let ratio = targetFormat.sampleRate / max(inputFormat.sampleRate, 1)
+        let capacity = max(AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 32, 1)
+        guard let output = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: capacity) else {
+            return nil
+        }
+
+        var error: NSError?
+        nonisolated(unsafe) var consumed = false
+        let status = converter.convert(to: output, error: &error) { _, outStatus in
+            if consumed {
+                outStatus.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            outStatus.pointee = .haveData
+            return buffer
+        }
+
+        guard status != .error, error == nil, output.frameLength > 0 else {
+            return nil
+        }
+        return output
+    }
+
+    private func formatsMatch(_ a: AVAudioFormat, _ b: AVAudioFormat) -> Bool {
+        a.sampleRate == b.sampleRate
+            && a.channelCount == b.channelCount
+            && a.commonFormat == b.commonFormat
+            && a.isInterleaved == b.isInterleaved
+    }
+
+    // MARK: - Timing
+
+    private static func timing(from result: SpeechTranscriber.Result) -> (start: TimeInterval, end: TimeInterval) {
+        var minStart: TimeInterval?
+        var maxEnd: TimeInterval?
+
+        for run in result.text.runs {
+            guard let timeRange = run.attributes[AttributeScopes.SpeechAttributes.TimeRangeAttribute.self] else {
+                continue
+            }
+            guard timeRange.start.isNumeric, timeRange.duration.isNumeric else { continue }
+            let start = CMTimeGetSeconds(timeRange.start)
+            let end = CMTimeGetSeconds(CMTimeRangeGetEnd(timeRange))
+            guard start.isFinite, end.isFinite else { continue }
+            minStart = min(minStart ?? start, start)
+            maxEnd = max(maxEnd ?? end, end)
+        }
+
+        if let minStart, let maxEnd {
+            return (minStart, maxEnd)
+        }
+
+        let range = result.range
+        if range.start.isNumeric, range.duration.isNumeric, CMTimeGetSeconds(range.duration) > 0 {
+            let start = CMTimeGetSeconds(range.start)
+            let end = CMTimeGetSeconds(CMTimeRangeGetEnd(range))
+            if start.isFinite, end.isFinite {
+                return (start, end)
+            }
+        }
+
+        return (0, 0)
+    }
+}

--- a/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriptionSession.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/StreamingTranscriptionSession.swift
@@ -1,0 +1,49 @@
+import AVFoundation
+import Foundation
+
+enum StreamingTranscriptionError: Error, LocalizedError, Sendable {
+    case unsupportedOnThisOS
+    case unsupportedLocale(String)
+    case notPrepared
+    case assetInstallFailed(String)
+    case sessionContention(String)
+    case analyzerFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedOnThisOS:
+            "Apple SpeechAnalyzer requires macOS 26 or later."
+        case .unsupportedLocale(let locale):
+            "SpeechAnalyzer does not support locale \"\(locale)\". Choose a supported locale in Settings or switch to Parakeet."
+        case .notPrepared:
+            "SpeechAnalyzer is not prepared yet. Wait for model download to finish or try again."
+        case .assetInstallFailed(let detail):
+            "Failed to install Apple speech assets: \(detail)"
+        case .sessionContention(let detail):
+            "SpeechAnalyzer is busy: \(detail). Stop other recordings using speech recognition and try again."
+        case .analyzerFailed(let detail):
+            "SpeechAnalyzer failed: \(detail)"
+        }
+    }
+}
+
+protocol StreamingTranscriptionProvider: Sendable {
+    var displayName: String { get }
+    func checkStatus(locale: Locale) async -> BackendStatus
+    func prepare(
+        locale: Locale,
+        onStatus: @Sendable (String) -> Void,
+        onProgress: @escaping @Sendable (Double) -> Void
+    ) async throws
+    /// One independent live session per speaker stream (you / them).
+    func makeSession(locale: Locale) async throws -> any StreamingTranscriptionSession
+}
+
+protocol StreamingTranscriptionSession: Sendable {
+    func run(
+        stream: AsyncStream<AVAudioPCMBuffer>,
+        onPartial: @escaping @Sendable (String) -> Void,
+        onFinal: @escaping @Sendable (StreamingTranscriber.FinalSegment) -> Void
+    ) async
+    func finish() async
+}

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -32,6 +32,7 @@ struct ActiveTranscriptionSession: Sendable, Equatable {
     func clearModelCache(
         using makeBackend: (TranscriptionModel) -> any TranscriptionBackend = { $0.makeBackend() }
     ) {
+        guard !transcriptionModel.usesStreamingSession else { return }
         makeBackend(transcriptionModel).clearModelCache()
     }
 }
@@ -209,6 +210,10 @@ final class TranscriptionEngine {
     private var systemBackend: (any TranscriptionBackend)?
     private var vadManager: VadManager?
 
+    private var streamingProvider: (any StreamingTranscriptionProvider)?
+    private var micStreamingSession: (any StreamingTranscriptionSession)?
+    private var systemStreamingSession: (any StreamingTranscriptionSession)?
+
     /// Audio recorder for tapping streams (set by ContentView when recording is enabled).
     var audioRecorder: AudioRecorder?
 
@@ -253,6 +258,10 @@ final class TranscriptionEngine {
     ) -> MicStartupHealthAction {
         guard !hasCapturedFrames, captureError == nil else { return .none }
         return hasRetried ? .showNoAudioError : .retryCapture
+    }
+
+    static func shouldLoadVAD(for model: TranscriptionModel) -> Bool {
+        !model.usesStreamingSession
     }
 
     func refreshModelAvailability() {
@@ -348,10 +357,20 @@ final class TranscriptionEngine {
         assetStatus = "Downloading \(transcriptionModel.displayName)..."
         beginDownloadTracking(for: transcriptionModel)
 
-        let vocab = settings.transcriptionCustomVocabulary
-        let backend = transcriptionModel.makeBackend(customVocabulary: vocab)
         do {
-            try await prepareBackend(backend)
+            if transcriptionModel.usesStreamingSession {
+                guard let provider = transcriptionModel.makeStreamingProvider() else {
+                    lastError = StreamingTranscriptionError.unsupportedOnThisOS.localizedDescription
+                    assetStatus = "Ready"
+                    clearDownloadTracking()
+                    return
+                }
+                try await prepareStreamingProvider(provider, locale: settings.locale)
+            } else {
+                let vocab = settings.transcriptionCustomVocabulary
+                let backend = transcriptionModel.makeBackend(customVocabulary: vocab)
+                try await prepareBackend(backend)
+            }
             needsModelDownload = false
             downloadConfirmed = false
             clearDownloadTracking()
@@ -363,7 +382,9 @@ final class TranscriptionEngine {
             lastError = "Failed to download: \(error.localizedDescription)"
             assetStatus = "Ready"
             clearDownloadTracking()
-            transcriptionModel.makeBackend().clearModelCache()
+            if !transcriptionModel.usesStreamingSession {
+                transcriptionModel.makeBackend().clearModelCache()
+            }
             needsModelDownload = true
         }
     }
@@ -426,52 +447,75 @@ final class TranscriptionEngine {
             beginDownloadTracking(for: transcriptionModel)
         }
         Log.transcription.info("Loading transcription model \(transcriptionModel.rawValue, privacy: .public)")
+        let usesStreaming = transcriptionModel.usesStreamingSession
         do {
-            let vocab = settings.transcriptionCustomVocabulary
-            let apiKey = settings.cloudASRApiKey
-            let noFiller = settings.removeFillerWords
-            let mic: any TranscriptionBackend
-            if transcriptionModel.isCloud,
-               let preparedCloudStartBackend,
-               preparedCloudStartBackend.model == transcriptionModel {
-                mic = preparedCloudStartBackend.backend
-                self.preparedCloudStartBackend = nil
-            } else {
-                mic = transcriptionModel.makeBackend(
-                    customVocabulary: vocab,
-                    apiKey: apiKey,
-                    removeFillerWords: noFiller
-                )
-                try await prepareBackend(mic)
-            }
-            self.micBackend = mic
+            if usesStreaming {
+                guard let provider = transcriptionModel.makeStreamingProvider() else {
+                    lastError = StreamingTranscriptionError.unsupportedOnThisOS.localizedDescription
+                    assetStatus = "Ready"
+                    isRunning = false
+                    clearDownloadTracking()
+                    downloadConfirmed = false
+                    activeTranscriptionSession = nil
+                    return
+                }
+                try await prepareStreamingProvider(provider, locale: locale)
+                streamingProvider = provider
 
-            // Parakeet needs a separate backend for system audio (mutable decoder state).
-            // Qwen3 is actor-based and thread-safe, so reuse the same instance.
-            if transcriptionModel == .qwen3ASR06B || transcriptionModel.isCloud {
-                self.systemBackend = mic
+                if settings.enableDiarization {
+                    Log.transcription.info("Diarization is ignored when using Apple SpeechAnalyzer")
+                }
+                diarizationManager = nil
+                vadManager = nil
+                micBackend = nil
+                systemBackend = nil
             } else {
-                let sys = transcriptionModel.makeBackend(customVocabulary: vocab, apiKey: apiKey, removeFillerWords: noFiller)
-                try await sys.prepare { _ in }
-                self.systemBackend = sys
-            }
+                let vocab = settings.transcriptionCustomVocabulary
+                let apiKey = settings.cloudASRApiKey
+                let noFiller = settings.removeFillerWords
+                let mic: any TranscriptionBackend
+                if transcriptionModel.isCloud,
+                   let preparedCloudStartBackend,
+                   preparedCloudStartBackend.model == transcriptionModel {
+                    mic = preparedCloudStartBackend.backend
+                    self.preparedCloudStartBackend = nil
+                } else {
+                    mic = transcriptionModel.makeBackend(
+                        customVocabulary: vocab,
+                        apiKey: apiKey,
+                        removeFillerWords: noFiller
+                    )
+                    try await prepareBackend(mic)
+                }
+                self.micBackend = mic
 
-            assetStatus = "Loading VAD model..."
-            Log.transcription.info("Loading VAD model")
-            let vad = try await VadManager()
-            self.vadManager = vad
+                // Parakeet needs a separate backend for system audio (mutable decoder state).
+                // Qwen3 is actor-based and thread-safe, so reuse the same instance.
+                if transcriptionModel == .qwen3ASR06B || transcriptionModel.isCloud {
+                    self.systemBackend = mic
+                } else {
+                    let sys = transcriptionModel.makeBackend(customVocabulary: vocab, apiKey: apiKey, removeFillerWords: noFiller)
+                    try await sys.prepare { _ in }
+                    self.systemBackend = sys
+                }
 
-            // Optionally load speaker diarization model
-            if settings.enableDiarization {
-                assetStatus = "Loading diarization model..."
-                Log.transcription.info("Loading LS-EEND diarization model")
-                let dm = DiarizationManager()
-                let variant = LSEENDVariant(rawValue: settings.diarizationVariant.rawValue) ?? .dihard3
-                try await dm.load(variant: variant)
-                self.diarizationManager = dm
-                Log.transcription.info("Diarization model loaded")
-            } else {
-                self.diarizationManager = nil
+                assetStatus = "Loading VAD model..."
+                Log.transcription.info("Loading VAD model")
+                let vad = try await VadManager()
+                self.vadManager = vad
+
+                // Optionally load speaker diarization model
+                if settings.enableDiarization {
+                    assetStatus = "Loading diarization model..."
+                    Log.transcription.info("Loading LS-EEND diarization model")
+                    let dm = DiarizationManager()
+                    let variant = LSEENDVariant(rawValue: settings.diarizationVariant.rawValue) ?? .dihard3
+                    try await dm.load(variant: variant)
+                    self.diarizationManager = dm
+                    Log.transcription.info("Diarization model loaded")
+                } else {
+                    self.diarizationManager = nil
+                }
             }
 
             needsModelDownload = false
@@ -486,6 +530,7 @@ final class TranscriptionEngine {
             assetStatus = "Ready"
             isRunning = false
             clearDownloadTracking()
+            streamingProvider = nil
             // Clear corrupt cache so the next attempt triggers a fresh download.
             // Cloud models don't have local caches or download flows.
             if !transcriptionModel.isCloud {
@@ -500,9 +545,11 @@ final class TranscriptionEngine {
             return
         }
 
-        guard let vadManager else {
-            activeTranscriptionSession = nil
-            return
+        if !usesStreaming {
+            guard vadManager != nil else {
+                activeTranscriptionSession = nil
+                return
+            }
         }
 
         // 2. Start mic capture
@@ -513,6 +560,7 @@ final class TranscriptionEngine {
             lastError = msg
             assetStatus = "Ready"
             isRunning = false
+            streamingProvider = nil
             activeTranscriptionSession = nil
             return
         }
@@ -527,12 +575,35 @@ final class TranscriptionEngine {
         }
 
         Log.transcription.info("Starting mic capture, targetMicID=\(targetMicID, privacy: .public), aec=\(useAEC, privacy: .public)")
-        startMicStream(
-            locale: locale,
-            vadManager: vadManager,
-            deviceID: targetMicID,
-            echoCancellation: useAEC
-        )
+        if usesStreaming {
+            do {
+                try await startMicStreamingSession(
+                    locale: locale,
+                    deviceID: targetMicID,
+                    echoCancellation: useAEC
+                )
+            } catch {
+                Log.transcription.error("Failed to start mic streaming session: \(error, privacy: .public)")
+                lastError = error.localizedDescription
+                assetStatus = "Ready"
+                isRunning = false
+                micCapture.finishStream()
+                await tearDownStreamingSessions()
+                await micTask?.value
+                micCapture.stop()
+                micTask = nil
+                streamingProvider = nil
+                activeTranscriptionSession = nil
+                return
+            }
+        } else if let vadManager {
+            startMicStream(
+                locale: locale,
+                vadManager: vadManager,
+                deviceID: targetMicID,
+                echoCancellation: useAEC
+            )
+        }
 
         // Check for immediate mic capture failure
         if let micError = micCapture.captureError {
@@ -558,16 +629,38 @@ final class TranscriptionEngine {
                 self.lastError = "Microphone is not producing audio. Check your input device in System Settings."
             case .retryCapture:
                 Log.transcription.error("No mic audio after 5s, retrying mic capture once")
-                self.micCapture.finishStream()
-                await self.micTask?.value
-                self.micTask = nil
-                self.micCapture.stop()
-                self.startMicStream(
-                    locale: locale,
-                    vadManager: vadManager,
-                    deviceID: targetMicID,
-                    echoCancellation: false
-                )
+                if self.streamingProvider != nil {
+                    await self.micStreamingSession?.finish()
+                    self.micStreamingSession = nil
+                    self.micCapture.finishStream()
+                    await self.micTask?.value
+                    self.micTask = nil
+                    self.micCapture.stop()
+                    do {
+                        try await self.startMicStreamingSession(
+                            locale: locale,
+                            deviceID: targetMicID,
+                            echoCancellation: false
+                        )
+                    } catch {
+                        Log.transcription.error("Mic streaming retry failed: \(error, privacy: .public)")
+                        self.lastError = error.localizedDescription
+                        return
+                    }
+                } else if let vadManager = self.vadManager {
+                    self.micCapture.finishStream()
+                    await self.micTask?.value
+                    self.micTask = nil
+                    self.micCapture.stop()
+                    self.startMicStream(
+                        locale: locale,
+                        vadManager: vadManager,
+                        deviceID: targetMicID,
+                        echoCancellation: false
+                    )
+                } else {
+                    return
+                }
 
                 try? await Task.sleep(for: .seconds(5))
                 guard self.isRunning else { return }
@@ -588,9 +681,37 @@ final class TranscriptionEngine {
         }
 
         // 3. Start system audio capture
-        await startSystemAudioStream(locale: locale, vadManager: vadManager)
+        if usesStreaming {
+            do {
+                try await startSystemAudioStreamingSession(locale: locale)
+            } catch {
+                Log.transcription.error("Failed to start system streaming session: \(error, privacy: .public)")
+                lastError = error.localizedDescription
+                assetStatus = "Ready"
+                isRunning = false
+                micCapture.finishStream()
+                systemCapture.finishStream()
+                await tearDownStreamingSessions()
+                micTask?.cancel()
+                sysTask?.cancel()
+                await micTask?.value
+                await sysTask?.value
+                micCapture.stop()
+                await systemCapture.stop()
+                micTask = nil
+                sysTask = nil
+                streamingProvider = nil
+                activeTranscriptionSession = nil
+                return
+            }
+        } else if let vadManager {
+            await startSystemAudioStream(locale: locale, vadManager: vadManager)
+        }
 
-        assetStatus = "Transcribing (\(micBackend?.displayName ?? transcriptionModel.displayName))"
+        let displayName = streamingProvider?.displayName
+            ?? micBackend?.displayName
+            ?? transcriptionModel.displayName
+        assetStatus = "Transcribing (\(displayName))"
         Log.transcription.info("All transcription tasks started")
 
         // Install CoreAudio listeners for live device routing changes
@@ -752,6 +873,11 @@ final class TranscriptionEngine {
         micCapture.finishStream()
         systemCapture.finishStream()
 
+        await micStreamingSession?.finish()
+        await systemStreamingSession?.finish()
+        micStreamingSession = nil
+        systemStreamingSession = nil
+
         micTask?.cancel()
         sysTask?.cancel()
         await micTask?.value
@@ -774,6 +900,7 @@ final class TranscriptionEngine {
         micBackend = nil
         systemBackend = nil
         vadManager = nil
+        streamingProvider = nil
         transcriptStore.volatileYouText = ""
         transcriptStore.volatileThemText = ""
         liveCloudTranscriptIssue = nil
@@ -809,6 +936,17 @@ final class TranscriptionEngine {
         micTask = nil
         sysTask = nil
         micKeepAliveTask = nil
+        let micSession = micStreamingSession
+        let sysSession = systemStreamingSession
+        micStreamingSession = nil
+        systemStreamingSession = nil
+        streamingProvider = nil
+        if micSession != nil || sysSession != nil {
+            Task {
+                await micSession?.finish()
+                await sysSession?.finish()
+            }
+        }
         Task { await systemCapture.stop() }
         micCapture.stop()
         currentMicDeviceID = 0
@@ -826,7 +964,7 @@ final class TranscriptionEngine {
     }
 
     private func performMicRestart(inputDeviceID: AudioDeviceID) async {
-        guard isRunning, let vadManager else { return }
+        guard isRunning else { return }
 
         userSelectedDeviceID = inputDeviceID
 
@@ -843,6 +981,41 @@ final class TranscriptionEngine {
         }
 
         Log.transcription.info("Switching mic from \(self.currentMicDeviceID, privacy: .public) to \(targetMicID, privacy: .public)")
+
+        if streamingProvider != nil {
+            await micStreamingSession?.finish()
+            micStreamingSession = nil
+            micCapture.finishStream()
+            await micTask?.value
+
+            if Task.isCancelled || !isRunning {
+                return
+            }
+
+            micTask = nil
+            micCapture.stop()
+
+            guard await ensureMicrophonePermission() else {
+                Log.transcription.error("Mic permission lost during device switch")
+                return
+            }
+
+            do {
+                try await startMicStreamingSession(
+                    locale: settings.locale,
+                    deviceID: targetMicID
+                )
+                currentMicDeviceID = targetMicID
+                lastError = nil
+                Log.transcription.info("Mic restarted on device \(targetMicID, privacy: .public)")
+            } catch {
+                Log.transcription.error("Mic streaming restart failed: \(error, privacy: .public)")
+                lastError = error.localizedDescription
+            }
+            return
+        }
+
+        guard let vadManager else { return }
 
         micCapture.finishStream()
         await micTask?.value
@@ -891,9 +1064,33 @@ final class TranscriptionEngine {
     }
 
     private func performSystemAudioRestart() async {
-        guard isRunning, let vadManager else { return }
+        guard isRunning else { return }
 
         Log.transcription.info("Restarting system audio stream")
+
+        if streamingProvider != nil {
+            await systemStreamingSession?.finish()
+            systemStreamingSession = nil
+            systemCapture.finishStream()
+            await sysTask?.value
+
+            if Task.isCancelled || !isRunning {
+                return
+            }
+
+            sysTask = nil
+            await systemCapture.stop()
+            do {
+                try await startSystemAudioStreamingSession(locale: settings.locale)
+                Log.transcription.info("System audio stream restarted")
+            } catch {
+                Log.transcription.error("System streaming restart failed: \(error, privacy: .public)")
+                lastError = error.localizedDescription
+            }
+            return
+        }
+
+        guard let vadManager else { return }
 
         systemCapture.finishStream()
         await sysTask?.value
@@ -907,6 +1104,102 @@ final class TranscriptionEngine {
         await startSystemAudioStream(locale: settings.locale, vadManager: vadManager)
 
         Log.transcription.info("System audio stream restarted")
+    }
+
+    private func startMicStreamingSession(
+        locale: Locale,
+        deviceID: AudioDeviceID,
+        echoCancellation: Bool = false
+    ) async throws {
+        guard let provider = streamingProvider else {
+            throw StreamingTranscriptionError.notPrepared
+        }
+
+        var micStream = micCapture.bufferStream(deviceID: deviceID, echoCancellation: echoCancellation)
+        if let recorder = audioRecorder {
+            micStream = Self.tappedStream(micStream) { buffer in
+                recorder.writeMicBuffer(buffer)
+            }
+        }
+
+        let session = try await provider.makeSession(locale: locale)
+        micStreamingSession = session
+        let store = transcriptStore
+        micTask = Task.detached {
+            await session.run(
+                stream: micStream,
+                onPartial: { text in
+                    Task { @MainActor in store.volatileYouText = text }
+                },
+                onFinal: { segment in
+                    Task { @MainActor in
+                        store.volatileYouText = ""
+                        store.append(Utterance(text: segment.text, speaker: .you))
+                    }
+                }
+            )
+        }
+    }
+
+    private func startSystemAudioStreamingSession(locale: Locale) async throws {
+        guard let provider = streamingProvider else {
+            throw StreamingTranscriptionError.notPrepared
+        }
+
+        Log.transcription.info("Starting system audio capture")
+
+        let sysStreams: SystemAudioCapture.CaptureStreams
+        do {
+            var outputID: AudioDeviceID? = settings.outputDeviceID != 0 ? settings.outputDeviceID : nil
+            // If the stored ID is stale, try resolving via stable UID.
+            if let id = outputID,
+               !SystemAudioCapture.availableOutputDevices().contains(where: { $0.id == id }),
+               let uid = settings.outputDeviceUID,
+               let resolved = SystemAudioCapture.outputDeviceID(forUID: uid) {
+                settings.outputDeviceID = resolved
+                outputID = resolved
+            }
+            sysStreams = try await systemCapture.bufferStream(outputDeviceID: outputID)
+            Log.transcription.info("System audio capture started")
+            clearSystemAudioErrorIfPresent()
+        } catch {
+            let msg = "Failed to start system audio: \(error.localizedDescription)"
+            Log.transcription.error("Failed to start system audio: \(error, privacy: .public)")
+            lastError = msg
+            throw error
+        }
+
+        var sysStream = sysStreams.systemAudio
+        if let recorder = audioRecorder {
+            sysStream = Self.tappedStream(sysStream) { buffer in
+                recorder.writeSysBuffer(buffer)
+            }
+        }
+
+        let session = try await provider.makeSession(locale: locale)
+        systemStreamingSession = session
+        let store = transcriptStore
+        sysTask = Task.detached {
+            await session.run(
+                stream: sysStream,
+                onPartial: { text in
+                    Task { @MainActor in store.volatileThemText = text }
+                },
+                onFinal: { segment in
+                    Task { @MainActor in
+                        store.volatileThemText = ""
+                        store.append(Utterance(text: segment.text, speaker: .them))
+                    }
+                }
+            )
+        }
+    }
+
+    private func tearDownStreamingSessions() async {
+        await micStreamingSession?.finish()
+        await systemStreamingSession?.finish()
+        micStreamingSession = nil
+        systemStreamingSession = nil
     }
 
     private func startMicStream(
@@ -1156,6 +1449,10 @@ final class TranscriptionEngine {
 
     private static func modelNeedsDownload(_ model: TranscriptionModel) -> Bool {
         guard !model.isCloud else { return false }
+        if model.usesStreamingSession {
+            // Conservative sync heuristic — real status is async via makeStreamingProvider().
+            return model.isSelectableOnCurrentOS
+        }
         let backend = model.makeBackend()
         if case .needsDownload = backend.checkStatus() {
             return true
@@ -1291,6 +1588,24 @@ final class TranscriptionEngine {
 
     private func prepareBackend(_ backend: any TranscriptionBackend) async throws {
         try await backend.prepare(
+            onStatus: { [weak self] status in
+                Task { @MainActor in self?.assetStatus = status }
+            },
+            onProgress: { [weak self] fraction in
+                Task { @MainActor in
+                    self?.downloadProgress = fraction
+                    self?.updateDownloadDetail(fraction: fraction)
+                }
+            }
+        )
+    }
+
+    private func prepareStreamingProvider(
+        _ provider: any StreamingTranscriptionProvider,
+        locale: Locale
+    ) async throws {
+        try await provider.prepare(
+            locale: locale,
             onStatus: { [weak self] status in
                 Task { @MainActor in self?.assetStatus = status }
             },

--- a/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/TranscriptionEngine.swift
@@ -246,6 +246,11 @@ final class TranscriptionEngine {
         switch mode {
         case .live:
             self.needsModelDownload = Self.modelNeedsDownload(settings.transcriptionModel)
+            if settings.transcriptionModel.usesStreamingSession {
+                Task { @MainActor [weak self] in
+                    await self?.refreshStreamingDownloadStatus()
+                }
+            }
         case .scripted:
             self.needsModelDownload = false
         }
@@ -260,14 +265,22 @@ final class TranscriptionEngine {
         return hasRetried ? .showNoAudioError : .retryCapture
     }
 
-    static func shouldLoadVAD(for model: TranscriptionModel) -> Bool {
+    nonisolated static func shouldLoadVAD(for model: TranscriptionModel) -> Bool {
         !model.usesStreamingSession
     }
 
     func refreshModelAvailability() {
         switch mode {
         case .live:
-            needsModelDownload = Self.modelNeedsDownload(settings.transcriptionModel)
+            if settings.transcriptionModel.usesStreamingSession {
+                // Sync path cannot query Speech assets; refresh asynchronously.
+                needsModelDownload = false
+                Task { @MainActor [weak self] in
+                    await self?.refreshStreamingDownloadStatus()
+                }
+            } else {
+                needsModelDownload = Self.modelNeedsDownload(settings.transcriptionModel)
+            }
         case .scripted:
             needsModelDownload = false
         }
@@ -1450,14 +1463,35 @@ final class TranscriptionEngine {
     private static func modelNeedsDownload(_ model: TranscriptionModel) -> Bool {
         guard !model.isCloud else { return false }
         if model.usesStreamingSession {
-            // Conservative sync heuristic — real status is async via makeStreamingProvider().
-            return model.isSelectableOnCurrentOS
+            // Speech asset status is async (AssetInventory / installedLocales).
+            // Never force-true here — that blocked Live start with a silent return
+            // and left the UI in .recording with no capture. Async refresh sets
+            // needsModelDownload from StreamingTranscriptionProvider.checkStatus.
+            return false
         }
         let backend = model.makeBackend()
         if case .needsDownload = backend.checkStatus() {
             return true
         }
         return false
+    }
+
+    private func refreshStreamingDownloadStatus() async {
+        let model = settings.transcriptionModel
+        guard model.usesStreamingSession else { return }
+        guard let provider = model.makeStreamingProvider() else {
+            needsModelDownload = false
+            return
+        }
+
+        let status = await provider.checkStatus(locale: settings.locale)
+        let needsDownload: Bool
+        if case .needsDownload = status {
+            needsDownload = true
+        } else {
+            needsDownload = false
+        }
+        needsModelDownload = needsDownload
     }
 
     private func validateConfiguredInputDevice() -> StartPreflightIssue? {

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -439,12 +439,12 @@ private struct TranscriptionSettingsTab: View {
                 Section("Transcription") {
                     Picker("Model", selection: $settings.transcriptionModel) {
                         Section("Local") {
-                            ForEach(TranscriptionModel.allCases.filter { !$0.isCloud }) { model in
+                            ForEach(TranscriptionModel.allCases.filter { !$0.isCloud && $0.isSelectableOnCurrentOS }) { model in
                                 Text(model.displayName).tag(model)
                             }
                         }
                         Section("Cloud") {
-                            ForEach(TranscriptionModel.allCases.filter { $0.isCloud }) { model in
+                            ForEach(TranscriptionModel.allCases.filter { $0.isCloud && $0.isSelectableOnCurrentOS }) { model in
                                 Text(model.displayName).tag(model)
                             }
                         }

--- a/OpenOats/Sources/OpenOats/Wizard/SetupDetector.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/SetupDetector.swift
@@ -54,6 +54,15 @@ actor SetupDetector {
         nonisolated func modelStatuses() -> [TranscriptionModel: BackendStatus] {
             var result: [TranscriptionModel: BackendStatus] = [:]
             for model in TranscriptionModel.allCases {
+                if model.usesStreamingSession {
+                    // SpeechAnalyzer uses makeStreamingProvider(); sync path cannot await checkStatus.
+                    if model.isSelectableOnCurrentOS {
+                        result[model] = .needsDownload(prompt: model.downloadPrompt)
+                    } else {
+                        result[model] = .error(reason: "Apple SpeechAnalyzer requires macOS 26 or later.")
+                    }
+                    continue
+                }
                 result[model] = model.makeBackend().checkStatus()
             }
             return result

--- a/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/AppSettingsTests.swift
@@ -70,7 +70,7 @@ final class AppSettingsTests: XCTestCase {
 
     func testTranscriptionModelAllCases() {
         let cases = TranscriptionModel.allCases
-        XCTAssertEqual(cases.count, 9)
+        XCTAssertEqual(cases.count, 10)
     }
 
     func testTranscriptionModelDisplayNames() {

--- a/OpenOats/Tests/OpenOatsTests/SpeechAnalyzerProviderTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SpeechAnalyzerProviderTests.swift
@@ -1,0 +1,247 @@
+import AVFoundation
+import Speech
+import XCTest
+@testable import OpenOatsKit
+
+final class SpeechAnalyzerProviderTests: XCTestCase {
+
+    // MARK: - TranscriptionModel wiring (no Speech runtime)
+
+    func testSpeechAnalyzerUsesStreamingSessionOnly() {
+        XCTAssertTrue(TranscriptionModel.speechAnalyzer.usesStreamingSession)
+        for model in TranscriptionModel.allCases where model != .speechAnalyzer {
+            XCTAssertFalse(model.usesStreamingSession)
+        }
+    }
+
+    func testIsSelectableOnCurrentOSMatchesAvailability() {
+        let selectable = TranscriptionModel.speechAnalyzer.isSelectableOnCurrentOS
+        if #available(macOS 26, *) {
+            XCTAssertTrue(selectable)
+        } else {
+            XCTAssertFalse(selectable)
+        }
+    }
+
+    func testSettingsPickerSourceExcludesUnselectable() {
+        let local = TranscriptionModel.allCases.filter { !$0.isCloud && $0.isSelectableOnCurrentOS }
+        if #available(macOS 26, *) {
+            XCTAssertTrue(local.contains(.speechAnalyzer))
+        } else {
+            XCTAssertFalse(local.contains(.speechAnalyzer))
+        }
+    }
+
+    func testNotInBatchSuitableModels() {
+        XCTAssertFalse(TranscriptionModel.batchSuitableModels.contains(.speechAnalyzer))
+    }
+
+    func testShouldLoadVADFalseForSpeechAnalyzer() {
+        XCTAssertFalse(TranscriptionEngine.shouldLoadVAD(for: .speechAnalyzer))
+        XCTAssertTrue(TranscriptionEngine.shouldLoadVAD(for: .parakeetV3))
+    }
+
+    // MARK: - checkStatus (mock asset checker, macOS 26+)
+
+    @available(macOS 26, *)
+    func testCheckStatusUnsupportedLocaleReturnsError() async {
+        let mock = MockSpeechAssetChecker(supportedLocaleResult: nil)
+        let provider = SpeechAnalyzerProvider(assets: mock)
+        let locale = Locale(identifier: "xx-XX")
+
+        let status = await provider.checkStatus(locale: locale)
+
+        guard case .error(let reason) = status else {
+            XCTFail("Expected .error, got \(status)")
+            return
+        }
+        XCTAssertTrue(reason.contains("does not support locale"))
+        XCTAssertTrue(reason.contains("xx-XX"))
+    }
+
+    @available(macOS 26, *)
+    func testCheckStatusSupportedButNotInstalledReturnsNeedsDownload() async {
+        let resolved = Locale(identifier: "en-US")
+        let mock = MockSpeechAssetChecker(
+            supportedLocaleResult: resolved,
+            installedLocalesResult: []
+        )
+        let provider = SpeechAnalyzerProvider(assets: mock)
+
+        let status = await provider.checkStatus(locale: resolved)
+
+        XCTAssertEqual(
+            status,
+            .needsDownload(prompt: TranscriptionModel.speechAnalyzer.downloadPrompt)
+        )
+    }
+
+    @available(macOS 26, *)
+    func testCheckStatusInstalledLocaleReturnsReady() async {
+        let resolved = Locale(identifier: "en-US")
+        let mock = MockSpeechAssetChecker(
+            supportedLocaleResult: resolved,
+            installedLocalesResult: [resolved]
+        )
+        let provider = SpeechAnalyzerProvider(assets: mock)
+
+        let status = await provider.checkStatus(locale: resolved)
+
+        XCTAssertEqual(status, .ready)
+    }
+
+    @available(macOS 26, *)
+    func testCheckStatusEquivalentInstalledLocaleReturnsReady() async {
+        let resolved = Locale(identifier: "en-US")
+        let installedVariant = Locale(identifier: "en_US")
+        let mock = MockSpeechAssetChecker(
+            supportedLocaleResult: resolved,
+            installedLocalesResult: [installedVariant],
+            equivalentLocaleMap: [installedVariant: resolved]
+        )
+        let provider = SpeechAnalyzerProvider(assets: mock)
+
+        let status = await provider.checkStatus(locale: resolved)
+
+        XCTAssertEqual(status, .ready)
+    }
+
+    @available(macOS 26, *)
+    func testProviderDisplayName() {
+        let provider = SpeechAnalyzerProvider(assets: MockSpeechAssetChecker())
+        XCTAssertEqual(provider.displayName, "Apple SpeechAnalyzer")
+    }
+
+    // MARK: - Integration smoke (macOS 26+, real Speech assets)
+
+    func testSpeechAnalyzerSessionSmoke() async throws {
+        try XCTSkipUnless({
+            if #available(macOS 26, *) { return true }
+            return false
+        }(), "Requires macOS 26+")
+
+        if #available(macOS 26, *) {
+            try await runSpeechAnalyzerSessionSmoke()
+        }
+    }
+}
+
+// MARK: - Integration helpers
+
+@available(macOS 26, *)
+private extension SpeechAnalyzerProviderTests {
+    func runSpeechAnalyzerSessionSmoke() async throws {
+        let provider = SpeechAnalyzerProvider()
+        let locale = Locale(identifier: "en-US")
+        let status = await provider.checkStatus(locale: locale)
+
+        switch status {
+        case .needsDownload:
+            throw XCTSkip("Apple speech assets not installed for \(locale.identifier)")
+        case .error(let reason):
+            throw XCTSkip("Locale not supported: \(reason)")
+        case .ready:
+            break
+        case .downloading:
+            throw XCTSkip("Speech assets are currently downloading")
+        }
+
+        let session = try await provider.makeSession(locale: locale)
+        let stream = makeBriefSilenceStream(sampleRate: 16_000, bufferCount: 3, framesPerBuffer: 1_600)
+
+        let runTask = Task {
+            await session.run(
+                stream: stream,
+                onPartial: { _ in },
+                onFinal: { _ in }
+            )
+        }
+
+        await runTask.value
+        await session.finish()
+    }
+
+    func makeBriefSilenceStream(
+        sampleRate: Double,
+        bufferCount: Int,
+        framesPerBuffer: AVAudioFrameCount
+    ) -> AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { continuation in
+            let format = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: sampleRate,
+                channels: 1,
+                interleaved: true
+            )!
+            for _ in 0..<bufferCount {
+                guard let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: framesPerBuffer) else {
+                    continue
+                }
+                buffer.frameLength = framesPerBuffer
+                if let channelData = buffer.floatChannelData {
+                    for i in 0..<Int(framesPerBuffer) {
+                        channelData[0][i] = 0
+                    }
+                }
+                continuation.yield(buffer)
+            }
+            continuation.finish()
+        }
+    }
+}
+
+// MARK: - Mock asset checker
+
+@available(macOS 26, *)
+private struct MockSpeechAssetChecker: SpeechAssetChecking {
+    var supportedLocaleResult: Locale?
+    var installedLocalesResult: [Locale] = []
+    var equivalentLocaleMap: [Locale: Locale] = [:]
+
+    init(
+        supportedLocaleResult: Locale? = Locale(identifier: "en-US"),
+        installedLocalesResult: [Locale] = [],
+        equivalentLocaleMap: [Locale: Locale] = [:]
+    ) {
+        self.supportedLocaleResult = supportedLocaleResult
+        self.installedLocalesResult = installedLocalesResult
+        self.equivalentLocaleMap = equivalentLocaleMap
+    }
+
+    func supportedLocales() async -> [Locale] {
+        if let supportedLocaleResult {
+            return [supportedLocaleResult]
+        }
+        return []
+    }
+
+    func installedLocales() async -> [Locale] {
+        installedLocalesResult
+    }
+
+    func supportedLocale(equivalentTo locale: Locale) async -> Locale? {
+        if let mapped = equivalentLocaleMap[locale] {
+            return mapped
+        }
+        if let supportedLocaleResult, locale == supportedLocaleResult {
+            return supportedLocaleResult
+        }
+        return supportedLocaleResult
+    }
+
+    func status(for modules: [any SpeechModule]) async -> AssetInventory.Status {
+        .installed
+    }
+
+    func assetInstallationRequest(supporting modules: [any SpeechModule]) async throws -> AssetInstallationRequest? {
+        nil
+    }
+
+    func reservedLocales() async -> [Locale] {
+        []
+    }
+
+    func release(reservedLocale: Locale) async -> Bool {
+        true
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/SpeechAnalyzerProviderTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SpeechAnalyzerProviderTests.swift
@@ -149,15 +149,11 @@ private extension SpeechAnalyzerProviderTests {
         let session = try await provider.makeSession(locale: locale)
         let stream = makeBriefSilenceStream(sampleRate: 16_000, bufferCount: 3, framesPerBuffer: 1_600)
 
-        let runTask = Task {
-            await session.run(
-                stream: stream,
-                onPartial: { _ in },
-                onFinal: { _ in }
-            )
-        }
-
-        await runTask.value
+        await session.run(
+            stream: stream,
+            onPartial: { _ in },
+            onFinal: { _ in }
+        )
         await session.finish()
     }
 
@@ -183,7 +179,9 @@ private extension SpeechAnalyzerProviderTests {
                         channelData[0][i] = 0
                     }
                 }
-                continuation.yield(buffer)
+                // AVAudioPCMBuffer is not Sendable; mirror production capture taps.
+                nonisolated(unsafe) let unsafeBuffer = buffer
+                continuation.yield(unsafeBuffer)
             }
             continuation.finish()
         }

--- a/OpenOats/Tests/OpenOatsTests/TranscriptionBackendTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/TranscriptionBackendTests.swift
@@ -316,6 +316,23 @@ final class TranscriptionBackendTests: XCTestCase {
         XCTAssertFalse(batchModels.contains(.assemblyAI))
         XCTAssertFalse(batchModels.contains(.elevenLabsScribe))
         XCTAssertFalse(batchModels.contains(.cohereTranscribeArabic))
+        XCTAssertFalse(batchModels.contains(.speechAnalyzer))
+    }
+
+    // MARK: - SpeechAnalyzer factory
+
+    func testSpeechAnalyzerUsesStreamingSession() {
+        XCTAssertTrue(TranscriptionModel.speechAnalyzer.usesStreamingSession)
+    }
+
+    func testMakeStreamingProviderSpeechAnalyzer() {
+        let provider = TranscriptionModel.speechAnalyzer.makeStreamingProvider()
+        if #available(macOS 26, *) {
+            XCTAssertNotNil(provider)
+            XCTAssertEqual(provider?.displayName, "Apple SpeechAnalyzer")
+        } else {
+            XCTAssertNil(provider)
+        }
     }
 
     func testIsCloudProperty() {
@@ -330,6 +347,7 @@ final class TranscriptionBackendTests: XCTestCase {
         XCTAssertFalse(TranscriptionModel.whisperBase.isCloud)
         XCTAssertFalse(TranscriptionModel.whisperSmall.isCloud)
         XCTAssertFalse(TranscriptionModel.whisperLargeV3Turbo.isCloud)
+        XCTAssertFalse(TranscriptionModel.speechAnalyzer.isCloud)
     }
 }
 

--- a/OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/TranscriptionEngineTests.swift
@@ -97,6 +97,14 @@ final class TranscriptionEngineTests: XCTestCase {
         )
     }
 
+    // MARK: - VAD loading
+
+    func testShouldLoadVADFalseForSpeechAnalyzer() {
+        XCTAssertFalse(TranscriptionEngine.shouldLoadVAD(for: .speechAnalyzer))
+        XCTAssertTrue(TranscriptionEngine.shouldLoadVAD(for: .parakeetV3))
+        XCTAssertTrue(TranscriptionEngine.shouldLoadVAD(for: .whisperBase))
+    }
+
     // MARK: - Diarization Feed Gate
 
     func testDiarizationFeedRelayStopsAfterFirstFailure() async {


### PR DESCRIPTION
## Summary
- Additive Settings option for Apple SpeechAnalyzer (macOS 26+); does not replace FluidAudio/Parakeet/Whisper/cloud
- Capture (MicCapture / system audio) unchanged; Tahoe capture bugs out of scope
- macOS 15–25 unaffected: option hidden and persisted selections clamped to Parakeet v3
- Dual independent SpeechAnalyzer sessions for You/Them; diarization ignored for this engine
- Live path uses StreamingTranscriptionSession (bypasses VAD)
- Streaming asset readiness is refreshed asynchronously via `checkStatus` (no longer force-blocks Live start)

## Test plan
- [x] macOS 26: select SpeechAnalyzer in Settings, start meeting — capture starts (download-gate fix verified locally)
- [ ] macOS 15–25: SpeechAnalyzer absent from picker; Parakeet still works
- [ ] Unsupported locale shows hard error (no DictationTranscriber fallback)
- [ ] Stop/finalize mid-sentence; mic device switch during SpeechAnalyzer session
- [x] Unit tests: SpeechAnalyzerProviderTests / shouldLoadVAD / usesStreamingSession (shouldLoadVAD marked `nonisolated` for Swift 6)
- [ ] Integration smoke XCTSkipUnless on non-26 / missing assets

## Known limitations
- XCTest suite may require full Xcode (not CLT-only) to run locally
- Dual-session contention fails start with `lastError` (no silent serialization)
- SetupDetector still uses a sync approximation for streaming model status in the setup wizard
- No README engines bullet (no existing enumerated ASR list)