### PR TITLE
Fix text selection: allow selecting across transcript lines and notes paragraphs (drag + Cmd+A)

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
+++ b/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
@@ -60,6 +60,7 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
     @FocusState private var renameFieldFocused: Bool
     @State private var renamingSpeakerKey: String? = nil
     @State private var speakerRenameText: String = ""
+    @State private var speakerRenameAnchorRect: CGRect = .zero
     @State private var editingTagsSessionID: String?
     @State private var editingTags: [String] = []
     @State private var newTagText: String = ""
@@ -3314,21 +3315,17 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                         .padding(.horizontal, 16)
                         .padding(.vertical, 4)
                 }
-                LazyVStack(alignment: .leading, spacing: 8) {
-                    let isCleaning: Bool = {
-                        if case .inProgress = state.cleanupStatus { return true }
-                        return false
-                    }()
-                    ForEach(Array(state.loadedTranscript.enumerated()), id: \.offset) { _, record in
-                        transcriptRow(
-                            record: record,
-                            isCleaning: isCleaning,
-                            showingOriginal: state.showingOriginal,
-                            sessionID: selectedSession?.id,
-                            speakerNames: selectedSession?.speakerNames
-                        )
-                    }
-                }
+                let isCleaning: Bool = {
+                    if case .inProgress = state.cleanupStatus { return true }
+                    return false
+                }()
+                transcriptFlow(
+                    controller: controller,
+                    state: state,
+                    isCleaning: isCleaning,
+                    sessionID: selectedSession?.id,
+                    speakerNames: selectedSession?.speakerNames
+                )
                 .padding(16)
             }
         }
@@ -3387,54 +3384,74 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
     }
 
     @ViewBuilder
