### PR TITLE
Fix cloud credentials for audio imports

### DIFF
--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -215,6 +215,9 @@ extension OpenOatsRootApp {
 
         let model = settings.transcriptionModel
         let locale = settings.locale
+        let customVocabulary = settings.transcriptionCustomVocabulary
+        let apiKey = settings.cloudASRApiKey
+        let removeFillerWords = settings.removeFillerWords
         let repo = coordinator.sessionRepository
 
         // Derive start date and duration from file
@@ -252,6 +255,9 @@ extension OpenOatsRootApp {
                 sessionID: sessionID,
                 model: model,
                 locale: locale,
+                customVocabulary: customVocabulary,
+                apiKey: apiKey,
+                removeFillerWords: removeFillerWords,
                 sessionRepository: repo
             )
 

--- a/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
@@ -361,6 +361,9 @@ actor BatchAudioTranscriber {
         sessionID: String,
         model: TranscriptionModel,
         locale: Locale,
+        customVocabulary: String,
+        apiKey: String,
+        removeFillerWords: Bool,
         sessionRepository: SessionRepository
     ) async {
         currentTask?.cancel()
@@ -375,6 +378,9 @@ actor BatchAudioTranscriber {
                     sessionID: sessionID,
                     model: model,
                     locale: locale,
+                    customVocabulary: customVocabulary,
+                    apiKey: apiKey,
+                    removeFillerWords: removeFillerWords,
                     sessionRepository: sessionRepository
                 )
             } catch is CancellationError {
@@ -400,6 +406,9 @@ actor BatchAudioTranscriber {
         sessionID: String,
         model: TranscriptionModel,
         locale: Locale,
+        customVocabulary: String,
+        apiKey: String,
+        removeFillerWords: Bool,
         sessionRepository: SessionRepository
     ) async throws {
         Log.batchTranscription.info("Starting audio import for \(sessionID, privacy: .public) from \(url.lastPathComponent, privacy: .public)")
@@ -407,7 +416,11 @@ actor BatchAudioTranscriber {
         status = .loading(model: model.displayName)
 
         // Prepare backend and VAD
-        let backend = model.makeBackend()
+        let backend = model.makeBackend(
+            customVocabulary: customVocabulary,
+            apiKey: apiKey,
+            removeFillerWords: removeFillerWords
+        )
         try await backend.prepare { statusMsg in
             Log.batchTranscription.debug("Backend: \(statusMsg, privacy: .public)")
         }


### PR DESCRIPTION
Fix for Issue: #689

## Summary

- pass the configured cloud ASR API key into imported-recording transcription
- preserve custom vocabulary and filler-word settings for imported recordings

## Root cause

`BatchAudioTranscriber.runImport` created the selected backend with `model.makeBackend()` and therefore used the default empty API key. Cloud backends failed during preparation even when the same saved credentials worked for live meetings.

The import entry point now snapshots the active transcription settings and passes them through to backend construction.

## User impact

Users can import meeting recordings with AssemblyAI and other configured cloud transcription backends without receiving a misleading invalid API key error.

## Validation

- `swift build`
- `git diff --check`
- `swift test` compiled the application and changed sources, but the test target could not run in this environment because the active Command Line Tools installation does not provide the `XCTest` module
