### PR TITLE
Use speaker names in exports, and seed them from the calendar event

### DIFF
--- a/OpenOats/Sources/OpenOats/Intelligence/MarkdownMeetingWriter.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/MarkdownMeetingWriter.swift
@@ -25,6 +25,8 @@ enum MarkdownMeetingWriter {
         let language: String?
         let meetingApp: String?
         let engine: String?
+        /// Per-session speaker display names, keyed by `Speaker.storageKey`.
+        let speakerNames: [String: String]?
 
         init(from index: SessionIndex) {
             self.sessionID = index.id
@@ -34,6 +36,7 @@ enum MarkdownMeetingWriter {
             self.language = index.language
             self.meetingApp = index.meetingApp
             self.engine = index.engine
+            self.speakerNames = index.speakerNames
         }
     }
 
@@ -100,7 +103,13 @@ enum MarkdownMeetingWriter {
     static func buildMarkdown(metadata: Metadata, records: [SessionRecord], notesMarkdown: String? = nil) -> String {
         let resolvedTitle = metadata.title?.isEmpty == false ? metadata.title! : "Meeting"
         let frontmatter = buildFrontmatter(metadata: metadata, records: records, title: resolvedTitle)
-        let body = buildBody(title: resolvedTitle, records: records, startedAt: metadata.startedAt, notesMarkdown: notesMarkdown)
+        let body = buildBody(
+            title: resolvedTitle,
+            records: records,
+            startedAt: metadata.startedAt,
+            notesMarkdown: notesMarkdown,
+            speakerNames: metadata.speakerNames
+        )
         return frontmatter + "\n" + body
     }
 
@@ -122,7 +131,7 @@ enum MarkdownMeetingWriter {
         let speakerLabels: [String] = {
             var seen: [String] = []
             for r in records {
-                let label = r.speaker.displayLabel
+                let label = speakerLabel(r.speaker, speakerNames: metadata.speakerNames)
                 if !seen.contains(label) { seen.append(label) }
             }
             return seen.isEmpty ? ["You", "Them"] : seen
@@ -162,7 +171,13 @@ enum MarkdownMeetingWriter {
 
     // MARK: - Body
 
-    static func buildBody(title: String, records: [SessionRecord], startedAt: Date, notesMarkdown: String? = nil) -> String {
+    static func buildBody(
+        title: String,
+        records: [SessionRecord],
+        startedAt: Date,
+        notesMarkdown: String? = nil,
+        speakerNames: [String: String]? = nil
+    ) -> String {
         var parts: [String] = []
 
         // H1 title
@@ -181,7 +196,11 @@ enum MarkdownMeetingWriter {
         parts.append("## Transcript")
         parts.append("")
 
-        let transcriptLines = formatTranscriptLines(records: records, startedAt: startedAt)
+        let transcriptLines = formatTranscriptLines(
+            records: records,
+            startedAt: startedAt,
+            speakerNames: speakerNames
+        )
         parts.append(transcriptLines)
 
         return parts.joined(separator: "\n")
@@ -189,7 +208,11 @@ enum MarkdownMeetingWriter {
 
     // MARK: - Transcript Formatting
 
-    static func formatTranscriptLines(records: [SessionRecord], startedAt: Date) -> String {
+    static func formatTranscriptLines(
+        records: [SessionRecord],
+        startedAt: Date,
+        speakerNames: [String: String]? = nil
+    ) -> String {
         var lines: [String] = []
 
         for record in records {
@@ -197,7 +220,7 @@ enum MarkdownMeetingWriter {
                 record.timestamp,
                 relativeTo: startedAt
             )
-            let speaker = speakerLabel(record.speaker)
+            let speaker = speakerLabel(record.speaker, speakerNames: speakerNames)
             let text = record.cleanedText ?? record.text
             lines.append("[\(relativeTimestamp)] **\(speaker):** \(text)")
             lines.append("")
@@ -245,8 +268,8 @@ enum MarkdownMeetingWriter {
 
     // MARK: - Speaker Label
 
-    static func speakerLabel(_ speaker: Speaker) -> String {
-        speaker.displayLabel
+    static func speakerLabel(_ speaker: Speaker, speakerNames: [String: String]? = nil) -> String {
+        speaker.displayName(speakerNames: speakerNames)
     }
 
     // MARK: - YAML Quoting

--- a/OpenOats/Sources/OpenOats/Meeting/SpeakerNameSeeder.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/SpeakerNameSeeder.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Derives per-session speaker display names from the bound calendar event.
+///
+/// `SessionIndex.speakerNames` has always supported real names — the transcript UI
+/// lets you rename a speaker by hand — but nothing ever populated it, so every
+/// session started life as "You" and "Them" even when the calendar knew exactly
+/// who was invited.
+///
+/// Seeding is deliberately conservative. A wrong name attached to a transcript is
+/// worse than a generic one, so names are only assigned when the mapping is
+/// forced: one remote voice, one invitee besides the recorder. With two remote
+/// voices and three invitees there is nothing in the calendar event that says
+/// which diarizer cluster belongs to which person.
+enum SpeakerNameSeeder {
+    /// Returns names to store in `SessionIndex.speakerNames`, or an empty
+    /// dictionary when the mapping would be a guess.
+    ///
+    /// - Parameters:
+    ///   - remoteSpeakerKeys: `Speaker.storageKey` for every non-mic speaker that
+    ///     actually appears in the transcript.
+    ///   - participantNames: Display names invited to the calendar event.
+    ///   - recorderName: The local user's name, excluded from the candidates
+    ///     because they are recorded on the microphone as `.you`.
+    static func seededNames(
+        remoteSpeakerKeys: [String],
+        participantNames: [String],
+        recorderName: String?
+    ) -> [String: String] {
+        let speakers = orderedUnique(remoteSpeakerKeys)
+        let recorder = normalized(recorderName)
+
+        let candidates = orderedUnique(
+            participantNames.compactMap { name in
+                let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !trimmed.isEmpty else { return nil }
+                guard recorder == nil || normalized(trimmed) != recorder else { return nil }
+                return trimmed
+            }
+        )
+
+        guard speakers.count == 1, candidates.count == 1 else { return [:] }
+        return [speakers[0]: candidates[0]]
+    }
+
+    /// Remote speaker keys present in a finished session, in first-heard order.
+    static func remoteSpeakerKeys(in utterances: [Utterance]) -> [String] {
+        orderedUnique(utterances.filter { $0.speaker.isRemote }.map { $0.speaker.storageKey })
+    }
+
+    private static func orderedUnique(_ values: [String]) -> [String] {
+        var seen: Set<String> = []
+        return values.filter { seen.insert($0).inserted }
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed.lowercased()
+    }
+}

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -441,6 +441,18 @@ actor SessionRepository {
             ?? existingMetadata?.startedAt
             ?? Date()
 
+        // Names the user set by hand always win; otherwise take them from the
+        // calendar event, which only happens when the mapping is unambiguous.
+        let speakerNames = existingMetadata?.speakerNames ?? {
+            guard let event = metadata.calendarEvent else { return nil }
+            let seeded = SpeakerNameSeeder.seededNames(
+                remoteSpeakerKeys: SpeakerNameSeeder.remoteSpeakerKeys(in: metadata.utterances),
+                participantNames: event.invitedParticipantDisplayNames,
+                recorderName: NSFullUserName()
+            )
+            return seeded.isEmpty ? nil : seeded
+        }()
+
         // Write session.json with final metadata
         let sessionMeta = SessionMetadata(
             id: sessionID,
@@ -455,7 +467,8 @@ actor SessionRepository {
             engine: metadata.engine,
             calendarEvent: metadata.calendarEvent,
             transcriptIssue: metadata.transcriptIssue,
-            transcriptRecovery: nil
+            transcriptRecovery: nil,
+            speakerNames: speakerNames
         )
         writeSessionMetadata(sessionMeta, sessionID: sessionID)
 

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -1362,7 +1362,8 @@ actor SessionRepository {
 
         for record in records {
             let displayText = record.cleanedText ?? record.text
-            result += "[\(timeFmt.string(from: record.timestamp))] \(record.speaker.displayLabel): \(displayText)\n"
+            let speaker = record.speaker.displayName(speakerNames: meta?.speakerNames)
+            result += "[\(timeFmt.string(from: record.timestamp))] \(speaker): \(displayText)\n"
         }
 
         return result
@@ -1964,7 +1965,8 @@ actor SessionRepository {
             source: meta?.source,
             meetingFamilyKey: meta?.calendarEvent.flatMap { MeetingHistoryResolver.seriesHistoryKey(for: $0) },
             transcriptIssue: meta?.transcriptIssue,
-            transcriptRecovery: meta?.transcriptRecovery
+            transcriptRecovery: meta?.transcriptRecovery,
+            speakerNames: meta?.speakerNames
         )
 
         let outputTarget = MarkdownMeetingWriter.write(

--- a/OpenOats/Tests/OpenOatsTests/MarkdownMeetingWriterSpeakerNameTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MarkdownMeetingWriterSpeakerNameTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class MarkdownMeetingWriterSpeakerNameTests: XCTestCase {
+    private let start = Date(timeIntervalSince1970: 1_774_000_000)
+
+    private func makeMetadata(speakerNames: [String: String]?) -> MarkdownMeetingWriter.Metadata {
+        var index = SessionIndex(
+            id: "session_test",
+            startedAt: start,
+            endedAt: start.addingTimeInterval(600),
+            utteranceCount: 2,
+            hasNotes: false,
+            engine: "parakeetV2"
+        )
+        index.speakerNames = speakerNames
+        return MarkdownMeetingWriter.Metadata(from: index)
+    }
+
+    private var records: [SessionRecord] {
+        [
+            SessionRecord(speaker: .you, text: "Hello", timestamp: start),
+            SessionRecord(speaker: .them, text: "Hi there", timestamp: start.addingTimeInterval(30)),
+        ]
+    }
+
+    func testTranscriptLinesUseSpeakerNames() {
+        let lines = MarkdownMeetingWriter.formatTranscriptLines(
+            records: records,
+            startedAt: start,
+            speakerNames: ["them": "Ada Lovelace"]
+        )
+
+        XCTAssertTrue(lines.contains("**Ada Lovelace:** Hi there"), lines)
+        XCTAssertFalse(lines.contains("**Them:**"), lines)
+    }
+
+    func testTranscriptLinesFallBackToDefaultLabels() {
+        let lines = MarkdownMeetingWriter.formatTranscriptLines(
+            records: records,
+            startedAt: start,
+            speakerNames: nil
+        )
+
+        XCTAssertTrue(lines.contains("**Them:** Hi there"), lines)
+    }
+
+    func testFrontMatterParticipantsUseSpeakerNames() {
+        let markdown = MarkdownMeetingWriter.buildFrontmatter(
+            metadata: makeMetadata(speakerNames: ["them": "Ada Lovelace"]),
+            records: records,
+            title: "Sync"
+        )
+
+        XCTAssertTrue(markdown.contains("  - Ada Lovelace"), markdown)
+        XCTAssertFalse(markdown.contains("  - Them"), markdown)
+    }
+
+    func testFrontMatterParticipantsFallBackToDefaultLabels() {
+        let markdown = MarkdownMeetingWriter.buildFrontmatter(
+            metadata: makeMetadata(speakerNames: nil),
+            records: records,
+            title: "Sync"
+        )
+
+        XCTAssertTrue(markdown.contains("  - Them"), markdown)
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/SpeakerNameSeederTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SpeakerNameSeederTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class SpeakerNameSeederTests: XCTestCase {
+    func testSeedsTheOnlyRemoteSpeakerFromTheOnlyOtherInvitee() {
+        let names = SpeakerNameSeeder.seededNames(
+            remoteSpeakerKeys: ["them"],
+            participantNames: ["Ada Lovelace", "Grace Hopper"],
+            recorderName: "Grace Hopper"
+        )
+
+        XCTAssertEqual(names, ["them": "Ada Lovelace"])
+    }
+
+    func testRecorderMatchIsCaseAndWhitespaceInsensitive() {
+        let names = SpeakerNameSeeder.seededNames(
+            remoteSpeakerKeys: ["remote_2"],
+            participantNames: ["Ada Lovelace", "  grace hopper "],
+            recorderName: "Grace Hopper"
+        )
+
+        XCTAssertEqual(names, ["remote_2": "Ada Lovelace"])
+    }
+
+    // Two voices and two candidates is exactly the case where the calendar event
+    // cannot say which cluster is which person. No name beats a wrong name.
+    func testDoesNotGuessWhenSeveralSpeakersCouldMatchSeveralInvitees() {
+        let names = SpeakerNameSeeder.seededNames(
+            remoteSpeakerKeys: ["them", "remote_2"],
+            participantNames: ["Ada Lovelace", "Alan Turing", "Grace Hopper"],
+            recorderName: "Grace Hopper"
+        )
+
+        XCTAssertTrue(names.isEmpty)
+    }
+
+    func testDoesNotSeedWhenOneVoiceHasSeveralCandidateInvitees() {
+        let names = SpeakerNameSeeder.seededNames(
+            remoteSpeakerKeys: ["them"],
+            participantNames: ["Ada Lovelace", "Alan Turing", "Grace Hopper"],
+            recorderName: "Grace Hopper"
+        )
+
+        XCTAssertTrue(names.isEmpty)
+    }
+
+    func testDoesNotSeedWithoutInvitees() {
+        XCTAssertTrue(
+            SpeakerNameSeeder.seededNames(
+                remoteSpeakerKeys: ["them"],
+                participantNames: [],
+                recorderName: "Grace Hopper"
+            ).isEmpty
+        )
+    }
+
+    func testIgnoresBlankParticipantNames() {
+        let names = SpeakerNameSeeder.seededNames(
+            remoteSpeakerKeys: ["them"],
+            participantNames: ["   ", "Ada Lovelace"],
+            recorderName: nil
+        )
+
+        XCTAssertEqual(names, ["them": "Ada Lovelace"])
+    }
+
+    func testRemoteSpeakerKeysExcludeTheMicrophoneAndDeduplicate() {
+        let utterances = [
+            Utterance(text: "hi", speaker: .you),
+            Utterance(text: "hello", speaker: .them),
+            Utterance(text: "again", speaker: .them),
+            Utterance(text: "third voice", speaker: .remote(2)),
+        ]
+
+        XCTAssertEqual(
+            SpeakerNameSeeder.remoteSpeakerKeys(in: utterances),
+            ["them", "remote_2"]
+        )
+    }
+}


### PR DESCRIPTION
Two commits, split so the first can be taken on its own.

## 1. Renamed speakers never reached exports

`SessionIndex.speakerNames` already exists, and the transcript UI already writes to it — clicking a speaker label opens a rename field that calls `updateSessionSpeakerNames`. Nothing downstream ever read it.

Both export paths rendered `Speaker.displayLabel` directly:

```swift
// MarkdownMeetingWriter
static func speakerLabel(_ speaker: Speaker) -> String { speaker.displayLabel }

// SessionRepository.exportPlainText
result += "[\(timeFmt.string(from: record.timestamp))] \(record.speaker.displayLabel): \(displayText)\n"
```

So a session where every speaker had been named by hand still exported as "You" and "Them" — in the frontmatter `participants` list and on every transcript line. The rename only ever showed up in the app.

`Speaker.displayName(speakerNames:)` was already written for exactly this and was unused outside the detail pane. This threads the session's names through `MarkdownMeetingWriter.Metadata` and into `exportPlainText`, and calls it. The mirror path built its `SessionIndex` field by field and dropped `speakerNames` on the way, so that is passed through too.

Sessions with no names are unchanged — `displayName` falls back to `displayLabel`.

This is what `docs/meeting-format-spec.md` calls the "Future State: Named Participants"; the writer already supported it structurally.

## 2. Seed the names from the calendar event

Nothing populated `speakerNames` automatically. When a session is bound to a calendar event the invitee list is already in `CalendarEvent.participants`, and `invitedParticipantDisplayNames` already resolves it to display names.

Seeding is deliberately narrow. Names are assigned only when the mapping is **forced**: one remote voice in the transcript, and one invitee left after removing the recorder (`NSFullUserName()`, which the writer already uses for the `recorder:` field). Two voices and three invitees carry no signal about which diarizer cluster belongs to which person, so that case is left alone — a confidently wrong name on a transcript is worse than a generic one.

Names the user set by hand always win; seeding only ever fills an empty field.

In practice this covers 1:1 calls, which is where the naming matters most and where the answer is unambiguous.

## Testing

- `SpeakerNameSeederTests` — 7 cases, mostly about *declining* to guess.
- `MarkdownMeetingWriterSpeakerNameTests` — 4 cases covering transcript lines and the frontmatter participants list, with and without names.
- Full suite: 712 tests, 0 failures.
- `swift build -c debug` and `swift build -c release` both clean.

## Note on ordering

This is independent of #701 and #702 and can be merged in any order. It is most useful with #701, since seeding reads whichever calendar event the session bound to — if that binding is wrong, the seeded name is wrong too. The narrow one-voice/one-invitee rule limits the blast radius, but #701 is what makes the input trustworthy.
