### PR TITLE
Use AssemblyAI's latest default speech model

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/AssemblyAIBackend.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/AssemblyAIBackend.swift
@@ -178,23 +178,10 @@ final class AssemblyAIBackend: TranscriptionBackend, @unchecked Sendable {
         }
     }
 
-    // MARK: - Private: Create Transcript
+    // MARK: - Create Transcript
 
     private func createTranscript(audioURL: URL, locale: Locale) async throws -> String {
-        var body: [String: Any] = [
-            "audio_url": audioURL.absoluteString,
-            "speech_models": ["universal-3-pro", "universal-2"],
-        ]
-
-        // Language code from locale (e.g. "en", "pl", "de")
-        let languageCode = locale.language.languageCode?.identifier
-        if let languageCode, !languageCode.isEmpty {
-            body["language_code"] = languageCode
-        }
-
-        if !customSpelling.isEmpty {
-            body["custom_spelling"] = customSpelling
-        }
+        let body = makeTranscriptRequestBody(audioURL: audioURL, locale: locale)
 
         var request = URLRequest(url: URL(string: "https://api.assemblyai.com/v2/transcript")!)
         request.httpMethod = "POST"
@@ -220,6 +207,28 @@ final class AssemblyAIBackend: TranscriptionBackend, @unchecked Sendable {
 
             return id
         }
+    }
+
+    // MARK: - Internal for tests
+
+    func makeTranscriptRequestBody(audioURL: URL, locale: Locale) -> [String: Any] {
+        // Let AssemblyAI route to its latest default model. Pinning speech_models
+        // would require an app update whenever a named model is deprecated.
+        var body: [String: Any] = [
+            "audio_url": audioURL.absoluteString,
+        ]
+
+        // Language code from locale (e.g. "en", "pl", "de")
+        let languageCode = locale.language.languageCode?.identifier
+        if let languageCode, !languageCode.isEmpty {
+            body["language_code"] = languageCode
+        }
+
+        if !customSpelling.isEmpty {
+            body["custom_spelling"] = customSpelling
+        }
+
+        return body
     }
 
     // MARK: - Private: Poll

--- a/OpenOats/Tests/OpenOatsTests/TranscriptionBackendTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/TranscriptionBackendTests.swift
@@ -199,6 +199,20 @@ final class TranscriptionBackendTests: XCTestCase {
         }
     }
 
+    func testAssemblyAITranscriptRequestUsesLatestDefaultModel() throws {
+        let backend = AssemblyAIBackend(apiKey: "test-key")
+        let audioURL = try XCTUnwrap(URL(string: "https://cdn.assemblyai.com/test.wav"))
+
+        let body = backend.makeTranscriptRequestBody(
+            audioURL: audioURL,
+            locale: Locale(identifier: "en-US")
+        )
+
+        XCTAssertEqual(body["audio_url"] as? String, audioURL.absoluteString)
+        XCTAssertEqual(body["language_code"] as? String, "en")
+        XCTAssertNil(body["speech_models"])
+    }
+
     // MARK: - ElevenLabsScribeBackend
 
     func testElevenLabsDisplayName() {


### PR DESCRIPTION
## Summary

- remove the explicit `universal-3-pro` / `universal-2` model list from AssemblyAI transcript requests
- let AssemblyAI automatically select its latest default speech recognition model
- add a regression test that verifies transcript payloads omit `speech_models`

## Why

AssemblyAI will deprecate `universal-3-pro` on September 2, 2026, after which requests that explicitly name it will fail. The backend currently pins that model in every transcript request.

Because `speech_models` is optional, omitting it lets AssemblyAI route requests to its current Universal default. This avoids the immediate deprecation failure and future app changes solely for renamed default models. See AssemblyAI's [model selection documentation](https://www.assemblyai.com/docs/pre-recorded-audio/select-the-speech-model).

## Impact

AssemblyAI cloud transcription continues working after the deprecation and automatically follows AssemblyAI's latest default model. Existing API keys, language hints, and custom spelling behavior are unchanged.

## Validation

- `git diff --check`
- verified production sources contain neither the deprecated model ID nor an emitted `"speech_models"` payload key
- added `testAssemblyAITranscriptRequestUsesLatestDefaultModel`
- `swift test` could not run in the local Linux workspace because the Swift toolchain is unavailable; the repository's macOS CI will run the full builds and test suite
