### PR TITLE
Prefer real meetings over overlapping personal blocks when binding a session to a calendar event

### DIFF
--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -55,7 +55,8 @@ final class CalendarManager {
 
     // MARK: - Event Lookup
 
-    /// Find the calendar event that best overlaps the given date (typically now).
+    /// Find the calendar event the given date (typically now) most likely belongs to.
+    /// Real meetings are preferred over personal blocks — see `CalendarEventMatcher`.
     /// Returns nil if no event is found or access is not authorized.
     func currentEvent(
         at date: Date = Date(),
@@ -74,20 +75,11 @@ final class CalendarManager {
             end: windowEnd,
             calendars: calendars
         )
-        let events = store.events(matching: predicate)
-
-        // Prefer the event whose start is closest to now, breaking ties by duration
-        let best = events
+        let candidates = store.events(matching: predicate)
             .filter { !$0.isAllDay }
-            .min { a, b in
-                let distA = abs(a.startDate.timeIntervalSince(date))
-                let distB = abs(b.startDate.timeIntervalSince(date))
-                if distA != distB { return distA < distB }
-                return a.startDate < b.startDate
-            }
+            .map { CalendarEvent(from: $0) }
 
-        guard let best else { return nil }
-        return CalendarEvent(from: best)
+        return CalendarEventMatcher.bestMatch(among: candidates, at: date)
     }
 
     /// Upcoming calendar events starting within the given time window, ordered by start date.
@@ -227,6 +219,46 @@ extension Participant {
             name: attendee.name,
             email: attendee.url.absoluteString
                 .replacingOccurrences(of: "mailto:", with: "")
+        )
+    }
+}
+
+// MARK: - Candidate Ranking
+
+/// Picks which of several overlapping calendar events a recording belongs to.
+///
+/// Start-time proximity alone is not enough. Personal blocks — family events,
+/// focus time, reminders — routinely start on the same clock boundary as a real
+/// meeting, and when the distances tie the winner is whatever order EventKit
+/// happened to return. Events that carry invitees or a conference link are
+/// ranked ahead of those that carry neither, so a genuine meeting always beats a
+/// solo block that merely overlaps it.
+enum CalendarEventMatcher {
+    /// True when the event looks like something worth recording: it has invitees,
+    /// or a join link / online-meeting hint.
+    static func isLikelyMeeting(_ event: CalendarEvent) -> Bool {
+        event.isOnlineMeeting || !event.participants.isEmpty
+    }
+
+    /// Returns the best match for `date`, or nil when there are no candidates.
+    static func bestMatch(among events: [CalendarEvent], at date: Date) -> CalendarEvent? {
+        events.min { lhs, rhs in
+            sortKey(for: lhs, at: date) < sortKey(for: rhs, at: date)
+        }
+    }
+
+    /// Lexicographic ranking key, lowest wins: real meetings first, then the
+    /// closest start, then the shorter event. `startDate` keeps ties deterministic
+    /// rather than dependent on EventKit's ordering.
+    private static func sortKey(
+        for event: CalendarEvent,
+        at date: Date
+    ) -> (Int, TimeInterval, TimeInterval, Date) {
+        (
+            isLikelyMeeting(event) ? 0 : 1,
+            abs(event.startDate.timeIntervalSince(date)),
+            event.endDate.timeIntervalSince(event.startDate),
+            event.startDate
         )
     }
 }

