### PR TITLE
Fix phi3.5 model tag

### DIFF
--- a/OpenOats/Sources/OpenOats/Wizard/RecommendationEngine.swift
+++ b/OpenOats/Sources/OpenOats/Wizard/RecommendationEngine.swift
@@ -149,7 +149,7 @@ enum RecommendationEngine {
                 selectedModel: nil,
                 realtimeModel: nil,
                 ollamaBaseURL: "http://localhost:11434",
-                ollamaLLMModel: "phi3.5:3.8b-mini-q4_K_M"
+                ollamaLLMModel: "phi3.5:3.8b-mini-instruct-q4_K_M"
             )
 
         case .localENFull, .localMultiFull:
@@ -216,7 +216,7 @@ enum RecommendationEngine {
 
         switch profile {
         case .localENLight, .localMultiLight:
-            models.append("phi3.5:3.8b-mini-q4_K_M")
+            models.append("phi3.5:3.8b-mini-instruct-q4_K_M")
         case .localENFull, .localMultiFull:
             models.append("qwen3:8b")
         default:

--- a/OpenOats/Tests/OpenOatsTests/RecommendationEngineTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/RecommendationEngineTests.swift
@@ -130,7 +130,7 @@ final class RecommendationEngineTests: XCTestCase {
         XCTAssertEqual(recommendation.profile, .localENLight)
         XCTAssertEqual(recommendation.transcriptionModel, .parakeetV2)
         XCTAssertEqual(recommendation.llmProvider, .ollama)
-        XCTAssertEqual(recommendation.ollamaLLMModel, "phi3.5:3.8b-mini-q4_K_M")
+        XCTAssertEqual(recommendation.ollamaLLMModel, "phi3.5:3.8b-mini-instruct-q4_K_M")
         XCTAssertEqual(recommendation.ollamaBaseURL, "http://localhost:11434")
         XCTAssertEqual(recommendation.sidecastIntensity, .quiet)
     }
@@ -158,7 +158,7 @@ final class RecommendationEngineTests: XCTestCase {
 
         XCTAssertEqual(recommendation.profile, .localMultiLight)
         XCTAssertEqual(recommendation.transcriptionModel, .whisperSmall)
-        XCTAssertEqual(recommendation.ollamaLLMModel, "phi3.5:3.8b-mini-q4_K_M")
+        XCTAssertEqual(recommendation.ollamaLLMModel, "phi3.5:3.8b-mini-instruct-q4_K_M")
     }
 
     func testLocalMultiHighRAM() {


### PR DESCRIPTION
The phi3.5 tag baked into the wizard doesn't exist on the Ollama registry, so every pull failed instantly and got misreported as "check your internet connection." Fixes #690.