### PR TITLE
Add Export to .txt/.pdf/.docx in the session detail toolbar

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ContentExporter.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentExporter.swift
@@ -1,0 +1,156 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+// MARK: - Export Format
+
+enum ExportFormat: CaseIterable {
+    case plainText
+    case pdf
+    case docx
+
+    var menuTitle: String {
+        switch self {
+        case .plainText: "Plain Text (.txt)"
+        case .pdf: "PDF (.pdf)"
+        case .docx: "Word (.docx)"
+        }
+    }
+
+    var fileExtension: String {
+        switch self {
+        case .plainText: "txt"
+        case .pdf: "pdf"
+        case .docx: "docx"
+        }
+    }
+
+    var contentType: UTType {
+        switch self {
+        case .plainText: .plainText
+        case .pdf: .pdf
+        case .docx: UTType("org.openxmlformats.wordprocessingml.document") ?? .data
+        }
+    }
+}
+
+// MARK: - Content Exporter
+
+/// Saves meeting content to a user-chosen file as plain text, PDF, or Word.
+@MainActor
+enum ContentExporter {
+    enum ExportError: LocalizedError {
+        case pdfGenerationFailed
+
+        var errorDescription: String? {
+            switch self {
+            case .pdfGenerationFailed: "The PDF could not be generated."
+            }
+        }
+    }
+
+    static func export(
+        plainText: @autoclosure () -> String,
+        attributedText: @autoclosure () -> NSAttributedString,
+        format: ExportFormat,
+        suggestedFileName: String
+    ) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [format.contentType]
+        panel.canCreateDirectories = true
+        panel.isExtensionHidden = false
+        panel.nameFieldStringValue = "\(sanitizedFileName(suggestedFileName)).\(format.fileExtension)"
+        // The main window is a non-activating panel; without this the save
+        // dialog can open behind other windows.
+        NSApp.activate(ignoringOtherApps: true)
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            switch format {
+            case .plainText:
+                try plainText().write(to: url, atomically: true, encoding: .utf8)
+            case .pdf:
+                try writePDF(resolvingColors(in: attributedText()), to: url)
+            case .docx:
+                try writeDocx(resolvingColors(in: attributedText()), to: url)
+            }
+        } catch {
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = "Export Failed"
+            alert.informativeText = error.localizedDescription
+            alert.runModal()
+        }
+    }
+
+    private static func sanitizedFileName(_ name: String) -> String {
+        let cleaned = name
+            .components(separatedBy: CharacterSet(charactersIn: "/:\\"))
+            .joined(separator: "-")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned.isEmpty ? "Export" : cleaned
+    }
+
+    // MARK: Writers
+
+    private static func writePDF(_ text: NSAttributedString, to url: URL) throws {
+        let printInfo = NSPrintInfo()
+        printInfo.topMargin = 54
+        printInfo.bottomMargin = 54
+        printInfo.leftMargin = 54
+        printInfo.rightMargin = 54
+        printInfo.horizontalPagination = .fit
+        printInfo.verticalPagination = .automatic
+        printInfo.jobDisposition = .save
+        printInfo.dictionary()[NSPrintInfo.AttributeKey.jobSavingURL] = url
+
+        let pageWidth = printInfo.paperSize.width - printInfo.leftMargin - printInfo.rightMargin
+        let textView = NSTextView(usingTextLayoutManager: false)
+        textView.appearance = NSAppearance(named: .aqua)
+        textView.textContainerInset = .zero
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainer?.size = NSSize(width: pageWidth, height: .greatestFiniteMagnitude)
+        textView.textStorage?.setAttributedString(text)
+
+        var contentHeight: CGFloat = 1
+        if let layoutManager = textView.layoutManager, let container = textView.textContainer {
+            layoutManager.ensureLayout(for: container)
+            contentHeight = max(ceil(layoutManager.usedRect(for: container).height), 1)
+        }
+        textView.frame = NSRect(x: 0, y: 0, width: pageWidth, height: contentHeight)
+
+        let operation = NSPrintOperation(view: textView, printInfo: printInfo)
+        operation.showsPrintPanel = false
+        operation.showsProgressPanel = false
+        guard operation.run() else {
+            throw ExportError.pdfGenerationFailed
+        }
+    }
+
+    private static func writeDocx(_ text: NSAttributedString, to url: URL) throws {
+        let data = try text.data(
+            from: NSRange(location: 0, length: text.length),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.officeOpenXML]
+        )
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// Resolves dynamic system colors to light appearance so a dark-mode
+    /// export doesn't come out as white text on a white page.
+    private static func resolvingColors(in text: NSAttributedString) -> NSAttributedString {
+        guard let aqua = NSAppearance(named: .aqua) else { return text }
+        let result = NSMutableAttributedString(attributedString: text)
+        result.enumerateAttribute(
+            .foregroundColor,
+            in: NSRange(location: 0, length: result.length)
+        ) { value, range, _ in
+            guard let color = value as? NSColor else { return }
+            var resolved = color
+            aqua.performAsCurrentDrawingAppearance {
+                resolved = NSColor(cgColor: color.cgColor) ?? color
+            }
+            result.addAttribute(.foregroundColor, value: resolved, range: range)
+        }
+        return result
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
+++ b/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
@@ -1556,6 +1556,39 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
         }
 
         copyCurrentContentButton(state: state)