--- a/OpenOats/Tests/OpenOatsTests/CalendarEventMatcherTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/CalendarEventMatcherTests.swift
@@ -1,0 +1,148 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class CalendarEventMatcherTests: XCTestCase {
+    private func makeEvent(
+        id: String,
+        title: String,
+        start: Date,
+        durationMinutes: Double,
+        participants: [Participant] = [],
+        isOnlineMeeting: Bool = false
+    ) -> CalendarEvent {
+        CalendarEvent(
+            id: id,
+            title: title,
+            startDate: start,
+            endDate: start.addingTimeInterval(durationMinutes * 60),
+            calendarTitle: nil,
+            organizer: nil,
+            participants: participants,
+            isOnlineMeeting: isOnlineMeeting,
+            meetingURL: nil
+        )
+    }
+
+    private let noon = Date(timeIntervalSinceReferenceDate: 800_000_000)
+
+    // The regression this ranking exists for: a personal all-hands-free block and a
+    // real meeting start on the same clock boundary, so start-distance ties and the
+    // winner used to be whichever one EventKit listed first.
+    func testPrefersInvitedMeetingWhenStartTimesTie() {
+        let personalBlock = makeEvent(
+            id: "personal",
+            title: "Kids - Prep Group Class",
+            start: noon,
+            durationMinutes: 60
+        )
+        let realMeeting = makeEvent(
+            id: "meeting",
+            title: "Quarterly Review",
+            start: noon,
+            durationMinutes: 60,
+            participants: [Participant(name: "Ada", email: "ada@example.com")]
+        )
+
+        // Both orderings must produce the same winner.
+        for candidates in [[personalBlock, realMeeting], [realMeeting, personalBlock]] {
+            let best = CalendarEventMatcher.bestMatch(
+                among: candidates,
+                at: noon.addingTimeInterval(103)
+            )
+            XCTAssertEqual(best?.id, "meeting")
+        }
+    }
+
+    func testPrefersOnlineMeetingOverCloserPersonalBlock() {
+        let personalBlock = makeEvent(
+            id: "personal",
+            title: "Focus time",
+            start: noon,
+            durationMinutes: 120
+        )
+        let onlineMeeting = makeEvent(
+            id: "meeting",
+            title: "Standup",
+            start: noon.addingTimeInterval(10 * 60),
+            durationMinutes: 15,
+            isOnlineMeeting: true
+        )
+
+        let best = CalendarEventMatcher.bestMatch(among: [personalBlock, onlineMeeting], at: noon)
+
+        XCTAssertEqual(best?.id, "meeting")
+    }
+
+    func testPrefersClosestStartAmongMeetings() {
+        let earlier = makeEvent(
+            id: "earlier",
+            title: "Design Sync",
+            start: noon.addingTimeInterval(-12 * 60),
+            durationMinutes: 30,
+            isOnlineMeeting: true
+        )
+        let closer = makeEvent(
+            id: "closer",
+            title: "1:1",
+            start: noon.addingTimeInterval(-2 * 60),
+            durationMinutes: 30,
+            isOnlineMeeting: true
+        )
+
+        let best = CalendarEventMatcher.bestMatch(among: [earlier, closer], at: noon)
+
+        XCTAssertEqual(best?.id, "closer")
+    }
+
+    func testPrefersShorterEventWhenMeetingsTieOnStart() {
+        let long = makeEvent(
+            id: "long",
+            title: "Offsite",
+            start: noon,
+            durationMinutes: 240,
+            isOnlineMeeting: true
+        )
+        let short = makeEvent(
+            id: "short",
+            title: "Kickoff",
+            start: noon,
+            durationMinutes: 30,
+            isOnlineMeeting: true
+        )
+
+        let best = CalendarEventMatcher.bestMatch(among: [long, short], at: noon)
+
+        XCTAssertEqual(best?.id, "short")
+    }
+
+    // Recording an in-person meeting that nobody was invited to is still supported:
+    // with no meeting-like candidate, ranking falls back to closest start.
+    func testFallsBackToClosestStartWhenNoCandidateLooksLikeAMeeting() {
+        let far = makeEvent(id: "far", title: "Errand", start: noon.addingTimeInterval(-14 * 60), durationMinutes: 30)
+        let near = makeEvent(id: "near", title: "Coffee", start: noon.addingTimeInterval(60), durationMinutes: 30)
+
+        let best = CalendarEventMatcher.bestMatch(among: [far, near], at: noon)
+
+        XCTAssertEqual(best?.id, "near")
+    }
+
+    func testReturnsNilWithoutCandidates() {
+        XCTAssertNil(CalendarEventMatcher.bestMatch(among: [], at: noon))
+    }
+
+    func testIsLikelyMeetingRequiresInviteesOrOnlineHint() {
+        let bare = makeEvent(id: "bare", title: "Block", start: noon, durationMinutes: 30)
+        let invited = makeEvent(
+            id: "invited",
+            title: "Review",
+            start: noon,
+            durationMinutes: 30,
+            participants: [Participant(name: nil, email: "ada@example.com")]
+        )
+        let online = makeEvent(id: "online", title: "Call", start: noon, durationMinutes: 30, isOnlineMeeting: true)
+
+        XCTAssertFalse(CalendarEventMatcher.isLikelyMeeting(bare))
+        XCTAssertTrue(CalendarEventMatcher.isLikelyMeeting(invited))
+        XCTAssertTrue(CalendarEventMatcher.isLikelyMeeting(online))
+    }
+}