-    private func transcriptRow(record: SessionRecord, isCleaning: Bool, showingOriginal: Bool, sessionID: String? = nil, speakerNames: [String: String]? = nil) -> some View {
-        HStack(alignment: .firstTextBaseline, spacing: 8) {
-            let speakerKey = record.speaker.storageKey
-            let isRenameable = sessionID != nil && record.speaker.isRemote
-            let label = record.speaker.displayName(speakerNames: speakerNames)
-
-            Group {
-                if isRenameable {
-                    Button(label) {
-                        speakerRenameText = label
-                        renamingSpeakerKey = speakerKey
-                    }
-                    .buttonStyle(.plain)
-                    .popover(isPresented: Binding(
-                        get: { renamingSpeakerKey == speakerKey },
-                        set: { if !$0 { renamingSpeakerKey = nil } }
-                    )) {
-                        SpeakerRenamePopover(
-                            text: $speakerRenameText,
-                            placeholder: record.speaker.displayLabel
-                        ) {
-                            guard let sid = sessionID else { return }
-                            var names = speakerNames ?? [:]
-                            let trimmed = speakerRenameText.trimmingCharacters(in: .whitespaces)
-                            if trimmed.isEmpty || trimmed == record.speaker.displayLabel {
-                                names.removeValue(forKey: speakerKey)
-                            } else {
-                                names[speakerKey] = trimmed
-                            }
-                            controller.updateSessionSpeakerNames(sessionID: sid, speakerNames: names)
-                            renamingSpeakerKey = nil
-                        }
-                    }
-                } else {
-                    Text(label)
-                }
+    /// The whole transcript as one selectable text flow (drag across lines,
+    /// Cmd+A, Cmd+C). Speaker labels for renameable speakers are links that
+    /// open the rename popover anchored at the clicked label.
+    private func transcriptFlow(
+        controller: NotesController,
+        state: NotesState,
+        isCleaning: Bool,
+        sessionID: String?,
+        speakerNames: [String: String]?
+    ) -> some View {
+        let lines = state.loadedTranscript.map { record in
+            TranscriptFlow.Line(
+                timestamp: nil,
+                speakerLabel: record.speaker.displayName(speakerNames: speakerNames),
+                speakerColor: NSColor(record.speaker.color),
+                renameKey: (sessionID != nil && record.speaker.isRemote) ? record.speaker.storageKey : nil,
+                text: state.showingOriginal ? record.text : (record.cleanedText ?? record.text),
+                textIsSecondary: isCleaning && record.cleanedText == nil
+            )
+        }
+        return SelectableTextFlow(
+            attributedText: TranscriptFlow.attributed(lines: lines, showsTimestampColumn: false),
+            onLinkClick: { url, rect in
+                guard let key = TranscriptFlow.renameKey(from: url) else { return false }
+                speakerRenameText = speakerNames?[key] ?? defaultSpeakerLabel(forKey: key)
+                speakerRenameAnchorRect = rect
+                renamingSpeakerKey = key
+                return true
             }
-            .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(record.speaker.color)
-            .frame(minWidth: 36, alignment: .trailing)
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .popover(
+            isPresented: Binding(
+                get: { renamingSpeakerKey != nil },
+                set: { if !$0 { renamingSpeakerKey = nil } }
+            ),
+            attachmentAnchor: .rect(.rect(speakerRenameAnchorRect))
+        ) {
+            SpeakerRenamePopover(
+                text: $speakerRenameText,
+                placeholder: defaultSpeakerLabel(forKey: renamingSpeakerKey ?? "")
+            ) {
+                guard let sid = sessionID, let key = renamingSpeakerKey else {
+                    renamingSpeakerKey = nil
+                    return
+                }
+                var names = speakerNames ?? [:]
+                let trimmed = speakerRenameText.trimmingCharacters(in: .whitespaces)
+                if trimmed.isEmpty || trimmed == defaultSpeakerLabel(forKey: key) {
+                    names.removeValue(forKey: key)
+                } else {
+                    names[key] = trimmed
+                }
+                controller.updateSessionSpeakerNames(sessionID: sid, speakerNames: names)
+                renamingSpeakerKey = nil
+            }
+        }
+    }
 
-            let displayText = showingOriginal ? record.text : (record.cleanedText ?? record.text)
-            Text(displayText)
-                .font(.system(size: 13))
-                .foregroundStyle(
-                    isCleaning && record.cleanedText == nil ? .secondary : .primary
-                )
-                .textSelection(.enabled)
+    private func defaultSpeakerLabel(forKey key: String) -> String {
+        switch key {
+        case "you": return "You"
+        case "them": return "Them"
+        default:
+            if key.hasPrefix("remote_"), let n = Int(key.dropFirst("remote_".count)) {
+                return "Speaker \(n)"
+            }
+            return "Speaker"
         }
     }
 
@@ -3454,46 +3471,79 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
 
     // MARK: - Markdown Rendering
 
+    private enum NotesFlowItem {
+        case flow(NSAttributedString)
+        case image(altText: String, relativePath: String)
+        case fileLink(label: String, relativePath: String)
+    }
+
     private func markdownContent(_ markdown: String, sessionDirectory: URL? = nil) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            let sections = parseMarkdownSections(markdown)
-            ForEach(Array(sections.enumerated()), id: \.offset) { _, section in
-                if let heading = section.heading {
-                    Text(heading)
-                        .font(.system(size: section.level == 1 ? 18 : 15, weight: .bold))
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.top, section.level == 1 ? 4 : 2)
-                }
-                if !section.body.isEmpty {
-                    sectionBodyView(section.body, sessionDirectory: sessionDirectory)
+            let items = notesFlowItems(markdown)
+            ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                switch item {
+                case .flow(let attributed):
+                    SelectableTextFlow(
+                        attributedText: attributed,
+                        onLinkClick: { url, _ in openNotesLink(url, sessionDirectory: sessionDirectory) }
+                    )
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                case .image(let altText, let relativePath):
+                    localImagePreview(relativePath: relativePath, altText: altText, sessionDirectory: sessionDirectory)
+                case .fileLink(let label, let relativePath):
+                    localAttachmentPreview(label: label, relativePath: relativePath, sessionDirectory: sessionDirectory)
                 }
             }
         }
     }
 
-    @ViewBuilder
-    private func sectionBodyView(_ body: String, sessionDirectory: URL?) -> some View {
-        let blocks = NoteAssetMarkdownParser.parseBody(body)
-        ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
-            switch block {
-            case .text(let text):
-                if let attributed = try? AttributedString(markdown: text, options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)) {
-                    Text(attributed)
-                        .font(.system(size: 13))
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    Text(text)
-                        .font(.system(size: 13))
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+    /// Merges headings and text blocks into contiguous selectable flows so
+    /// selection spans the whole notes document; image and attachment previews
+    /// stay as interactive views between flows.
+    private func notesFlowItems(_ markdown: String) -> [NotesFlowItem] {
+        var items: [NotesFlowItem] = []
+        var flow = NSMutableAttributedString()
+
+        func appendBlock(_ block: NSAttributedString) {
+            if flow.length > 0 {
+                flow.append(MarkdownTextFlow.blockSeparator())
+            }
+            flow.append(block)
+        }
+        func flushFlow() {
+            guard flow.length > 0 else { return }
+            items.append(.flow(flow))
+            flow = NSMutableAttributedString()
+        }
+
+        for section in parseMarkdownSections(markdown) {
+            if let heading = section.heading {
+                appendBlock(MarkdownTextFlow.heading(heading, level: section.level))
+            }
+            guard !section.body.isEmpty else { continue }
+            for block in NoteAssetMarkdownParser.parseBody(section.body) {
+                switch block {
+                case .text(let text):
+                    appendBlock(MarkdownTextFlow.inlineMarkdown(text))
+                case .image(let altText, let relativePath):
+                    flushFlow()
+                    items.append(.image(altText: altText, relativePath: relativePath))
+                case .fileLink(let label, let relativePath):
+                    flushFlow()
+                    items.append(.fileLink(label: label, relativePath: relativePath))
                 }
-            case .image(let altText, let relativePath):
-                localImagePreview(relativePath: relativePath, altText: altText, sessionDirectory: sessionDirectory)
-            case .fileLink(let label, let relativePath):
-                localAttachmentPreview(label: label, relativePath: relativePath, sessionDirectory: sessionDirectory)
             }
         }
+        flushFlow()
+        return items
+    }
+
+    private func openNotesLink(_ url: URL, sessionDirectory: URL?) -> Bool {
+        if url.scheme == nil, let sessionDirectory {
+            let resolvedURL = sessionDirectory.appendingPathComponent(url.relativeString)
+            return NSWorkspace.shared.open(resolvedURL)
+        }
+        return NSWorkspace.shared.open(url)
     }
 
     @ViewBuilder

--- a/OpenOats/Sources/OpenOats/Views/SelectableTextFlow.swift
+++ b/OpenOats/Sources/OpenOats/Views/SelectableTextFlow.swift
@@ -1,0 +1,280 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Selectable Text Flow
+
+/// Renders an attributed string in a single non-editable `NSTextView`, so a
+/// selection can span the whole content (drag across lines, Cmd+A, Cmd+C).
+/// SwiftUI's per-`Text` `.textSelection(.enabled)` cannot select across views,
+/// which limited transcript and notes selection to one paragraph at a time.
+struct SelectableTextFlow: NSViewRepresentable {
+    let attributedText: NSAttributedString
+    /// Called when a link in the text is clicked, with the link URL and the
+    /// bounding rect of the link run in the view's coordinate space. Return
+    /// true if handled; returning false falls back to the system behavior.
+    /// When nil, all links use the system behavior (open URL).
+    var onLinkClick: ((URL, CGRect) -> Bool)? = nil
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> NSTextView {
+        let view = NSTextView(usingTextLayoutManager: false)
+        view.isEditable = false
+        view.isSelectable = true
+        view.drawsBackground = false
+        view.textContainerInset = .zero
+        view.textContainer?.lineFragmentPadding = 0
+        view.textContainer?.widthTracksTextView = true
+        view.isVerticallyResizable = false
+        view.isHorizontallyResizable = false
+        // Links carry their own styling in the attributed string; just show a hand cursor.
+        view.linkTextAttributes = [.cursor: NSCursor.pointingHand]
+        view.delegate = context.coordinator
+        return view
+    }
+
+    func updateNSView(_ nsView: NSTextView, context: Context) {
+        context.coordinator.onLinkClick = onLinkClick
+        guard let storage = nsView.textStorage else { return }
+        guard !storage.isEqual(to: attributedText) else { return }
+
+        let previousSelection = nsView.selectedRanges
+        storage.setAttributedString(attributedText)
+
+        // Keep the selection alive across live-transcript updates (text appends
+        // at the end, so absolute offsets stay valid).
+        let length = attributedText.length
+        let restored = previousSelection.compactMap { value -> NSValue? in
+            let range = value.rangeValue
+            guard range.location <= length else { return nil }
+            return NSValue(range: NSRange(
+                location: range.location,
+                length: min(range.length, length - range.location)
+            ))
+        }
+        if !restored.isEmpty {
+            nsView.selectedRanges = restored
+        }
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, nsView: NSTextView, context: Context) -> CGSize? {
+        guard let width = proposal.width, width.isFinite, width > 0,
+              let layoutManager = nsView.layoutManager,
+              let container = nsView.textContainer else { return nil }
+        container.size = NSSize(width: width, height: .greatestFiniteMagnitude)
+        layoutManager.ensureLayout(for: container)
+        let height = ceil(layoutManager.usedRect(for: container).height)
+        return CGSize(width: width, height: height)
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var onLinkClick: ((URL, CGRect) -> Bool)?
+
+        func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+            guard let onLinkClick else { return false }
+            let url: URL?
+            if let linkURL = link as? URL {
+                url = linkURL
+            } else if let linkString = link as? String {
+                url = URL(string: linkString)
+            } else {
+                url = nil
+            }
+            guard let url else { return false }
+
+            var rect = CGRect(x: 0, y: 0, width: 1, height: 1)
+            if let layoutManager = textView.layoutManager,
+               let container = textView.textContainer,
+               let storage = textView.textStorage,
+               charIndex < storage.length {
+                var linkRange = NSRange(location: charIndex, length: 1)
+                _ = storage.attribute(
+                    .link,
+                    at: charIndex,
+                    longestEffectiveRange: &linkRange,
+                    in: NSRange(location: 0, length: storage.length)
+                )
+                let glyphRange = layoutManager.glyphRange(forCharacterRange: linkRange, actualCharacterRange: nil)
+                rect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: container)
+                rect.origin.x += textView.textContainerOrigin.x
+                rect.origin.y += textView.textContainerOrigin.y
+            }
+            return onLinkClick(url, rect)
+        }
+    }
+}
+
+// MARK: - Transcript Flow Builder
+
+/// Builds the transcript as one attributed string whose column layout mirrors
+/// the previous per-row HStack: optional right-aligned timestamp column, then a
+/// right-aligned speaker column, then the utterance text with hanging indent.
+enum TranscriptFlow {
+    static let renameLinkScheme = "openoats-rename"
+
+    struct Line {
+        var timestamp: String?      // nil hides the timestamp for this row
+        var speakerLabel: String
+        var speakerColor: NSColor
+        var renameKey: String?      // non-nil makes the speaker label a rename link
+        var text: String
+        var textIsSecondary: Bool = false
+    }
+
+    static func renameURL(forKey key: String) -> URL? {
+        URL(string: "\(renameLinkScheme)://speaker/\(key)")
+    }
+
+    static func renameKey(from url: URL) -> String? {
+        guard url.scheme == renameLinkScheme else { return nil }
+        return url.lastPathComponent
+    }
+
+    static func speakerColumnWidth(forLabels labels: [String]) -> CGFloat {
+        let font = speakerFont()
+        return labels.reduce(CGFloat(36)) { widest, label in
+            max(widest, ceil((label as NSString).size(withAttributes: [.font: font]).width))
+        }
+    }
+
+    static func attributed(lines: [Line], showsTimestampColumn: Bool) -> NSAttributedString {
+        let timestampFont = NSFont.monospacedSystemFont(ofSize: 10, weight: .regular)
+        let bodyFont = NSFont.systemFont(ofSize: 13)
+        let speakerFont = speakerFont()
+
+        let timestampWidth: CGFloat = 34
+        let speakerWidth = speakerColumnWidth(forLabels: lines.map(\.speakerLabel))
+        let speakerRightEdge = showsTimestampColumn ? timestampWidth + 6 + speakerWidth : speakerWidth
+        let textStart = speakerRightEdge + (showsTimestampColumn ? 6 : 8)
+
+        let paragraph = NSMutableParagraphStyle()
+        var tabs: [NSTextTab] = []
+        if showsTimestampColumn {
+            tabs.append(NSTextTab(textAlignment: .right, location: timestampWidth))
+        }
+        tabs.append(NSTextTab(textAlignment: .right, location: speakerRightEdge))
+        tabs.append(NSTextTab(textAlignment: .left, location: textStart))
+        paragraph.tabStops = tabs
+        paragraph.headIndent = textStart
+        paragraph.paragraphSpacing = 8
+        paragraph.lineBreakMode = .byWordWrapping
+
+        let result = NSMutableAttributedString()
+        for (index, line) in lines.enumerated() {
+            if index > 0 {
+                result.append(NSAttributedString(string: "\n", attributes: [
+                    .font: bodyFont,
+                    .paragraphStyle: paragraph,
+                ]))
+            }
+
+            let timestampField = showsTimestampColumn ? "\t\(line.timestamp ?? "")\t" : "\t"
+            result.append(NSAttributedString(string: timestampField, attributes: [
+                .font: timestampFont,
+                .foregroundColor: NSColor.tertiaryLabelColor,
+                .paragraphStyle: paragraph,
+            ]))
+
+            var speakerAttributes: [NSAttributedString.Key: Any] = [
+                .font: speakerFont,
+                .foregroundColor: line.speakerColor,
+                .paragraphStyle: paragraph,
+            ]
+            if let key = line.renameKey, let url = renameURL(forKey: key) {
+                speakerAttributes[.link] = url
+                speakerAttributes[.toolTip] = "Rename speaker"
+            }
+            result.append(NSAttributedString(string: line.speakerLabel, attributes: speakerAttributes))
+
+            result.append(NSAttributedString(string: "\t\(line.text)", attributes: [
+                .font: bodyFont,
+                .foregroundColor: line.textIsSecondary ? NSColor.secondaryLabelColor : NSColor.labelColor,
+                .paragraphStyle: paragraph,
+            ]))
+        }
+        return result
+    }
+
+    private static func speakerFont() -> NSFont {
+        NSFont.systemFont(ofSize: 11, weight: .semibold)
+    }
+}
+
+// MARK: - Markdown Flow Builder
+
+/// Converts note markdown pieces into attributed strings for a single
+/// selectable flow, matching the previous per-block `Text` styling.
+enum MarkdownTextFlow {
+    /// Blank-line separator between blocks: a newline ends the previous
+    /// paragraph, then an empty paragraph with a fixed line height provides the
+    /// vertical gap (copies out as a plain blank line).
+    static func blockSeparator(gap: CGFloat = 12) -> NSAttributedString {
+        let result = NSMutableAttributedString(string: "\n", attributes: [
+            .font: NSFont.systemFont(ofSize: 13),
+        ])
+        let gapStyle = NSMutableParagraphStyle()
+        gapStyle.minimumLineHeight = gap
+        gapStyle.maximumLineHeight = gap
+        result.append(NSAttributedString(string: "\n", attributes: [
+            .font: NSFont.systemFont(ofSize: 2),
+            .paragraphStyle: gapStyle,
+        ]))
+        return result
+    }
+
+    static func heading(_ text: String, level: Int) -> NSAttributedString {
+        let style = NSMutableParagraphStyle()
+        style.paragraphSpacingBefore = level == 1 ? 4 : 2
+        style.lineBreakMode = .byWordWrapping
+        return NSAttributedString(string: text, attributes: [
+            .font: NSFont.systemFont(ofSize: level == 1 ? 18 : 15, weight: .bold),
+            .foregroundColor: NSColor.labelColor,
+            .paragraphStyle: style,
+        ])
+    }
+
+    static func inlineMarkdown(_ text: String) -> NSAttributedString {
+        let baseFont = NSFont.systemFont(ofSize: 13)
+        let style = NSMutableParagraphStyle()
+        style.lineBreakMode = .byWordWrapping
+
+        let parsed = (try? AttributedString(
+            markdown: text,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(text)
+
+        let result = NSMutableAttributedString()
+        for run in parsed.runs {
+            var font = baseFont
+            var attributes: [NSAttributedString.Key: Any] = [
+                .foregroundColor: NSColor.labelColor,
+                .paragraphStyle: style,
+            ]
+            if let intent = run.inlinePresentationIntent {
+                if intent.contains(.code) {
+                    font = NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)
+                }
+                var traits: NSFontDescriptor.SymbolicTraits = []
+                if intent.contains(.stronglyEmphasized) { traits.insert(.bold) }
+                if intent.contains(.emphasized) { traits.insert(.italic) }
+                if !traits.isEmpty {
+                    let descriptor = font.fontDescriptor.withSymbolicTraits(
+                        font.fontDescriptor.symbolicTraits.union(traits)
+                    )
+                    font = NSFont(descriptor: descriptor, size: font.pointSize) ?? font
+                }
+                if intent.contains(.strikethrough) {
+                    attributes[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+                }
+            }
+            if let link = run.link {
+                attributes[.link] = link
+                attributes[.foregroundColor] = NSColor.linkColor
+                attributes[.underlineStyle] = NSUnderlineStyle.single.rawValue
+            }
+            attributes[.font] = font
+            result.append(NSAttributedString(string: String(parsed.characters[run.range]), attributes: attributes))
+        }
+        return result
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/TranscriptView.swift
+++ b/OpenOats/Sources/OpenOats/Views/TranscriptView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 struct TranscriptView: View {
@@ -96,27 +97,36 @@ struct TranscriptView: View {
                     .frame(maxWidth: .infinity, minHeight: 110)
                     .padding(16)
                 } else {
-                    LazyVStack(alignment: .leading, spacing: 8) {
-                        ForEach(0..<visible.count, id: \.self) { index in
-                            let utterance = visible[index]
-                            UtteranceBubble(
-                                utterance: utterance,
-                                showTimestamp: shouldShowTimestamp(at: index, in: visible)
-                            )
-                            .id(utterance.id)
+                    let speakerColumnWidth = TranscriptFlow.speakerColumnWidth(
+                        forLabels: visible.map(\.speaker.displayLabel)
+                    )
+                    VStack(alignment: .leading, spacing: 8) {
+                        if !visible.isEmpty {
+                            SelectableTextFlow(attributedText: transcriptFlowText(for: visible))
+                                .frame(maxWidth: .infinity, alignment: .leading)
                         }
 
                         if !isSearching {
                             if !volatileYouText.isEmpty {
-                                VolatileIndicator(text: volatileYouText, speaker: .you)
-                                    .id("volatile-you")
+                                VolatileIndicator(
+                                    text: volatileYouText,
+                                    speaker: .you,
+                                    speakerColumnWidth: speakerColumnWidth
+                                )
                             }
 
                             if !volatileThemText.isEmpty {
-                                VolatileIndicator(text: volatileThemText, speaker: .them)
-                                    .id("volatile-them")
+                                VolatileIndicator(
+                                    text: volatileThemText,
+                                    speaker: .them,
+                                    speakerColumnWidth: speakerColumnWidth
+                                )
                             }
                         }
+
+                        Color.clear
+                            .frame(height: 1)
+                            .id("transcript-bottom")
                     }
                     .padding(16)
                 }
@@ -124,32 +134,28 @@ struct TranscriptView: View {
             .onChange(of: utterances.count) {
                 guard !isSearching, autoScrollEnabled else { return }
                 withAnimation(.easeOut(duration: 0.2)) {
-                    if let last = utterances.last {
-                        proxy.scrollTo(last.id, anchor: .bottom)
-                    }
+                    proxy.scrollTo("transcript-bottom", anchor: .bottom)
                 }
             }
             .onChange(of: volatileYouText) {
                 guard !isSearching, autoScrollEnabled else { return }
-                proxy.scrollTo("volatile-you", anchor: .bottom)
+                proxy.scrollTo("transcript-bottom", anchor: .bottom)
             }
             .onChange(of: volatileThemText) {
                 guard !isSearching, autoScrollEnabled else { return }
-                proxy.scrollTo("volatile-them", anchor: .bottom)
+                proxy.scrollTo("transcript-bottom", anchor: .bottom)
             }
             .onChange(of: searchText) {
-                if searchText.isEmpty, autoScrollEnabled, let last = utterances.last {
-                    proxy.scrollTo(last.id, anchor: .bottom)
+                if searchText.isEmpty, autoScrollEnabled {
+                    proxy.scrollTo("transcript-bottom", anchor: .bottom)
                 }
             }
             .overlay(alignment: .bottomTrailing) {
                 if !autoScrollEnabled {
                     Button {
                         autoScrollEnabled = true
-                        if let last = utterances.last {
-                            withAnimation(.easeOut(duration: 0.2)) {
-                                proxy.scrollTo(last.id, anchor: .bottom)
-                            }
+                        withAnimation(.easeOut(duration: 0.2)) {
+                            proxy.scrollTo("transcript-bottom", anchor: .bottom)
                         }
                     } label: {
                         Image(systemName: "arrow.down.circle.fill")
@@ -172,6 +178,21 @@ struct TranscriptView: View {
         let previous = Calendar.current.dateComponents([.hour, .minute], from: visible[index - 1].timestamp)
         return current.hour != previous.hour || current.minute != previous.minute
     }
+
+    private func transcriptFlowText(for visible: [Utterance]) -> NSAttributedString {
+        let lines = visible.enumerated().map { index, utterance in
+            TranscriptFlow.Line(
+                timestamp: shouldShowTimestamp(at: index, in: visible)
+                    ? timestampFormatter.string(from: utterance.timestamp)
+                    : nil,
+                speakerLabel: utterance.speaker.displayLabel,
+                speakerColor: NSColor(utterance.speaker.color),
+                renameKey: nil,
+                text: utterance.displayText
+            )
+        }
+        return TranscriptFlow.attributed(lines: lines, showsTimestampColumn: true)
+    }
 }
 
 // MARK: - Timestamp Formatter
@@ -182,38 +203,10 @@ private let timestampFormatter: DateFormatter = {
     return f
 }()
 
-private struct UtteranceBubble: View {
-    let utterance: Utterance
-    var showTimestamp: Bool = true
-
-    var body: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 6) {
-            if showTimestamp {
-                Text(timestampFormatter.string(from: utterance.timestamp))
-                    .font(.system(size: 10, design: .monospaced))
-                    .foregroundStyle(.tertiary)
-                    .frame(width: 34, alignment: .trailing)
-            } else {
-                Spacer()
-                    .frame(width: 34)
-            }
-
-            Text(utterance.speaker.displayLabel)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(utterance.speaker.color)
-                .frame(minWidth: 36, alignment: .trailing)
-
-            Text(utterance.displayText)
-                .font(.system(size: 13))
-                .foregroundStyle(.primary)
-                .textSelection(.enabled)
-        }
-    }
-}
-
 private struct VolatileIndicator: View {
     let text: String
     let speaker: Speaker
+    var speakerColumnWidth: CGFloat = 36
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
@@ -223,7 +216,7 @@ private struct VolatileIndicator: View {
             Text(speaker.displayLabel)
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(speaker.color)
-                .frame(minWidth: 36, alignment: .trailing)
+                .frame(width: max(36, speakerColumnWidth), alignment: .trailing)
 
             HStack(spacing: 4) {
                 Text(text)


### PR DESCRIPTION
## Bug

Text selection in the transcript and notes views only works one line/paragraph at a time:

- Dragging the cursor across multiple transcript lines doesn't extend the selection
- Cmd+A doesn't select anything
- Same for paragraphs in the generated notes

**Cause:** each transcript row and notes block is its own SwiftUI `Text` with `.textSelection(.enabled)`, and SwiftUI on macOS can't select across separate `Text` views.

## Fix

New `SelectableTextFlow` view (`Views/SelectableTextFlow.swift`): a non-editable, selectable `NSTextView` that renders the whole content as one text flow, so selection behaves like native macOS text — drag across everything, Cmd+A, Cmd+C, right-click → Copy.

Wired into the three affected surfaces:

- **Live transcript** (`TranscriptView`): the utterance list renders as one flow. The timestamp / speaker / text column layout is reproduced with tab stops (right-aligned timestamp at 34pt, right-aligned speaker column sized to the widest label, hanging indent for wrapped lines). Auto-scroll now targets a bottom anchor instead of per-row IDs; search filtering and the volatile (in-progress) indicators are unchanged, with the volatile rows aligned to the same speaker column width.
- **Session transcript** (`MeetingDetailPane`): same flow rendering. Speaker renaming is preserved — renameable speaker labels are links (`openoats-rename://` scheme, styled identically, hand cursor) that open the existing `SpeakerRenamePopover`, anchored at the clicked label via the link run's bounding rect. Cleanup styling (secondary color while cleaning) and the original/cleaned toggle behave as before.
- **Notes** (`MeetingDetailPane`): headings and markdown text blocks merge into continuous selectable flows (inline bold/italic/code/links mapped to `NSAttributedString`); image and attachment previews stay as interactive cards between flows. Relative asset links keep resolving against the session directory. Copied text preserves blank lines between blocks.

Selection is preserved across live-transcript updates (ranges are restored after the text storage is replaced; new text appends at the end so offsets stay valid).

## Testing

- `swift build -c debug` clean (no new warnings)
- Manually verified in the app: drag-selection across many transcript lines, Cmd+A / Cmd+C in live transcript, session transcript, and notes; speaker rename popover still opens from the label; auto-scroll and search still work
