### PR TITLE
Fix total notes failure when a reasoning model returns null content

### DIFF
--- a/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
@@ -277,6 +277,14 @@ final class NotesEngine {
                 }
                 if let error = self.error {
                     continuation.resume(throwing: GenerationError.failed(error))
+                } else if self.generatedMarkdown.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    // The stream finished without producing notes. Thinking mode and an
+                    // exhausted token budget both land here, and there is nothing worth
+                    // saving either way, so fail instead of storing an empty note.
+                    continuation.resume(throwing: GenerationError.failed(
+                        "The model returned empty notes. Thinking mode may be enabled on the "
+                        + "server, or the token budget was exhausted before the notes were written."
+                    ))
                 } else {
                     continuation.resume(returning: self.generatedMarkdown)
                 }

--- a/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
@@ -270,8 +270,22 @@ actor OpenRouterClient {
             throw OpenRouterError.httpError(statusCode, host: targetURL.host)
         }
 
+        return try Self.completionText(from: data)
+    }
+
+    /// Decodes a non-streaming chat completion, tolerating reasoning models
+    /// (e.g. Qwen3 served by mlx_lm.server) that return `"content": null` with
+    /// their output in a sibling `reasoning` field instead.
+    static func completionText(from data: Data) throws -> String {
         let completionResponse = try JSONDecoder().decode(CompletionResponse.self, from: data)
-        return completionResponse.choices.first?.message.content ?? ""
+        let message = completionResponse.choices.first?.message
+        let content = message?.content ?? ""
+        if content.isEmpty,
+           let reasoning = message?.reasoning,
+           !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw OpenRouterError.reasoningOnlyResponse
+        }
+        return content
     }
 
     private func streamAnthropicCompletion(
@@ -404,6 +418,7 @@ actor OpenRouterClient {
     enum OpenRouterError: Error, LocalizedError {
         case httpError(Int, host: String?)
         case missingAPIKey(host: String?)
+        case reasoningOnlyResponse
 
         var errorDescription: String? {
             switch self {
@@ -422,6 +437,10 @@ actor OpenRouterClient {
                 case nil: "LLM"
                 }
                 return "\(provider) API key required"
+            case .reasoningOnlyResponse:
+                return "LLM returned a reasoning-only response with no final content. "
+                    + "The server likely has thinking mode enabled (common with reasoning models "
+                    + "such as Qwen3 on mlx_lm.server); disable thinking so the model emits final content."
             }
         }
     }
@@ -449,7 +468,8 @@ actor OpenRouterClient {
         }
 
         struct CompletionMessage: Codable {
-            let content: String
+            let content: String?
+            let reasoning: String?
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift
@@ -183,6 +183,7 @@ actor OpenRouterClient {
                         return
                     }
 
+                    var outcome = StreamOutcome()
                     for try await line in bytes.lines {
                         guard line.hasPrefix("data: ") else { continue }
                         let payload = String(line.dropFirst(6))
@@ -190,14 +191,23 @@ actor OpenRouterClient {
 
                         guard let data = payload.data(using: .utf8) else { continue }
                         if let chunk = try? JSONDecoder().decode(SSEChunk.self, from: data) {
-                            if let content = chunk.choices.first?.delta.content {
+                            let choice = chunk.choices.first
+                            outcome.record(content: choice?.delta.content, reasoning: choice?.delta.reasoning)
+                            if let content = choice?.delta.content {
                                 continuation.yield(content)
-                            } else if chunk.choices.first?.finish_reason == "length" {
+                            } else if choice?.finish_reason == "length" {
                                 continuation.yield("…")
                             }
                         }
                     }
 
+                    // A stream that only ever carried reasoning tokens produced no
+                    // answer. Ending normally here would hand the caller an empty
+                    // string, so report it as a failure instead.
+                    if outcome.isReasoningOnly {
+                        continuation.finish(throwing: OpenRouterError.reasoningOnlyResponse)
+                        return
+                    }
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
@@ -276,16 +286,38 @@ actor OpenRouterClient {
     /// Decodes a non-streaming chat completion, tolerating reasoning models
     /// (e.g. Qwen3 served by mlx_lm.server) that return `"content": null` with
     /// their output in a sibling `reasoning` field instead.
+    /// A response carrying no usable content never resolves to an empty string:
+    /// callers get a described error rather than a silently blank answer.
     static func completionText(from data: Data) throws -> String {
         let completionResponse = try JSONDecoder().decode(CompletionResponse.self, from: data)
         let message = completionResponse.choices.first?.message
         let content = message?.content ?? ""
-        if content.isEmpty,
-           let reasoning = message?.reasoning,
-           !reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            throw OpenRouterError.reasoningOnlyResponse
+        // Test emptiness on the trimmed text but return the original, so a
+        // response of "\n" plus a full `reasoning` block is not mistaken for an answer.
+        guard content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return content
         }
-        return content
+
+        let reasoning = message?.reasoning?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        throw reasoning.isEmpty ? OpenRouterError.emptyResponse : OpenRouterError.reasoningOnlyResponse
+    }
+
+    /// Tracks what a streamed chat completion actually delivered.
+    ///
+    /// Reasoning models served locally can emit an entire answer as `reasoning`
+    /// deltas and never send a content delta. The stream then ends normally and
+    /// the caller silently receives nothing, so record both kinds of delta.
+    struct StreamOutcome {
+        private(set) var sawContent = false
+        private(set) var sawReasoning = false
+
+        mutating func record(content: String?, reasoning: String?) {
+            if let content, !content.isEmpty { sawContent = true }
+            if let reasoning, !reasoning.isEmpty { sawReasoning = true }
+        }
+
+        /// True when the stream carried reasoning tokens but no final content.
+        var isReasoningOnly: Bool { sawReasoning && !sawContent }
     }
 
     private func streamAnthropicCompletion(
@@ -419,6 +451,7 @@ actor OpenRouterClient {
         case httpError(Int, host: String?)
         case missingAPIKey(host: String?)
         case reasoningOnlyResponse
+        case emptyResponse
 
         var errorDescription: String? {
             switch self {
@@ -438,9 +471,11 @@ actor OpenRouterClient {
                 }
                 return "\(provider) API key required"
             case .reasoningOnlyResponse:
-                return "LLM returned a reasoning-only response with no final content. "
-                    + "The server likely has thinking mode enabled (common with reasoning models "
-                    + "such as Qwen3 on mlx_lm.server); disable thinking so the model emits final content."
+                return "The response contained only reasoning output and no final answer. "
+                    + "Thinking mode may be enabled on the server, or the token budget was "
+                    + "exhausted before the answer was written."
+            case .emptyResponse:
+                return "Empty response from server — the model returned no content."
             }
         }
     }
@@ -457,6 +492,7 @@ actor OpenRouterClient {
 
         struct Delta: Codable {
             let content: String?
+            let reasoning: String?
         }
     }
 

--- a/OpenOats/Tests/OpenOatsTests/NotesEngineTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesEngineTests.swift
@@ -130,4 +130,66 @@ final class NotesEngineTests: XCTestCase {
             )
         )
     }
+
+    // MARK: - Empty generation
+
+    @MainActor
+    private func makeSettings() -> AppSettings {
+        let notesDirectory = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("OpenOatsNotesEngineTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: notesDirectory, withIntermediateDirectories: true)
+
+        let suiteName = "com.openoats.tests.notesengine.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName) ?? .standard
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults.set(notesDirectory.path, forKey: "notesFolderPath")
+        let storage = AppSettingsStorage(
+            defaults: defaults,
+            secretStore: .ephemeral,
+            defaultNotesDirectory: notesDirectory,
+            runMigrations: false
+        )
+        return AppSettings(storage: storage)
+    }
+
+    @MainActor
+    func testGenerateMarkdownDetachedFailsWhenTheModelProducesNothing() async {
+        // A stream that ends after emitting only whitespace must not be saved as
+        // notes: the caller has to see a failure so it can retry or report.
+        let engine = NotesEngine(mode: .scripted(markdown: "   \n  "))
+        let transcript = [
+            SessionRecord(speaker: .you, text: "Hello.", timestamp: Date())
+        ]
+
+        do {
+            let markdown = try await engine.generateMarkdownDetached(
+                transcript: transcript,
+                template: TemplateStore.builtInTemplates.first!,
+                settings: makeSettings()
+            )
+            XCTFail("Expected empty generation to throw, got \(markdown.debugDescription)")
+        } catch {
+            XCTAssertTrue(
+                error.localizedDescription.contains("empty notes"),
+                "Unhelpful description: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    @MainActor
+    func testGenerateMarkdownDetachedReturnsNonEmptyMarkdown() async throws {
+        let engine = NotesEngine(mode: .scripted(markdown: "# Notes"))
+        let transcript = [
+            SessionRecord(speaker: .you, text: "Hello.", timestamp: Date())
+        ]
+
+        let markdown = try await engine.generateMarkdownDetached(
+            transcript: transcript,
+            template: TemplateStore.builtInTemplates.first!,
+            settings: makeSettings()
+        )
+
+        XCTAssertEqual(markdown, "# Notes")
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/OpenRouterClientTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/OpenRouterClientTests.swift
@@ -56,4 +56,58 @@ final class OpenRouterClientTests: XCTestCase {
     func testAnthropicMessagesURLRejectsInvalidBaseURL() {
         XCTAssertNil(OpenRouterClient.anthropicMessagesURL(from: "not a url"))
     }
+
+    // MARK: - Non-streaming completion decoding
+
+    private func completionData(message: String) -> Data {
+        Data(#"{"choices": [{"message": \#(message)}]}"#.utf8)
+    }
+
+    func testCompletionTextReturnsContentForNormalResponse() throws {
+        let data = completionData(message: #"{"role": "assistant", "content": "Meeting notes"}"#)
+
+        XCTAssertEqual(try OpenRouterClient.completionText(from: data), "Meeting notes")
+    }
+
+    func testCompletionTextPrefersContentWhenReasoningAlsoPresent() throws {
+        let data = completionData(
+            message: #"{"role": "assistant", "content": "Final notes", "reasoning": "thinking..."}"#
+        )
+
+        XCTAssertEqual(try OpenRouterClient.completionText(from: data), "Final notes")
+    }
+
+    func testCompletionTextThrowsForNullContentWithReasoning() {
+        // mlx_lm.server + Qwen3 with thinking enabled: content is null and the
+        // whole response lands in `reasoning`. This used to fail JSON decoding.
+        let data = completionData(
+            message: #"{"role": "assistant", "content": null, "reasoning": "Okay, the user wants..."}"#
+        )
+
+        XCTAssertThrowsError(try OpenRouterClient.completionText(from: data)) { error in
+            guard case OpenRouterClient.OpenRouterError.reasoningOnlyResponse = error else {
+                return XCTFail("Expected reasoningOnlyResponse, got \(error)")
+            }
+            let description = (error as? LocalizedError)?.errorDescription ?? ""
+            XCTAssertTrue(description.contains("reasoning-only"), "Unhelpful description: \(description)")
+        }
+    }
+
+    func testCompletionTextThrowsForEmptyContentWithReasoning() {
+        let data = completionData(
+            message: #"{"role": "assistant", "content": "", "reasoning": "Okay, the user wants..."}"#
+        )
+
+        XCTAssertThrowsError(try OpenRouterClient.completionText(from: data)) { error in
+            guard case OpenRouterClient.OpenRouterError.reasoningOnlyResponse = error else {
+                return XCTFail("Expected reasoningOnlyResponse, got \(error)")
+            }
+        }
+    }
+
+    func testCompletionTextReturnsEmptyStringForNullContentWithoutReasoning() throws {
+        let data = completionData(message: #"{"role": "assistant", "content": null}"#)
+
+        XCTAssertEqual(try OpenRouterClient.completionText(from: data), "")
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/OpenRouterClientTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/OpenRouterClientTests.swift
@@ -89,7 +89,9 @@ final class OpenRouterClientTests: XCTestCase {
                 return XCTFail("Expected reasoningOnlyResponse, got \(error)")
             }
             let description = (error as? LocalizedError)?.errorDescription ?? ""
-            XCTAssertTrue(description.contains("reasoning-only"), "Unhelpful description: \(description)")
+            XCTAssertTrue(description.contains("only reasoning output"), "Unhelpful description: \(description)")
+            XCTAssertTrue(description.contains("Thinking mode"), "Unhelpful description: \(description)")
+            XCTAssertTrue(description.contains("token budget"), "Unhelpful description: \(description)")
         }
     }
 
@@ -105,9 +107,81 @@ final class OpenRouterClientTests: XCTestCase {
         }
     }
 
-    func testCompletionTextReturnsEmptyStringForNullContentWithoutReasoning() throws {
+    func testCompletionTextThrowsForWhitespaceOnlyContentWithReasoning() {
+        // Untrimmed emptiness checks let a "\n" content field pass as an answer.
+        let data = completionData(
+            message: #"{"role": "assistant", "content": "\n", "reasoning": "Okay, the user wants..."}"#
+        )
+
+        XCTAssertThrowsError(try OpenRouterClient.completionText(from: data)) { error in
+            guard case OpenRouterClient.OpenRouterError.reasoningOnlyResponse = error else {
+                return XCTFail("Expected reasoningOnlyResponse, got \(error)")
+            }
+        }
+    }
+
+    func testCompletionTextReturnsContentUntrimmedWhenItIsNotBlank() throws {
+        let data = completionData(message: #"{"role": "assistant", "content": "  Meeting notes\n"}"#)
+
+        XCTAssertEqual(try OpenRouterClient.completionText(from: data), "  Meeting notes\n")
+    }
+
+    func testCompletionTextThrowsEmptyResponseForNullContentWithoutReasoning() {
         let data = completionData(message: #"{"role": "assistant", "content": null}"#)
 
-        XCTAssertEqual(try OpenRouterClient.completionText(from: data), "")
+        XCTAssertThrowsError(try OpenRouterClient.completionText(from: data)) { error in
+            guard case OpenRouterClient.OpenRouterError.emptyResponse = error else {
+                return XCTFail("Expected emptyResponse, got \(error)")
+            }
+            let description = (error as? LocalizedError)?.errorDescription ?? ""
+            XCTAssertTrue(description.contains("Empty response"), "Unhelpful description: \(description)")
+        }
+    }
+
+    func testCompletionTextThrowsEmptyResponseWhenThereAreNoChoices() {
+        let data = Data(#"{"choices": []}"#.utf8)
+
+        XCTAssertThrowsError(try OpenRouterClient.completionText(from: data)) { error in
+            guard case OpenRouterClient.OpenRouterError.emptyResponse = error else {
+                return XCTFail("Expected emptyResponse, got \(error)")
+            }
+        }
+    }
+
+    // MARK: - Streaming completion outcome
+
+    func testStreamOutcomeFlagsReasoningOnlyStream() {
+        var outcome = OpenRouterClient.StreamOutcome()
+        outcome.record(content: nil, reasoning: "Okay, the user wants")
+        outcome.record(content: "", reasoning: " a summary...")
+
+        XCTAssertTrue(outcome.isReasoningOnly)
+    }
+
+    func testStreamOutcomeIsNotReasoningOnlyWhenContentArrives() {
+        var outcome = OpenRouterClient.StreamOutcome()
+        outcome.record(content: nil, reasoning: "Okay, the user wants")
+        outcome.record(content: "## Summary", reasoning: nil)
+
+        XCTAssertFalse(outcome.isReasoningOnly)
+    }
+
+    func testStreamOutcomeIsNotReasoningOnlyForAnOrdinaryStream() {
+        var outcome = OpenRouterClient.StreamOutcome()
+        outcome.record(content: "## Summary", reasoning: nil)
+        outcome.record(content: "\n- point", reasoning: nil)
+
+        XCTAssertFalse(outcome.isReasoningOnly)
+        XCTAssertTrue(outcome.sawContent)
+        XCTAssertFalse(outcome.sawReasoning)
+    }
+
+    func testStreamOutcomeIgnoresEmptyDeltas() {
+        var outcome = OpenRouterClient.StreamOutcome()
+        outcome.record(content: "", reasoning: "")
+
+        XCTAssertFalse(outcome.isReasoningOnly)
+        XCTAssertFalse(outcome.sawContent)
+        XCTAssertFalse(outcome.sawReasoning)
     }
 }


### PR DESCRIPTION
## Root cause

`CompletionResponse.CompletionMessage.content` is declared non-optional (`OpenOats/Sources/OpenOats/Intelligence/OpenRouterClient.swift:452`). A reasoning model served via an OpenAI-compatible endpoint (e.g. Qwen3 on `mlx_lm.server` with thinking enabled) returns `"content": null` with its output in a sibling `"reasoning"` field. `JSONDecoder` then throws at the decode site (`:273`), which surfaces as a total notes-generation failure. The streaming path is unaffected — `SSEChunk.Delta.content` (`:440`) is already `String?`.

## What changed

- `CompletionMessage.content` is now `String?`, and `reasoning: String?` is decoded alongside it.
- The decode + fallback logic moved into an internal `static completionText(from:)` so it is unit-testable, same shape as the existing `preflightError(for:apiKey:)` static.
- Normal fallback is `content ?? ""`. When content is nil/empty but `reasoning` is non-empty, a new `OpenRouterError.reasoningOnlyResponse` is thrown whose description names the likely cause (thinking mode enabled server-side) instead of silently producing empty notes.

## Testing

- 5 new decoder tests in `OpenRouterClientTests` with JSON fixtures: normal content; content + reasoning both present (content wins); `"content": null` + reasoning (throws `reasoningOnlyResponse`, description checked); empty-string content + reasoning (throws); null content with no reasoning (returns `""`, matching the old `?? ""` intent).
- `swift build -c debug`, `swift test` (728 tests, 0 failures), and `swift build -c release` all pass locally (macOS, arm64).

## Risk

Low, confined to the non-streaming completion path. Well-formed responses decode identically. Responses that previously crashed the decoder now either recover (content present) or fail with an actionable error message.


---

## Revised after self-review

Re-reading the call graph showed the original patch did not fix the reported bug. `completionText` is only reachable from `complete()` (`SidecastEngine:86`, `SuggestionEngine:176`, `LiveTranscriptCleaner:198`, `BatchTextCleaner:292`, `MeetingDetailPane:3873`). Notes generation does not go through any of them: `NotesEngine.generate` calls `streamCompletion` (`NotesEngine.swift:222`). The "streaming path is unaffected" line in the root-cause section above is wrong — `SSEChunk.Delta.content` being optional is exactly why the streaming failure was silent rather than loud. This revision fixes the streaming path as well.

**Streaming path.** `SSEChunk.Delta` now decodes the sibling `reasoning` field. `streamCompletion` records whether the stream ever delivered a content delta and whether it ever delivered a reasoning delta. A stream that delivered reasoning but no content finishes with `reasoningOnlyResponse` instead of finishing normally and handing the caller an empty string.

**Empty notes are a failure.** `NotesEngine` now rejects a completed stream whose accumulated markdown is empty or whitespace-only. This is deliberately generic: it catches a reasoning-only stream, a token budget exhausted before any notes were written, and any other shape of "the model produced nothing", without needing to recognise the provider's flavour of it.

**Trim asymmetry.** The first pass trimmed `reasoning` before testing it but tested `content` untrimmed, so a response of `"content": "\n"` beside a full reasoning block slipped through as a successful empty answer. Emptiness is now tested on the trimmed text; non-blank content is still returned untrimmed.

**No more silent empty string.** Before this PR, `"content": null` with no `reasoning` threw a `DecodingError`, which the Ask pane surfaced as a visible `askError`. Making `content` optional turned that into a silent empty bubble. Fully-empty responses now throw `emptyResponse` ("Empty response from server — the model returned no content"), so that regression is gone and empty `choices` is covered too.

**Error copy.** The cleaners call `complete(maxTokens: 512)`, so hitting the token budget mid-reasoning is at least as likely as server-side thinking mode. The message no longer asserts one cause: "The response contained only reasoning output and no final answer. Thinking mode may be enabled on the server, or the token budget was exhausted before the answer was written."

**Where this copy is seen.** Today it reaches users directly only through the Ask pane, which renders `askError`. Everything else logs it to diagnostics. If #707 also lands, it additionally reaches the notes-failure notification, which carries the underlying `localizedDescription` — and in that auto-notes path #707's notification title fronts this message.

**Testing.** 737 tests, 0 failures (was 728). New coverage: whitespace-only content beside reasoning, untrimmed passthrough of non-blank content, `emptyResponse` for null content with no reasoning and for empty `choices`, the reworded description, the stream outcome tracker (reasoning-only, content-arrives, ordinary stream, empty deltas), and `generateMarkdownDetached` failing on whitespace-only output.

## Merge order

Merge this before #707. #707 relies on the `reasoningOnlyResponse` error introduced here to classify a
reasoning-only completion as non-retriable; without this branch it falls back to treating that case as a
generic failure. No other open PR touches these files.