+        exportCurrentContentMenu(state: state)
+    }
+
+    private func exportCurrentContentMenu(state: NotesState) -> some View {
+        Menu {
+            ForEach(ExportFormat.allCases, id: \.self) { format in
+                Button(format.menuTitle) {
+                    ContentExporter.export(
+                        plainText: currentContentPlainText(state: state),
+                        attributedText: currentContentAttributedText(state: state),
+                        format: format,
+                        suggestedFileName: exportSuggestedFileName(state: state)
+                    )
+                }
+            }
+        } label: {
+            Label("Export", systemImage: "square.and.arrow.up")
+                .font(.system(size: 12))
+        }
+        .menuStyle(.button)
+        .buttonStyle(.bordered)
+        .disabled(copyContentIsEmpty(state: state))
+        .help("Export as file")
+    }
+
+    private func exportSuggestedFileName(state: NotesState) -> String {
+        let session = selectedSession(in: state)
+        let title = session?.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        var name = (title?.isEmpty == false ? title! : "Meeting")
+        if let startedAt = session?.startedAt {
+            name += " " + startedAt.formatted(.iso8601.year().month().day())
+        }
+        return "\(name) - \(detailViewMode.rawValue)"
     }
 
     @ViewBuilder
@@ -3724,22 +3757,93 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
     // MARK: - Actions
 
     private func copyCurrentContent(state: NotesState) {
-        let text: String
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(currentContentPlainText(state: state), forType: .string)
+    }
+
+    private func currentContentPlainText(state: NotesState) -> String {
         switch detailViewMode {
         case .transcript:
-            text = state.loadedTranscript.map { record in
+            return state.loadedTranscript.map { record in
                 let label = record.speaker.displayLabel
                 let content = state.showingOriginal ? record.text : (record.cleanedText ?? record.text)
                 return "[\(MeetingDetailPaneFormatters.transcriptTimeFormatter.string(from: record.timestamp))] \(label): \(content)"
             }.joined(separator: "\n")
         case .notes:
-            text = state.loadedTranscript.isEmpty ? state.manualNotesDraft : (state.loadedNotes?.markdown ?? "")
+            return state.loadedTranscript.isEmpty ? state.manualNotesDraft : (state.loadedNotes?.markdown ?? "")
         case .ask:
-            text = formattedAskConversation()
+            return formattedAskConversation()
+        }
+    }
+
+    private func currentContentAttributedText(state: NotesState) -> NSAttributedString {
+        switch detailViewMode {
+        case .transcript:
+            let speakerNames = selectedSession(in: state)?.speakerNames
+            let lines = state.loadedTranscript.map { record in
+                TranscriptFlow.Line(
+                    timestamp: MeetingDetailPaneFormatters.transcriptTimeFormatter.string(from: record.timestamp),
+                    speakerLabel: record.speaker.displayName(speakerNames: speakerNames),
+                    speakerColor: NSColor(record.speaker.color),
+                    renameKey: nil,
+                    text: state.showingOriginal ? record.text : (record.cleanedText ?? record.text)
+                )
+            }
+            // "HH:mm:ss" needs a wider column than the on-screen "HH:mm" default.
+            return TranscriptFlow.attributed(lines: lines, showsTimestampColumn: true, timestampColumnWidth: 50)
+        case .notes:
+            let markdown = state.loadedTranscript.isEmpty
+                ? state.manualNotesDraft
+                : (state.loadedNotes?.markdown ?? "")
+            return notesExportAttributedText(markdown)
+        case .ask:
+            return askExportAttributedText()
+        }
+    }
+
+    /// Image and attachment blocks become placeholder lines since the export
+    /// is a text document.
+    private func notesExportAttributedText(_ markdown: String) -> NSAttributedString {
+        let flow = NSMutableAttributedString()
+        func appendBlock(_ block: NSAttributedString) {
+            if flow.length > 0 {
+                flow.append(MarkdownTextFlow.blockSeparator())
+            }
+            flow.append(block)
         }
 
-        NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(text, forType: .string)
+        for section in parseMarkdownSections(markdown) {
+            if let heading = section.heading {
+                appendBlock(MarkdownTextFlow.heading(heading, level: section.level))
+            }
+            guard !section.body.isEmpty else { continue }
+            for block in NoteAssetMarkdownParser.parseBody(section.body) {
+                switch block {
+                case .text(let text):
+                    appendBlock(MarkdownTextFlow.inlineMarkdown(text))
+                case .image(let altText, let relativePath):
+                    let name = altText.isEmpty ? (relativePath as NSString).lastPathComponent : altText
+                    appendBlock(MarkdownTextFlow.inlineMarkdown("*[Image: \(name)]*"))
+                case .fileLink(let label, let relativePath):
+                    let name = label.isEmpty ? (relativePath as NSString).lastPathComponent : label
+                    appendBlock(MarkdownTextFlow.inlineMarkdown("*[Attachment: \(name)]*"))
+                }
+            }
+        }
+        return flow
+    }
+
+    private func askExportAttributedText() -> NSAttributedString {
+        let flow = NSMutableAttributedString()
+        for message in askMessages {
+            if flow.length > 0 {
+                flow.append(MarkdownTextFlow.blockSeparator())
+            }
+            flow.append(MarkdownTextFlow.heading(message.role == .user ? "You" : "OpenOats", level: 3))
+            flow.append(MarkdownTextFlow.blockSeparator(gap: 4))
+            flow.append(MarkdownTextFlow.inlineMarkdown(message.text))
+        }
+        return flow
     }
 
     private func submitAskQuestion(state: NotesState) {

--- a/OpenOats/Sources/OpenOats/Views/SelectableTextFlow.swift
+++ b/OpenOats/Sources/OpenOats/Views/SelectableTextFlow.swift
@@ -137,12 +137,16 @@ enum TranscriptFlow {
         }
     }
 
-    static func attributed(lines: [Line], showsTimestampColumn: Bool) -> NSAttributedString {
+    static func attributed(
+        lines: [Line],
+        showsTimestampColumn: Bool,
+        timestampColumnWidth: CGFloat = 34
+    ) -> NSAttributedString {
         let timestampFont = NSFont.monospacedSystemFont(ofSize: 10, weight: .regular)
         let bodyFont = NSFont.systemFont(ofSize: 13)
         let speakerFont = speakerFont()
 
-        let timestampWidth: CGFloat = 34
+        let timestampWidth = timestampColumnWidth
         let speakerWidth = speakerColumnWidth(forLabels: lines.map(\.speakerLabel))
         let speakerRightEdge = showsTimestampColumn ? timestampWidth + 6 + speakerWidth : speakerWidth
         let textStart = speakerRightEdge + (showsTimestampColumn ? 6 : 8)


### PR DESCRIPTION
Follow-up to #696.

## What

An **Export** menu (share icon, next to the Copy button) in the session detail toolbar, offering **Plain Text (.txt)**, **PDF (.pdf)**, and **Word (.docx)**. It exports whatever the current tab shows:

- **Transcript** — `[HH:mm:ss] Speaker: text` in plain text; the PDF/Word version keeps the timestamp column, colored speaker labels, and hanging indents (custom speaker names respected)
- **Notes** — raw markdown in plain text; headings and inline styling in PDF/Word (image/attachment blocks become `[Image: …]` / `[Attachment: …]` placeholder lines)
- **Ask** — the conversation with You/OpenOats headings

A save panel proposes a name like `Meeting 2026-08-27 - Transcript.pdf` from the session title and date; the button is disabled when the tab is empty.

## How

- `ContentExporter` (new): save panel + three writers. Plain text shares the exact string the Copy button produces (extracted into `currentContentPlainText`). PDF renders the attributed string through an `NSTextView` + `NSPrintOperation` with `jobDisposition = .save`, so pagination is handled by the print system. Word uses `NSAttributedString`'s `.officeOpenXML` document type.
- Dynamic system colors are resolved to their light-appearance values before writing, so exporting while the app is in dark mode doesn't yield white text on a white page. The app is activated before `runModal()` so the save dialog can't open behind other windows (the main window is a non-activating panel).
- `TranscriptFlow.attributed` (from #696) gains an optional `timestampColumnWidth` (default unchanged) because the export's `HH:mm:ss` needs a wider column than the on-screen `HH:mm`.

## Testing

- `swift build -c debug` clean
- Writer code exercised headlessly with an 80-line transcript: produces a valid 5-page PDF (verified page 1 renders with correct columns, colors, hanging indents) and a valid Word 2007+ `.docx` (content confirmed in `word/document.xml`)
- Manually exercised in the app: all three formats from each tab, save panel naming, empty-tab disabled state
