### PR TITLE
Surface My Notes scratchpad post-session; bump Homebrew cask to 1.84.3

### DIFF
--- a/Casks/openoats.rb
+++ b/Casks/openoats.rb
@@ -1,6 +1,6 @@
 cask "openoats" do
-  version "1.84.2"
-  sha256 "f9599b077e560ea12560c5b0c00bee24e13b54bb148febe1eefe8f57e3f0daf6"
+  version "1.84.3"
+  sha256 "09ca4dd9ea4bff71322f247ee05f2268e59435eda3b947551d84e79e944ca003"
 
   url "https://github.com/yazinsai/OpenOats/releases/download/v#{version}/OpenOats.dmg"
   name "OpenOats"

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -45,6 +45,8 @@ struct NotesState {
     var hasOriginalTranscriptBackup: Bool = false
     /// Per-session custom guidance text for notes generation.
     var customNotesGuidance: String = ""
+    /// Scratchpad notes the user typed during the live recording ("My Notes").
+    var myNotesText: String = ""
     /// Sessions whose notes were freshly generated while the user was on a different session.
     /// Cleared when the user opens that session. Used to show the blue "unread" indicator.
     var freshlyGeneratedSessionIDs: Set<String> = []
@@ -310,6 +312,7 @@ final class NotesController {
             state.canRetranscribeSelectedSession = false
             state.hasOriginalTranscriptBackup = false
             state.customNotesGuidance = ""
+            state.myNotesText = ""
             return
         }
 
@@ -325,6 +328,7 @@ final class NotesController {
         state.canRetranscribeSelectedSession = false
         state.hasOriginalTranscriptBackup = false
         state.customNotesGuidance = ""
+        state.myNotesText = ""
         state.selectedSessionDirectory = coordinator.sessionRepository.sessionsDirectoryURL
             .appendingPathComponent(sessionID, isDirectory: true)
         state.showingOriginal = false
@@ -343,6 +347,7 @@ final class NotesController {
             async let canRetranscribe = coordinator.sessionRepository.hasRetainedBatchAudio(sessionID: sessionID)
             async let hasBackup = coordinator.sessionRepository.hasPreBatchTranscriptBackup(sessionID: sessionID)
             async let customGuidance = coordinator.sessionRepository.loadCustomNotesGuidance(sessionID: sessionID)
+            async let scratchpad = coordinator.sessionRepository.loadScratchpad(sessionID: sessionID)
             let data = await sessionData
             let unsavedDraft = unsavedManualNotesDraftsBySessionID[sessionID]
 
@@ -358,6 +363,7 @@ final class NotesController {
             state.canRetranscribeSelectedSession = await canRetranscribe
             state.hasOriginalTranscriptBackup = await hasBackup
             state.customNotesGuidance = await customGuidance ?? ""
+            state.myNotesText = await scratchpad
 
             let session = state.sessionHistory.first { $0.id == sessionID }
             let familySelection = session.map { Self.meetingFamilySelection(for: $0, calendarEvent: data.calendarEvent) }
@@ -408,6 +414,7 @@ final class NotesController {
         state.audioFileURL = nil
         state.showingOriginal = false
         state.customNotesGuidance = ""
+        state.myNotesText = ""
         state.selectedTemplate = selectedTemplate(
             sessionTemplateSnapshot: nil,
             meetingFamilySelection: selection
@@ -1103,6 +1110,15 @@ final class NotesController {
                 sessionID: sessionID,
                 guidance: text.isEmpty ? nil : text
             )
+        }
+    }
+
+    /// Update the "My Notes" scratchpad text for the selected (already-recorded) session.
+    func updateMyNotes(_ text: String) {
+        state.myNotesText = text
+        guard let sessionID = state.selectedSessionID else { return }
+        Task {
+            await coordinator.sessionRepository.saveScratchpad(sessionID: sessionID, text: text)
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
+++ b/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
@@ -3131,6 +3131,49 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                     }
 
                     VStack(alignment: .leading, spacing: 6) {
+                            Text("My Notes")
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(.secondary)
+
+                            ZStack(alignment: .topLeading) {
+                                if state.myNotesText.isEmpty {
+                                    Text("Notes you jotted down during the recording will appear here.")
+                                        .font(.system(size: 12))
+                                        .foregroundStyle(.quaternary)
+                                        .padding(.horizontal, 4)
+                                        .padding(.vertical, 6)
+                                }
+                                TextEditor(text: Binding(
+                                    get: { state.myNotesText },
+                                    set: { controller.updateMyNotes($0) }
+                                ))
+                                .font(.system(size: 12))
+                                .scrollContentBackground(.hidden)
+                                .frame(minHeight: 40, maxHeight: 100)
+                                .accessibilityIdentifier("meetingDetail.myNotesEditor")
+                            }
+                            .padding(4)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color(nsColor: .textBackgroundColor))
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .strokeBorder(.quaternary, lineWidth: 1)
+                            )
+                        }
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12)
+                                .fill(Color(nsColor: .controlBackgroundColor))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .strokeBorder(.quaternary, lineWidth: 1)
+                        )
+
+                    VStack(alignment: .leading, spacing: 6) {
                         Text("Custom Guidance")
                             .font(.system(size: 11, weight: .medium))
                             .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- The live-session "My Notes" scratchpad was persisted to `scratchpad.md` but had no way to be viewed or edited after the recording ended. Loads it into `NotesController` state on session select and surfaces it as an editable field in the pre-generation notes panel, next to Custom Guidance.
- Bumps the Homebrew cask from 1.84.2 to 1.84.3 (matches `automation/homebrew-cask-1.84.3`), since main's cask was behind the latest release.

Closes #694

## Test plan
- [x] `swift build -c debug` succeeds
- [ ] Manual: record a session, jot notes in "My Notes", stop, verify the text appears/edits in the notes panel before generating