### PR TITLE
Fix the "View" picker label wrapping to two lines in the detail toolbar

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
+++ b/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
@@ -1510,12 +1510,18 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
     private func detailToolbar(controller: NotesController, state: NotesState) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
+                Text("View")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .fixedSize()
+
                 Picker("View", selection: $detailViewMode) {
                     ForEach(MeetingDetailViewMode.allCases, id: \.self) { mode in
                         Text(mode.rawValue).tag(mode)
                     }
                 }
                 .pickerStyle(.segmented)
+                .labelsHidden()
                 .frame(minWidth: 120, maxWidth: 220)
                 .layoutPriority(1)
 


### PR DESCRIPTION
## Bug

The "View" label next to the Transcript / Notes / Ask segmented control in the session detail toolbar wraps onto two lines, rendering as "Vie" / "w".

**Cause:** on macOS a SwiftUI `Picker` renders its title as visible text next to the control, and the `.frame(minWidth: 120, maxWidth: 220)` caps the *labeled* picker as a whole. The three segments consume essentially the full width, leaving the built-in label a sliver, so it wraps.

## Fix

Render the label as an explicit `Text("View")` with `.fixedSize()` beside the picker (so it can never wrap), and add `.labelsHidden()` to the picker — the title is kept for VoiceOver while the width cap now applies only to the segmented control.