### PR DESCRIPTION
## The bug

`CalendarManager.currentEvent` ranks candidate events by how close their start is to the lookup instant, breaking ties on `startDate`:

```swift
.min { a, b in
    let distA = abs(a.startDate.timeIntervalSince(date))
    let distB = abs(b.startDate.timeIntervalSince(date))
    if distA != distB { return distA < distB }
    return a.startDate < b.startDate   // identical starts → always false
}
```

When two events start on the same clock boundary both keys tie, `min` keeps whichever element came first, and the answer is really EventKit's ordering. That is not a rare corner — personal blocks and meetings are both scheduled on the hour.

I hit it with a recording that started at 20:01:43:

| Event | Start | Attendees | Online |
|---|---|---|---|
| `Mimi - Prep Group Class` (Family Calendar) | 20:00:00 | 0 | no |
| the actual video call | 20:00:00 | 4 | yes |

The session bound to the family block. `session.json` came out with `"calendarEvent.title": "Mimi - Prep Group Class"`, `"participants": []`, `"isOnlineMeeting": false` — while the real meeting sat in the same candidate list carrying four invitees and a join link.

Note that overlap-based ranking would not have helped here either: the family block *contains* the recording start and covers 58 of its 75 minutes. Attendees and the conference link are the only signals that separate these two.

## The fix

Rank meeting-likeness — has invitees, or `isOnlineMeeting` — ahead of start proximity, then keep the existing proximity ordering, then prefer the shorter event (which the old doc comment claimed to do but never did), then `startDate` so the result is total and no longer depends on EventKit's ordering.

`CalendarEvent(from:)` already computes `participants` and `isOnlineMeeting`, so the discriminating signals cost nothing extra.

**Recording an in-person meeting still works the way it did.** Meeting-likeness only reorders candidates when at least one of them has it; with no meeting-like candidate, ranking falls straight back to closest start. The only outcomes that change are ones where a bare no-attendee block previously beat a real meeting.

The ranking moves into `CalendarEventMatcher`, a pure function over `CalendarEvent` values, so it is testable without an `EKEventStore`. The one behavioural cost is that all candidates are now converted to `CalendarEvent` before ranking rather than just the winner — that runs `NSDataDetector` over each event's notes. The lookup window is 30 minutes wide, so this is a handful of events at most.

## Testing

- `CalendarEventMatcherTests` — 7 new cases, including the tie above asserted in both input orderings, and the fallback that keeps no-attendee events working.
- Full suite: 708 tests, 0 failures.
- `swift build -c debug` and `swift build -c release` both clean.

## Possible follow-up, not included here

The event is resolved once at session start and passed through to `finalizeSession` unchanged, so a meeting that starts late binds against a point-in-time guess that the finished session's real interval could correct. That is a larger change and this fix stands on its own, so I left it out.
