### PR TITLE
Stop splitting one speaker across "Them" and "Speaker 1"

### DIFF
--- a/OpenOats/Sources/OpenOats/Transcription/DiarizationManager.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/DiarizationManager.swift
@@ -59,16 +59,23 @@ actor DiarizationManager {
 
         guard bestOverlap > 0 else { return .them }
 
-        // If only one speaker was detected in the entire session, fall back to .them
-        // for backward compatibility (no point labeling "Speaker 1" when there's only one).
-        let activeSpeakers = speakers.values.filter { $0.hasSegments }
-        if activeSpeakers.count <= 1 {
-            return .them
-        }
+        return Self.speaker(forDiarizerIndex: bestSpeaker)
+    }
 
-        // Map diarizer speaker index to Speaker enum
-        // Index 0 → .remote(1), index 1 → .remote(2), etc.
-        return .remote(bestSpeaker + 1)
+    /// Maps a diarizer cluster index to a stable `Speaker` label.
+    ///
+    /// The first cluster stays `.them`, so a session with one remote voice still
+    /// reads "Them" rather than "Speaker 1". Later clusters continue that numbering
+    /// — "Them" is speaker 1, so cluster 1 is "Speaker 2".
+    ///
+    /// The mapping deliberately depends only on the index, never on how many
+    /// clusters exist *so far*. `dominantSpeaker` runs live, once per utterance,
+    /// while the diarizer is still discovering speakers, so a "only one speaker
+    /// known yet, call it .them" rule labels one voice `.them` early and
+    /// `.remote(1)` from the moment a second voice appears. Nothing revisits the
+    /// earlier utterances, so a single participant ends up split across two labels.
+    nonisolated static func speaker(forDiarizerIndex index: Int) -> Speaker {
+        index <= 0 ? .them : .remote(index + 1)
     }
 
     /// Returns diarized speaker runs overlapping the given range.
@@ -82,14 +89,15 @@ actor DiarizationManager {
 
         let queryStart = Float(startTime)
         let queryEnd = Float(endTime)
-        let activeSpeakers = speakers.values.filter { $0.hasSegments }
+        let activeSpeakers = speakers.filter { $0.value.hasSegments }
 
+        // One voice owns the whole range; label it the same way dominantSpeaker would.
         if activeSpeakers.count <= 1 {
             return [
                 BatchTranscriptionSegmentLayout.SpeakerRun(
                     startTime: startTime,
                     endTime: endTime,
-                    speaker: .them
+                    speaker: Self.speaker(forDiarizerIndex: activeSpeakers.first?.key ?? 0)
                 )
             ]
         }
@@ -97,7 +105,7 @@ actor DiarizationManager {
         var runs: [BatchTranscriptionSegmentLayout.SpeakerRun] = []
 
         for (index, speaker) in speakers {
-            let mappedSpeaker = Speaker.remote(index + 1)
+            let mappedSpeaker = Self.speaker(forDiarizerIndex: index)
             let allSegments = speaker.finalizedSegments + speaker.tentativeSegments
             for segment in allSegments {
                 let overlapStart = max(segment.startTime, queryStart)

--- a/OpenOats/Tests/OpenOatsTests/DiarizerSpeakerMappingTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/DiarizerSpeakerMappingTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class DiarizerSpeakerMappingTests: XCTestCase {
+    // The first cluster keeps reading "Them" so one-remote-voice sessions are
+    // unchanged — that was the point of the old single-speaker fallback.
+    func testFirstClusterMapsToThem() {
+        XCTAssertEqual(DiarizationManager.speaker(forDiarizerIndex: 0), .them)
+    }
+
+    // "Them" is speaker 1, so numbering continues from 2.
+    func testLaterClustersContinueTheNumbering() {
+        XCTAssertEqual(DiarizationManager.speaker(forDiarizerIndex: 1), .remote(2))
+        XCTAssertEqual(DiarizationManager.speaker(forDiarizerIndex: 2), .remote(3))
+    }
+
+    // The regression: the label a voice gets must not depend on how many other
+    // voices the diarizer happens to have discovered by that point in the session.
+    func testLabelDependsOnlyOnClusterIndex() {
+        let earlyInSession = DiarizationManager.speaker(forDiarizerIndex: 0)
+        let lateInSession = DiarizationManager.speaker(forDiarizerIndex: 0)
+
+        XCTAssertEqual(earlyInSession, lateInSession)
+        XCTAssertEqual(earlyInSession.storageKey, lateInSession.storageKey)
+    }
+
+    func testNegativeIndexIsTreatedAsTheFirstCluster() {
+        XCTAssertEqual(DiarizationManager.speaker(forDiarizerIndex: -1), .them)
+    }
+}


### PR DESCRIPTION
## The bug

`DiarizationManager.dominantSpeaker` decides between `.them` and `.remote(n)` like this:

```swift
// If only one speaker was detected in the entire session, fall back to .them
// for backward compatibility (no point labeling "Speaker 1" when there's only one).
let activeSpeakers = speakers.values.filter { $0.hasSegments }
if activeSpeakers.count <= 1 {
    return .them
}
return .remote(bestSpeaker + 1)
```

The comment says "in the entire session", but this runs **live, once per utterance**, from `TranscriptionEngine`'s `onFinal` handler. `speakers` is the diarizer's running state, so `activeSpeakers.count` grows during the meeting and the branch flips partway through.

So one participant gets two labels. Everything they say before the diarizer registers a second cluster is stored as `them`; everything after is `remote_1`. Nothing goes back to fix the earlier rows.

From a two-person recording of mine, 820 utterances:

| Label | Count |
|---|---|
| `you` (me, mic) | 127 |
| `them` | 57 |
| `remote_1` | 636 |

Two people, three labels — `them` and `remote_1` are the same voice, just before and after the flip.

It also defeats the rename UI. `speakerNames` is keyed on `Speaker.storageKey`, so renaming `remote_1` to a real name leaves the 57 earlier rows still reading "Them", with no way to merge the two.

## The fix

Map the cluster index to a label directly, with no dependency on how many clusters exist *so far*:

```swift
nonisolated static func speaker(forDiarizerIndex index: Int) -> Speaker {
    index <= 0 ? .them : .remote(index + 1)
}
```

Cluster 0 stays `.them`, which is what the old fallback was protecting — a session with one remote voice still reads "Them", not "Speaker 1". Later clusters continue that numbering, so cluster 1 is "Speaker 2" (with "Them" as speaker 1).

`speakerRuns` carried a copy of the same fallback, hard-coded to `.them` regardless of which cluster was actually active. It now shares the mapping, so its single-speaker shortcut can no longer disagree with `dominantSpeaker`.

## Scope

Sessions already on disk keep the labels they were recorded with — there is no migration here, only a change to how new sessions are labelled. Happy to add one if you would rather old sessions were repaired too, though `Utterance` stores a wall-clock `timestamp` rather than an audio time range, so a retroactive re-query of the diarizer would need more than a rewrite pass.

The visible change for multi-speaker sessions is that the first remote cluster now reads "Them" instead of "Speaker 1". If you would rather keep "Speaker 1" and drop `.them` for multi-speaker recordings, that is a one-line change to the mapping and I am happy to switch it.

## Testing

- `DiarizerSpeakerMappingTests` — 4 new cases, including the invariant that the label depends only on the cluster index.
- Full suite: 705 tests, 0 failures.
- `swift build -c debug` and `swift build -c release` both clean.
