### PR TITLE
Fix retained batch audio growing without bound (~23 MB/min): file-based TTL, periodic sweep, retention setting

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppContainer.swift
+++ b/OpenOats/Sources/OpenOats/App/AppContainer.swift
@@ -71,13 +71,27 @@ final class AppContainer {
                     .appendingPathComponent("Documents/OpenOats", isDirectory: true)
             )
             let settings = AppSettings()
-            let coordinator = AppCoordinator(
-                sessionRepository: SessionRepository(
-                    batchAudioRetention: {
-                        RetainedBatchAudioRetention.stored(in: .standard).timeInterval
-                    }
-                )
+            let sessionRepository = SessionRepository(
+                batchAudioRetention: { settings.retainedBatchAudioRetentionInterval }
             )
+            let coordinator = AppCoordinator(sessionRepository: sessionRepository)
+            Task {
+                // When the periodic sweep removes retained audio, re-derive the
+                // UI state that depends on it (post-meeting banner, detail pane).
+                await sessionRepository.setRetainedAudioSweepHandler { sessionIDs in
+                    Task { @MainActor in
+                        for sessionID in sessionIDs {
+                            coordinator.liveSessionController?
+                                .retainedBatchAudioWasDeleted(sessionID: sessionID)
+                        }
+                        NotificationCenter.default.post(
+                            name: .retainedBatchAudioSwept,
+                            object: nil,
+                            userInfo: ["sessionIDs": sessionIDs]
+                        )
+                    }
+                }
+            }
             let updaterController = AppUpdaterController()
             return AppLaunchContext(
                 isFirstLaunch: false,

--- a/OpenOats/Sources/OpenOats/App/AppContainer.swift
+++ b/OpenOats/Sources/OpenOats/App/AppContainer.swift
@@ -71,7 +71,13 @@ final class AppContainer {
                     .appendingPathComponent("Documents/OpenOats", isDirectory: true)
             )
             let settings = AppSettings()
-            let coordinator = AppCoordinator()
+            let coordinator = AppCoordinator(
+                sessionRepository: SessionRepository(
+                    batchAudioRetention: {
+                        RetainedBatchAudioRetention.stored(in: .standard).timeInterval
+                    }
+                )
+            )
             let updaterController = AppUpdaterController()
             return AppLaunchContext(
                 isFirstLaunch: false,

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -1595,6 +1595,13 @@ final class LiveSessionController {
     /// Assigns `value` to `state[keyPath:]` only when it differs, avoiding spurious
     /// @Observable withMutation notifications that would trigger unnecessary layout passes.
     @inline(__always)
+    /// Clears the post-meeting "Re-transcribe" offer when the retained audio
+    /// backing it is deleted (user action or retention sweep).
+    func retainedBatchAudioWasDeleted(sessionID: String) {
+        guard coordinator.lastEndedSession?.id == sessionID else { return }
+        set(\.lastEndedSessionCanRetranscribe, false)
+    }
+
     private func set<T: Equatable>(_ kp: ReferenceWritableKeyPath<LiveSessionState, T>, _ value: T) {
         if state[keyPath: kp] != value { state[keyPath: kp] = value }
     }

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -942,6 +942,12 @@ final class NotesController {
         guard state.selectedSessionID == sessionID else { return }
 
         let sources = await coordinator.sessionRepository.audioSources(for: sessionID)
+        // Every await here yields the main actor, and the sweep fires while the
+        // user is working, so the selection can move on before we resume.
+        // Applying this session's audio state to whatever is selected now is
+        // worse than skipping the refresh, so re-check after each hop.
+        guard state.selectedSessionID == sessionID else { return }
+
         if let current = state.audioFileURL, !sources.contains(where: { $0.url == current }) {
             stopAudio()
             state.audioFileURL = sources.first?.url
@@ -949,11 +955,15 @@ final class NotesController {
             state.audioFileURL = sources.first?.url
         }
         state.availableAudioSources = sources
-        state.canRetranscribeSelectedSession =
-            await coordinator.sessionRepository.hasRetainedBatchAudio(sessionID: sessionID)
+
+        let canRetranscribe = await coordinator.sessionRepository.hasRetainedBatchAudio(sessionID: sessionID)
+        guard state.selectedSessionID == sessionID else { return }
+        state.canRetranscribeSelectedSession = canRetranscribe
     }
 
-    private func handleRetainedAudioSwept(sessionIDs: [String]) {
+    /// Entry point for the `.retainedBatchAudioSwept` notification.
+    /// Not private so tests can drive the sweep path directly.
+    func handleRetainedAudioSwept(sessionIDs: [String]) {
         guard let sessionID = state.selectedSessionID, sessionIDs.contains(sessionID) else { return }
         Task { await refreshRetainedAudioDependentState(sessionID: sessionID) }
     }

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -897,6 +897,26 @@ final class NotesController {
         }
     }
 
+    func deleteRetainedBatchAudio() {
+        guard let sessionID = state.selectedSessionID,
+              state.canRetranscribeSelectedSession else { return }
+
+        Task {
+            await coordinator.sessionRepository.cleanupBatchAudio(sessionID: sessionID)
+            guard state.selectedSessionID == sessionID else { return }
+
+            // The deleted stems may back the playback sources currently shown.
+            let sources = await coordinator.sessionRepository.audioSources(for: sessionID)
+            if let playingURL = state.audioFileURL, !sources.contains(where: { $0.url == playingURL }) {
+                stopAudio()
+            }
+            state.availableAudioSources = sources
+            state.audioFileURL = sources.first?.url
+            state.canRetranscribeSelectedSession =
+                await coordinator.sessionRepository.hasRetainedBatchAudio(sessionID: sessionID)
+        }
+    }
+
     // MARK: - Session Management
 
     func renameSession(sessionID: String, newTitle: String) {

--- a/OpenOats/Sources/OpenOats/App/NotesController.swift
+++ b/OpenOats/Sources/OpenOats/App/NotesController.swift
@@ -188,16 +188,32 @@ final class NotesController {
     @ObservationIgnored private var audioPlayer: AVPlayer?
     @ObservationIgnored private var playerObservation: Any?
 
+    /// Observer for retention-sweep removals, so open UI re-derives its state.
+    @ObservationIgnored nonisolated(unsafe) private var sweepObservation: (any NSObjectProtocol)?
+
     init(coordinator: AppCoordinator, settings: AppSettings? = nil) {
         self.coordinator = coordinator
         self.settings = settings
         startEngineObservation()
+        sweepObservation = NotificationCenter.default.addObserver(
+            forName: .retainedBatchAudioSwept,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let sessionIDs = notification.userInfo?["sessionIDs"] as? [String] else { return }
+            Task { @MainActor [weak self] in
+                self?.handleRetainedAudioSwept(sessionIDs: sessionIDs)
+            }
+        }
     }
 
     deinit {
         engineObservationTask?.cancel()
         meetingHistoryPreviewTask?.cancel()
         meetingFamilyKnowledgeBaseTask?.cancel()
+        if let sweepObservation {
+            NotificationCenter.default.removeObserver(sweepObservation)
+        }
     }
 
     // MARK: - Lifecycle
@@ -899,22 +915,47 @@ final class NotesController {
 
     func deleteRetainedBatchAudio() {
         guard let sessionID = state.selectedSessionID,
-              state.canRetranscribeSelectedSession else { return }
+              state.canRetranscribeSelectedSession,
+              // Re-check at action time: the menu's `.disabled(isBatchBusy)` is
+              // render-time only and the confirmation dialog is never re-gated.
+              coordinator.batchStatus == .idle else { return }
 
         Task {
-            await coordinator.sessionRepository.cleanupBatchAudio(sessionID: sessionID)
-            guard state.selectedSessionID == sessionID else { return }
-
-            // The deleted stems may back the playback sources currently shown.
-            let sources = await coordinator.sessionRepository.audioSources(for: sessionID)
-            if let playingURL = state.audioFileURL, !sources.contains(where: { $0.url == playingURL }) {
+            // Stop playback of a stem we are about to unlink, before unlinking.
+            let doomed = await coordinator.sessionRepository.batchAudioURLs(sessionID: sessionID)
+            if let current = state.audioFileURL, current == doomed.mic || current == doomed.sys {
                 stopAudio()
             }
-            state.availableAudioSources = sources
-            state.audioFileURL = sources.first?.url
-            state.canRetranscribeSelectedSession =
-                await coordinator.sessionRepository.hasRetainedBatchAudio(sessionID: sessionID)
+
+            // The repository refuses while a batch run holds the stems.
+            let removed = await coordinator.sessionRepository.cleanupBatchAudio(sessionID: sessionID)
+            guard removed else { return }
+
+            coordinator.liveSessionController?.retainedBatchAudioWasDeleted(sessionID: sessionID)
+            await refreshRetainedAudioDependentState(sessionID: sessionID)
         }
+    }
+
+    /// Re-derives audio-source and re-transcribe state after retained audio was
+    /// removed (user delete or retention sweep).
+    private func refreshRetainedAudioDependentState(sessionID: String) async {
+        guard state.selectedSessionID == sessionID else { return }
+
+        let sources = await coordinator.sessionRepository.audioSources(for: sessionID)
+        if let current = state.audioFileURL, !sources.contains(where: { $0.url == current }) {
+            stopAudio()
+            state.audioFileURL = sources.first?.url
+        } else if state.audioFileURL == nil {
+            state.audioFileURL = sources.first?.url
+        }
+        state.availableAudioSources = sources
+        state.canRetranscribeSelectedSession =
+            await coordinator.sessionRepository.hasRetainedBatchAudio(sessionID: sessionID)
+    }
+
+    private func handleRetainedAudioSwept(sessionIDs: [String]) {
+        guard let sessionID = state.selectedSessionID, sessionIDs.contains(sessionID) else { return }
+        Task { await refreshRetainedAudioDependentState(sessionID: sessionID) }
     }
 
     // MARK: - Session Management

--- a/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
+++ b/OpenOats/Sources/OpenOats/App/OpenOatsApp.swift
@@ -291,6 +291,9 @@ extension OpenOatsRootApp {
 
 extension Notification.Name {
     static let toggleSuggestionPanel = Notification.Name("toggleSuggestionPanel")
+    /// Posted after the retention sweep removes retained batch audio.
+    /// `userInfo["sessionIDs"]` carries the affected session IDs as `[String]`.
+    static let retainedBatchAudioSwept = Notification.Name("retainedBatchAudioSwept")
 }
 
 @MainActor

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -803,6 +803,20 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _retainedBatchAudioRetention: String
+    var retainedBatchAudioRetention: RetainedBatchAudioRetention {
+        get {
+            access(keyPath: \.retainedBatchAudioRetention)
+            return RetainedBatchAudioRetention(rawValue: _retainedBatchAudioRetention) ?? .default
+        }
+        set {
+            withMutation(keyPath: \.retainedBatchAudioRetention) {
+                _retainedBatchAudioRetention = newValue.rawValue
+                defaults.set(newValue.rawValue, forKey: RetainedBatchAudioRetention.defaultsKey)
+            }
+        }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _enableDiarization: Bool
     var enableDiarization: Bool {
         get { access(keyPath: \.enableDiarization); return _enableDiarization }
@@ -1519,6 +1533,8 @@ final class SettingsStore {
         self._batchTranscriptionModel = TranscriptionModel(
             rawValue: defaults.string(forKey: "batchTranscriptionModel") ?? ""
         ) ?? .whisperLargeV3Turbo
+        self._retainedBatchAudioRetention = defaults.string(forKey: RetainedBatchAudioRetention.defaultsKey)
+            ?? RetainedBatchAudioRetention.default.rawValue
         self._enableDiarization = defaults.bool(forKey: "enableDiarization")
         self._diarizationVariant = defaults.string(forKey: "diarizationVariant") ?? DiarizationVariant.dihard3.rawValue
 

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -3,6 +3,7 @@ import CoreAudio
 import Foundation
 import Observation
 import Security
+import os
 
 @Observable
 @MainActor
@@ -803,16 +804,22 @@ final class SettingsStore {
         }
     }
 
-    @ObservationIgnored nonisolated(unsafe) private var _retainedBatchAudioRetention: String
+    /// Lock-backed rather than `nonisolated(unsafe)`: the repository's retention
+    /// sweep reads this off the main actor through
+    /// `retainedBatchAudioRetentionInterval` while the settings picker writes it
+    /// on the main actor. Unsynchronised, that is a data race on the string's
+    /// storage, not merely a stale read.
+    @ObservationIgnored private let _retainedBatchAudioRetention: OSAllocatedUnfairLock<String>
     var retainedBatchAudioRetention: RetainedBatchAudioRetention {
         get {
             access(keyPath: \.retainedBatchAudioRetention)
             // Unknown raw values fail closed to keep-forever (see `stored(in:)`).
-            return RetainedBatchAudioRetention(rawValue: _retainedBatchAudioRetention) ?? .forever
+            let raw = _retainedBatchAudioRetention.withLock { $0 }
+            return RetainedBatchAudioRetention(rawValue: raw) ?? .forever
         }
         set {
             withMutation(keyPath: \.retainedBatchAudioRetention) {
-                _retainedBatchAudioRetention = newValue.rawValue
+                _retainedBatchAudioRetention.withLock { $0 = newValue.rawValue }
                 defaults.set(newValue.rawValue, forKey: RetainedBatchAudioRetention.defaultsKey)
             }
         }
@@ -821,7 +828,8 @@ final class SettingsStore {
     /// Nonisolated snapshot for the repository's off-main retention sweep.
     /// Unknown values fail closed to keep-forever.
     nonisolated var retainedBatchAudioRetentionInterval: TimeInterval? {
-        (RetainedBatchAudioRetention(rawValue: _retainedBatchAudioRetention) ?? .forever).timeInterval
+        let raw = _retainedBatchAudioRetention.withLock { $0 }
+        return (RetainedBatchAudioRetention(rawValue: raw) ?? .forever).timeInterval
     }
 
     @ObservationIgnored nonisolated(unsafe) private var _enableDiarization: Bool
@@ -1540,7 +1548,9 @@ final class SettingsStore {
         self._batchTranscriptionModel = TranscriptionModel(
             rawValue: defaults.string(forKey: "batchTranscriptionModel") ?? ""
         ) ?? .whisperLargeV3Turbo
-        self._retainedBatchAudioRetention = RetainedBatchAudioRetention.stored(in: defaults).rawValue
+        self._retainedBatchAudioRetention = OSAllocatedUnfairLock(
+            initialState: RetainedBatchAudioRetention.stored(in: defaults).rawValue
+        )
         self._enableDiarization = defaults.bool(forKey: "enableDiarization")
         self._diarizationVariant = defaults.string(forKey: "diarizationVariant") ?? DiarizationVariant.dihard3.rawValue
 

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -807,7 +807,8 @@ final class SettingsStore {
     var retainedBatchAudioRetention: RetainedBatchAudioRetention {
         get {
             access(keyPath: \.retainedBatchAudioRetention)
-            return RetainedBatchAudioRetention(rawValue: _retainedBatchAudioRetention) ?? .default
+            // Unknown raw values fail closed to keep-forever (see `stored(in:)`).
+            return RetainedBatchAudioRetention(rawValue: _retainedBatchAudioRetention) ?? .forever
         }
         set {
             withMutation(keyPath: \.retainedBatchAudioRetention) {
@@ -815,6 +816,12 @@ final class SettingsStore {
                 defaults.set(newValue.rawValue, forKey: RetainedBatchAudioRetention.defaultsKey)
             }
         }
+    }
+
+    /// Nonisolated snapshot for the repository's off-main retention sweep.
+    /// Unknown values fail closed to keep-forever.
+    nonisolated var retainedBatchAudioRetentionInterval: TimeInterval? {
+        (RetainedBatchAudioRetention(rawValue: _retainedBatchAudioRetention) ?? .forever).timeInterval
     }
 
     @ObservationIgnored nonisolated(unsafe) private var _enableDiarization: Bool
@@ -1533,8 +1540,7 @@ final class SettingsStore {
         self._batchTranscriptionModel = TranscriptionModel(
             rawValue: defaults.string(forKey: "batchTranscriptionModel") ?? ""
         ) ?? .whisperLargeV3Turbo
-        self._retainedBatchAudioRetention = defaults.string(forKey: RetainedBatchAudioRetention.defaultsKey)
-            ?? RetainedBatchAudioRetention.default.rawValue
+        self._retainedBatchAudioRetention = RetainedBatchAudioRetention.stored(in: defaults).rawValue
         self._enableDiarization = defaults.bool(forKey: "enableDiarization")
         self._diarizationVariant = defaults.string(forKey: "diarizationVariant") ?? DiarizationVariant.dihard3.rawValue
 

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -335,6 +335,49 @@ enum DiarizationVariant: String, CaseIterable, Identifiable {
     }
 }
 
+/// How long audio retained for batch re-transcription (mic.caf / sys.caf) is
+/// kept before the automatic sweep deletes it. Raw values persist in UserDefaults.
+enum RetainedBatchAudioRetention: String, CaseIterable, Identifiable {
+    case threeDays
+    case sevenDays
+    case fourteenDays
+    case thirtyDays
+    case forever
+
+    static let `default`: RetainedBatchAudioRetention = .sevenDays
+    static let defaultsKey = "retainedBatchAudioRetention"
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .threeDays: "3 days"
+        case .sevenDays: "7 days"
+        case .fourteenDays: "14 days"
+        case .thirtyDays: "30 days"
+        case .forever: "Keep forever"
+        }
+    }
+
+    /// Retention window in seconds; `nil` means keep forever.
+    var timeInterval: TimeInterval? {
+        switch self {
+        case .threeDays: 3 * 24 * 3600
+        case .sevenDays: 7 * 24 * 3600
+        case .fourteenDays: 14 * 24 * 3600
+        case .thirtyDays: 30 * 24 * 3600
+        case .forever: nil
+        }
+    }
+
+    /// Reads the persisted value directly; safe off the main actor, so the
+    /// repository's sweep always sees the current setting.
+    static func stored(in defaults: UserDefaults) -> RetainedBatchAudioRetention {
+        guard let raw = defaults.string(forKey: defaultsKey) else { return .default }
+        return RetainedBatchAudioRetention(rawValue: raw) ?? .default
+    }
+}
+
 enum TranscriptionModel: String, CaseIterable, Identifiable {
     case parakeetV2
     case parakeetV3

--- a/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsTypes.swift
@@ -370,11 +370,17 @@ enum RetainedBatchAudioRetention: String, CaseIterable, Identifiable {
         }
     }
 
-    /// Reads the persisted value directly; safe off the main actor, so the
-    /// repository's sweep always sees the current setting.
+    /// Decodes the persisted value. Only a genuinely-unset key gets the 7-day
+    /// default; an unknown or non-string value (downgrade path, corruption)
+    /// fails CLOSED to keep-forever — deletion is destructive, so unknown
+    /// state must mean keep, never delete.
     static func stored(in defaults: UserDefaults) -> RetainedBatchAudioRetention {
-        guard let raw = defaults.string(forKey: defaultsKey) else { return .default }
-        return RetainedBatchAudioRetention(rawValue: raw) ?? .default
+        guard let object = defaults.object(forKey: defaultsKey) else { return .default }
+        guard let raw = object as? String,
+              let value = RetainedBatchAudioRetention(rawValue: raw) else {
+            return .forever
+        }
+        return value
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -193,6 +193,13 @@ actor SessionRepository {
     /// Repeating background sweep started in `init`, cancelled in `deinit`.
     private var retainedAudioSweepTask: Task<Void, Never>?
 
+    /// Sessions whose retained audio is currently being read by a batch run,
+    /// with a count so overlapping runs for the same session keep the guard up.
+    private var activeBatchAudioAccessCounts: [String: Int] = [:]
+
+    /// Invoked with the affected session IDs after a sweep removes retained audio.
+    private var onRetainedAudioSwept: (@Sendable ([String]) -> Void)?
+
     private let sessionsDirectory: URL
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
@@ -235,7 +242,10 @@ actor SessionRepository {
     init(
         rootDirectory: URL? = nil,
         mirrorRetryBackoff: TimeInterval = SessionRepository.defaultMirrorRetryBackoff,
-        batchAudioRetention: @escaping @Sendable () -> TimeInterval? = { SessionRepository.retainedBatchAudioLifetime }
+        // Fail closed: deleting audio is destructive, so a constructor path that
+        // does not wire the retention setting (tests, UI-test bootstrap, future
+        // call sites) must keep forever, never silently become a deleter.
+        batchAudioRetention: @escaping @Sendable () -> TimeInterval? = { nil }
     ) {
         self.batchAudioRetention = batchAudioRetention
 
@@ -313,6 +323,12 @@ actor SessionRepository {
     /// Register a callback invoked once per session when a write error occurs.
     func setWriteErrorHandler(_ handler: @escaping @Sendable (String) -> Void) {
         onWriteError = handler
+    }
+
+    /// Register a callback invoked with the affected session IDs after a sweep
+    /// removes retained batch audio, so dependent UI state can re-derive.
+    func setRetainedAudioSweepHandler(_ handler: @escaping @Sendable ([String]) -> Void) {
+        onRetainedAudioSwept = handler
     }
 
     // MARK: - Session Lifecycle
@@ -1594,8 +1610,29 @@ actor SessionRepository {
         return true
     }
 
-    func cleanupBatchAudio(sessionID: String) {
+    /// Marks a session's retained audio as in use by a batch transcription run,
+    /// which blocks the retention sweep and user deletion for that session.
+    /// Balanced by `endBatchAudioAccess`.
+    func beginBatchAudioAccess(sessionID: String) {
+        activeBatchAudioAccessCounts[sessionID, default: 0] += 1
+    }
+
+    func endBatchAudioAccess(sessionID: String) {
+        guard let count = activeBatchAudioAccessCounts[sessionID] else { return }
+        if count <= 1 {
+            activeBatchAudioAccessCounts.removeValue(forKey: sessionID)
+        } else {
+            activeBatchAudioAccessCounts[sessionID] = count - 1
+        }
+    }
+
+    /// Removes retained batch audio for one session. Refuses (returns `false`)
+    /// while a batch run is reading the stems.
+    @discardableResult
+    func cleanupBatchAudio(sessionID: String) -> Bool {
+        guard activeBatchAudioAccessCounts[sessionID] == nil else { return false }
         Self.removeRetainedBatchAudio(inSessionDirectory: sessionDirectory(for: sessionID))
+        return true
     }
 
     func loadBatchMeta(sessionID: String) -> BatchMeta? {
@@ -2354,40 +2391,65 @@ actor SessionRepository {
     // MARK: - Orphan Cleanup
 
     /// Re-evaluates retained batch audio against the current retention setting.
+    /// Sessions with an in-flight batch run are skipped.
     func sweepExpiredRetainedBatchAudio() {
-        Self.cleanupExpiredRetainedBatchAudio(in: sessionsDirectory, olderThan: batchAudioRetention())
+        let removed = Self.cleanupExpiredRetainedBatchAudio(
+            in: sessionsDirectory,
+            olderThan: batchAudioRetention(),
+            excluding: Set(activeBatchAudioAccessCounts.keys)
+        )
+        if !removed.isEmpty {
+            onRetainedAudioSwept?(removed)
+        }
     }
 
     /// Deletes retained batch audio whose newest artifact is older than `retention`.
-    /// A `nil` retention means keep forever.
+    /// A `nil` retention means keep forever. Returns the affected session IDs.
+    @discardableResult
     static func cleanupExpiredRetainedBatchAudio(
         in sessionsDirectory: URL,
         olderThan retention: TimeInterval?,
+        excluding activeSessionIDs: Set<String> = [],
         now: Date = Date()
-    ) {
-        guard let retention else { return }
+    ) -> [String] {
+        guard let retention else { return [] }
 
         let fm = FileManager.default
         guard let contents = try? fm.contentsOfDirectory(
             at: sessionsDirectory,
-            includingPropertiesForKeys: [.isDirectoryKey]
-        ) else { return }
+            includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey]
+        ) else { return [] }
 
         let cutoff = now.addingTimeInterval(-retention)
+        var removed: [String] = []
 
         for item in contents {
-            guard let values = try? item.resourceValues(forKeys: [.isDirectoryKey]),
-                  values.isDirectory == true else { continue }
+            // Skip symlinks: resource values follow links, so a symlink named
+            // session_* would otherwise delete its target's stems.
+            guard let values = try? item.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+                  values.isDirectory == true,
+                  values.isSymbolicLink != true else { continue }
 
             let name = item.lastPathComponent
             guard name.hasPrefix("session_") else { continue }
+            guard !activeSessionIDs.contains(name) else { continue }
 
-            guard let newest = newestRetainedBatchAudioModificationDate(inSessionDirectory: item),
-                  newest < cutoff else { continue }
+            let dates = retainedBatchAudioDates(inSessionDirectory: item)
+            if let stems = dates.stems {
+                let newest = max(stems, dates.metadata ?? stems)
+                guard newest < cutoff else { continue }
+            } else if let metadata = dates.metadata {
+                // No stems left: a lone batch-meta.json would otherwise live forever.
+                guard metadata < cutoff else { continue }
+            } else {
+                continue
+            }
 
             removeRetainedBatchAudio(inSessionDirectory: item)
+            removed.append(name)
             Log.sessionRepository.info("Cleaned up expired retained batch audio in \(name, privacy: .public)")
         }
+        return removed
     }
 
     /// The date that decides retained-audio expiry: the newest modification date
@@ -2397,6 +2459,14 @@ actor SessionRepository {
     /// would reset the TTL indefinitely. Returns `nil` when the session has no
     /// retained audio stems.
     static func newestRetainedBatchAudioModificationDate(inSessionDirectory sessionDirectory: URL) -> Date? {
+        let dates = retainedBatchAudioDates(inSessionDirectory: sessionDirectory)
+        guard let stems = dates.stems else { return nil }
+        return max(stems, dates.metadata ?? stems)
+    }
+
+    private static func retainedBatchAudioDates(
+        inSessionDirectory sessionDirectory: URL
+    ) -> (stems: Date?, metadata: Date?) {
         let audioDir = sessionDirectory.appendingPathComponent("audio", isDirectory: true)
         let audioStems = [
             audioDir.appendingPathComponent("mic.caf"),
@@ -2404,23 +2474,22 @@ actor SessionRepository {
             sessionDirectory.appendingPathComponent("mic.caf"),
             sessionDirectory.appendingPathComponent("sys.caf"),
         ]
-        let metadata = [
+        let metadataFiles = [
             audioDir.appendingPathComponent("batch-meta.json"),
             sessionDirectory.appendingPathComponent("batch-meta.json"),
         ]
 
-        var newest: Date?
+        var stems: Date?
         for url in audioStems {
             guard let date = modificationDate(of: url) else { continue }
-            newest = max(newest ?? date, date)
+            stems = max(stems ?? date, date)
         }
-        // Metadata alone does not make a session sweepable.
-        guard newest != nil else { return nil }
-        for url in metadata {
+        var metadata: Date?
+        for url in metadataFiles {
             guard let date = modificationDate(of: url) else { continue }
-            newest = max(newest ?? date, date)
+            metadata = max(metadata ?? date, date)
         }
-        return newest
+        return (stems, metadata)
     }
 
     private static func modificationDate(of url: URL) -> Date? {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -179,8 +179,19 @@ struct SessionMetadata: Codable, Sendable {
 /// sessions/<id>/audio/
 /// ```
 actor SessionRepository {
-    /// Retain batch stems/metadata long enough to support true reruns and debugging.
-    private static let retainedBatchAudioLifetime: TimeInterval = 7 * 24 * 3600
+    /// Default retention for batch stems/metadata: long enough to support true reruns and debugging.
+    static let retainedBatchAudioLifetime: TimeInterval = 7 * 24 * 3600
+
+    /// How often the running app re-checks retained batch audio for expiry.
+    /// The init-time sweep alone is not enough for a menu-bar app that stays up for weeks.
+    static let retainedBatchAudioSweepInterval: TimeInterval = 6 * 3600
+
+    /// Returns the current retention window in seconds (`nil` = keep forever).
+    /// Re-read on every sweep so setting changes apply without a relaunch.
+    private let batchAudioRetention: @Sendable () -> TimeInterval?
+
+    /// Repeating background sweep started in `init`, cancelled in `deinit`.
+    private var retainedAudioSweepTask: Task<Void, Never>?
 
     private let sessionsDirectory: URL
     private let encoder: JSONEncoder
@@ -216,9 +227,18 @@ actor SessionRepository {
     /// Default minimum interval between retries of a failed mirror.
     static let defaultMirrorRetryBackoff: TimeInterval = 5 * 60
 
-    /// - Parameter mirrorRetryBackoff: Minimum interval between retries of a
-    ///   session whose notes-folder mirror failed. Lowered by tests.
-    init(rootDirectory: URL? = nil, mirrorRetryBackoff: TimeInterval = SessionRepository.defaultMirrorRetryBackoff) {
+    /// - Parameters:
+    ///   - mirrorRetryBackoff: Minimum interval between retries of a session
+    ///     whose notes-folder mirror failed. Lowered by tests.
+    ///   - batchAudioRetention: How long retained batch audio lives. `nil`
+    ///     keeps it forever.
+    init(
+        rootDirectory: URL? = nil,
+        mirrorRetryBackoff: TimeInterval = SessionRepository.defaultMirrorRetryBackoff,
+        batchAudioRetention: @escaping @Sendable () -> TimeInterval? = { SessionRepository.retainedBatchAudioLifetime }
+    ) {
+        self.batchAudioRetention = batchAudioRetention
+
         let baseDirectory: URL
         if let rootDirectory {
             baseDirectory = rootDirectory
@@ -242,9 +262,25 @@ actor SessionRepository {
         try? FileManager.default.createDirectory(at: sessionsDirectory, withIntermediateDirectories: true)
         Self.dropMetadataNeverIndex(in: sessionsDirectory)
 
-        Self.cleanupExpiredRetainedBatchAudio(in: sessionsDirectory)
+        Self.cleanupExpiredRetainedBatchAudio(in: sessionsDirectory, olderThan: batchAudioRetention())
 
         Task { await self.restorePendingMirrors() }
+        Task { [weak self] in await self?.startPeriodicRetainedBatchAudioSweeps() }
+    }
+
+    deinit {
+        retainedAudioSweepTask?.cancel()
+    }
+
+    private func startPeriodicRetainedBatchAudioSweeps() {
+        guard retainedAudioSweepTask == nil else { return }
+        retainedAudioSweepTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(Self.retainedBatchAudioSweepInterval))
+                guard !Task.isCancelled, let self else { break }
+                await self.sweepExpiredRetainedBatchAudio()
+            }
+        }
     }
 
     // MARK: - Configuration
@@ -1559,19 +1595,7 @@ actor SessionRepository {
     }
 
     func cleanupBatchAudio(sessionID: String) {
-        let fm = FileManager.default
-
-        // Clean canonical audio/
-        let audioDir = sessionDirectory(for: sessionID).appendingPathComponent("audio", isDirectory: true)
-        try? fm.removeItem(at: audioDir.appendingPathComponent("mic.caf"))
-        try? fm.removeItem(at: audioDir.appendingPathComponent("sys.caf"))
-        try? fm.removeItem(at: audioDir.appendingPathComponent("batch-meta.json"))
-
-        // Clean legacy layout
-        let dir = sessionDirectory(for: sessionID)
-        try? fm.removeItem(at: dir.appendingPathComponent("mic.caf"))
-        try? fm.removeItem(at: dir.appendingPathComponent("sys.caf"))
-        try? fm.removeItem(at: dir.appendingPathComponent("batch-meta.json"))
+        Self.removeRetainedBatchAudio(inSessionDirectory: sessionDirectory(for: sessionID))
     }
 
     func loadBatchMeta(sessionID: String) -> BatchMeta? {
@@ -2329,46 +2353,94 @@ actor SessionRepository {
 
     // MARK: - Orphan Cleanup
 
-    private static func cleanupExpiredRetainedBatchAudio(in sessionsDirectory: URL) {
+    /// Re-evaluates retained batch audio against the current retention setting.
+    func sweepExpiredRetainedBatchAudio() {
+        Self.cleanupExpiredRetainedBatchAudio(in: sessionsDirectory, olderThan: batchAudioRetention())
+    }
+
+    /// Deletes retained batch audio whose newest artifact is older than `retention`.
+    /// A `nil` retention means keep forever.
+    static func cleanupExpiredRetainedBatchAudio(
+        in sessionsDirectory: URL,
+        olderThan retention: TimeInterval?,
+        now: Date = Date()
+    ) {
+        guard let retention else { return }
+
         let fm = FileManager.default
         guard let contents = try? fm.contentsOfDirectory(
             at: sessionsDirectory,
-            includingPropertiesForKeys: [.contentModificationDateKey, .isDirectoryKey]
+            includingPropertiesForKeys: [.isDirectoryKey]
         ) else { return }
 
-        let cutoff = Date().addingTimeInterval(-retainedBatchAudioLifetime)
+        let cutoff = now.addingTimeInterval(-retention)
 
         for item in contents {
-            guard let values = try? item.resourceValues(forKeys: [.isDirectoryKey, .contentModificationDateKey]),
+            guard let values = try? item.resourceValues(forKeys: [.isDirectoryKey]),
                   values.isDirectory == true else { continue }
 
             let name = item.lastPathComponent
             guard name.hasPrefix("session_") else { continue }
 
-            // Check both canonical audio/ and legacy layout
-            let audioDir = item.appendingPathComponent("audio", isDirectory: true)
-            let micCanonical = audioDir.appendingPathComponent("mic.caf")
-            let sysCanonical = audioDir.appendingPathComponent("sys.caf")
-            let micLegacy = item.appendingPathComponent("mic.caf")
-            let sysLegacy = item.appendingPathComponent("sys.caf")
+            guard let newest = newestRetainedBatchAudioModificationDate(inSessionDirectory: item),
+                  newest < cutoff else { continue }
 
-            let hasAudio = fm.fileExists(atPath: micCanonical.path) ||
-                           fm.fileExists(atPath: sysCanonical.path) ||
-                           fm.fileExists(atPath: micLegacy.path) ||
-                           fm.fileExists(atPath: sysLegacy.path)
-
-            guard hasAudio else { continue }
-
-            if let modDate = values.contentModificationDate, modDate < cutoff {
-                try? fm.removeItem(at: micCanonical)
-                try? fm.removeItem(at: sysCanonical)
-                try? fm.removeItem(at: audioDir.appendingPathComponent("batch-meta.json"))
-                try? fm.removeItem(at: micLegacy)
-                try? fm.removeItem(at: sysLegacy)
-                try? fm.removeItem(at: item.appendingPathComponent("batch-meta.json"))
-                Log.sessionRepository.info("Cleaned up expired retained batch audio in \(name, privacy: .public)")
-            }
+            removeRetainedBatchAudio(inSessionDirectory: item)
+            Log.sessionRepository.info("Cleaned up expired retained batch audio in \(name, privacy: .public)")
         }
+    }
+
+    /// The date that decides retained-audio expiry: the newest modification date
+    /// among mic.caf / sys.caf / batch-meta.json in the canonical and legacy
+    /// layouts. The session directory's own date is deliberately ignored —
+    /// unrelated metadata writes (notes edits, speaker renames) bump it and
+    /// would reset the TTL indefinitely. Returns `nil` when the session has no
+    /// retained audio stems.
+    static func newestRetainedBatchAudioModificationDate(inSessionDirectory sessionDirectory: URL) -> Date? {
+        let audioDir = sessionDirectory.appendingPathComponent("audio", isDirectory: true)
+        let audioStems = [
+            audioDir.appendingPathComponent("mic.caf"),
+            audioDir.appendingPathComponent("sys.caf"),
+            sessionDirectory.appendingPathComponent("mic.caf"),
+            sessionDirectory.appendingPathComponent("sys.caf"),
+        ]
+        let metadata = [
+            audioDir.appendingPathComponent("batch-meta.json"),
+            sessionDirectory.appendingPathComponent("batch-meta.json"),
+        ]
+
+        var newest: Date?
+        for url in audioStems {
+            guard let date = modificationDate(of: url) else { continue }
+            newest = max(newest ?? date, date)
+        }
+        // Metadata alone does not make a session sweepable.
+        guard newest != nil else { return nil }
+        for url in metadata {
+            guard let date = modificationDate(of: url) else { continue }
+            newest = max(newest ?? date, date)
+        }
+        return newest
+    }
+
+    private static func modificationDate(of url: URL) -> Date? {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+    }
+
+    /// Removes retained batch audio artifacts in both canonical and legacy layouts.
+    static func removeRetainedBatchAudio(inSessionDirectory sessionDirectory: URL) {
+        let fm = FileManager.default
+
+        // Canonical audio/ layout
+        let audioDir = sessionDirectory.appendingPathComponent("audio", isDirectory: true)
+        try? fm.removeItem(at: audioDir.appendingPathComponent("mic.caf"))
+        try? fm.removeItem(at: audioDir.appendingPathComponent("sys.caf"))
+        try? fm.removeItem(at: audioDir.appendingPathComponent("batch-meta.json"))
+
+        // Legacy layout (files directly in the session directory)
+        try? fm.removeItem(at: sessionDirectory.appendingPathComponent("mic.caf"))
+        try? fm.removeItem(at: sessionDirectory.appendingPathComponent("sys.caf"))
+        try? fm.removeItem(at: sessionDirectory.appendingPathComponent("batch-meta.json"))
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -1627,12 +1627,12 @@ actor SessionRepository {
     }
 
     /// Removes retained batch audio for one session. Refuses (returns `false`)
-    /// while a batch run is reading the stems.
+    /// while a batch run is reading the stems, or when the session's `audio/`
+    /// is a symlink and deleting would reach through it.
     @discardableResult
     func cleanupBatchAudio(sessionID: String) -> Bool {
         guard activeBatchAudioAccessCounts[sessionID] == nil else { return false }
-        Self.removeRetainedBatchAudio(inSessionDirectory: sessionDirectory(for: sessionID))
-        return true
+        return Self.removeRetainedBatchAudio(inSessionDirectory: sessionDirectory(for: sessionID))
     }
 
     func loadBatchMeta(sessionID: String) -> BatchMeta? {
@@ -2435,17 +2435,25 @@ actor SessionRepository {
             guard !activeSessionIDs.contains(name) else { continue }
 
             let dates = retainedBatchAudioDates(inSessionDirectory: item)
-            if let stems = dates.stems {
-                let newest = max(stems, dates.metadata ?? stems)
-                guard newest < cutoff else { continue }
-            } else if let metadata = dates.metadata {
-                // No stems left: a lone batch-meta.json would otherwise live forever.
-                guard metadata < cutoff else { continue }
-            } else {
+
+            // An artifact whose date could not be read has an unknown age. This
+            // sweep unlinks user audio, so unknown state means keep: without
+            // this guard a present-but-unreadable stem looks identical to an
+            // absent one, and an expired batch-meta.json would delete stems
+            // that were never shown to be old.
+            if dates.hasUnreadable {
+                Log.sessionRepository.info(
+                    "Keeping retained batch audio in \(name, privacy: .public): modification date unreadable"
+                )
+            }
+            guard retainedBatchAudioIsExpired(dates, cutoff: cutoff) else { continue }
+
+            guard removeRetainedBatchAudio(inSessionDirectory: item) else {
+                Log.sessionRepository.info(
+                    "Keeping retained batch audio in \(name, privacy: .public): audio/ is a symlink"
+                )
                 continue
             }
-
-            removeRetainedBatchAudio(inSessionDirectory: item)
             removed.append(name)
             Log.sessionRepository.info("Cleaned up expired retained batch audio in \(name, privacy: .public)")
         }
@@ -2460,13 +2468,48 @@ actor SessionRepository {
     /// retained audio stems.
     static func newestRetainedBatchAudioModificationDate(inSessionDirectory sessionDirectory: URL) -> Date? {
         let dates = retainedBatchAudioDates(inSessionDirectory: sessionDirectory)
-        guard let stems = dates.stems else { return nil }
+        guard !dates.hasUnreadable, let stems = dates.stems else { return nil }
         return max(stems, dates.metadata ?? stems)
     }
 
-    private static func retainedBatchAudioDates(
+    /// Whether a session's retained audio has expired, given its artifact dates.
+    /// Pure, so the fail-open rules can be asserted directly rather than through
+    /// filesystem states that are hard to stage without also blocking deletion.
+    static func retainedBatchAudioIsExpired(
+        _ dates: RetainedBatchAudioDates,
+        cutoff: Date
+    ) -> Bool {
+        // An artifact whose date could not be read has an unknown age, and this
+        // sweep unlinks user audio, so unknown means keep. Without this a
+        // present-but-unreadable stem is indistinguishable from an absent one,
+        // and an expired batch-meta.json would delete stems that were never
+        // shown to be old.
+        guard !dates.hasUnreadable else { return false }
+
+        if let stems = dates.stems {
+            return max(stems, dates.metadata ?? stems) < cutoff
+        }
+        if let metadata = dates.metadata {
+            // No stems left: a lone batch-meta.json would otherwise live forever.
+            return metadata < cutoff
+        }
+        return false
+    }
+
+    /// Modification dates of a session's retained audio artifacts.
+    struct RetainedBatchAudioDates {
+        /// Newest date among the mic/sys stems, or `nil` when none are present.
+        var stems: Date?
+        /// Newest date among the batch-meta.json files, or `nil` when absent.
+        var metadata: Date?
+        /// True when an artifact is present but its date could not be read.
+        /// Callers that delete must treat this as "age unknown" and keep.
+        var hasUnreadable: Bool
+    }
+
+    static func retainedBatchAudioDates(
         inSessionDirectory sessionDirectory: URL
-    ) -> (stems: Date?, metadata: Date?) {
+    ) -> RetainedBatchAudioDates {
         let audioDir = sessionDirectory.appendingPathComponent("audio", isDirectory: true)
         let audioStems = [
             audioDir.appendingPathComponent("mic.caf"),
@@ -2479,29 +2522,63 @@ actor SessionRepository {
             sessionDirectory.appendingPathComponent("batch-meta.json"),
         ]
 
-        var stems: Date?
+        var result = RetainedBatchAudioDates(stems: nil, metadata: nil, hasUnreadable: false)
         for url in audioStems {
-            guard let date = modificationDate(of: url) else { continue }
-            stems = max(stems ?? date, date)
+            switch modificationDate(of: url) {
+            case .date(let date): result.stems = max(result.stems ?? date, date)
+            case .unreadable: result.hasUnreadable = true
+            case .absent: continue
+            }
         }
-        var metadata: Date?
         for url in metadataFiles {
-            guard let date = modificationDate(of: url) else { continue }
-            metadata = max(metadata ?? date, date)
+            switch modificationDate(of: url) {
+            case .date(let date): result.metadata = max(result.metadata ?? date, date)
+            case .unreadable: result.hasUnreadable = true
+            case .absent: continue
+            }
         }
-        return (stems, metadata)
+        return result
     }
 
-    private static func modificationDate(of url: URL) -> Date? {
-        (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+    /// Why a modification date is unavailable, which a plain `Date?` cannot say.
+    /// "Not there" and "there but unreadable" call for opposite decisions when
+    /// the answer drives a deletion.
+    enum ModificationDateResult: Equatable {
+        case date(Date)
+        case absent
+        case unreadable
     }
 
-    /// Removes retained batch audio artifacts in both canonical and legacy layouts.
-    static func removeRetainedBatchAudio(inSessionDirectory sessionDirectory: URL) {
+    static func modificationDate(of url: URL) -> ModificationDateResult {
+        do {
+            let values = try url.resourceValues(forKeys: [.contentModificationDateKey])
+            guard let date = values.contentModificationDate else { return .unreadable }
+            return .date(date)
+        } catch let error as CocoaError where error.code == .fileReadNoSuchFile
+            || error.code == .fileNoSuchFile {
+            return .absent
+        } catch {
+            return .unreadable
+        }
+    }
+
+    /// Removes retained batch audio artifacts in both canonical and legacy
+    /// layouts. Returns `false` without deleting anything when `audio/` is a
+    /// symlink.
+    ///
+    /// `removeItem` resolves every path component but the last, so
+    /// `<session>/audio/mic.caf` deletes through a symlinked `audio/` and takes
+    /// the real file on the other volume with it. Relocating `audio/` is exactly
+    /// what a user storing gigabytes per meeting is likely to have done, so the
+    /// canonical removals are refused rather than redirected.
+    @discardableResult
+    static func removeRetainedBatchAudio(inSessionDirectory sessionDirectory: URL) -> Bool {
         let fm = FileManager.default
 
-        // Canonical audio/ layout
         let audioDir = sessionDirectory.appendingPathComponent("audio", isDirectory: true)
+        if isSymbolicLink(audioDir) { return false }
+
+        // Canonical audio/ layout
         try? fm.removeItem(at: audioDir.appendingPathComponent("mic.caf"))
         try? fm.removeItem(at: audioDir.appendingPathComponent("sys.caf"))
         try? fm.removeItem(at: audioDir.appendingPathComponent("batch-meta.json"))
@@ -2510,6 +2587,16 @@ actor SessionRepository {
         try? fm.removeItem(at: sessionDirectory.appendingPathComponent("mic.caf"))
         try? fm.removeItem(at: sessionDirectory.appendingPathComponent("sys.caf"))
         try? fm.removeItem(at: sessionDirectory.appendingPathComponent("batch-meta.json"))
+        return true
+    }
+
+    /// Whether `url` is itself a symlink. Uses the no-follow attribute lookup:
+    /// `resourceValues(forKeys: [.isSymbolicLinkKey])` answers about the link,
+    /// but only when the link resolves.
+    static func isSymbolicLink(_ url: URL) -> Bool {
+        guard let type = try? FileManager.default
+            .attributesOfItem(atPath: url.path)[.type] as? FileAttributeType else { return false }
+        return type == .typeSymbolicLink
     }
 }
 

--- a/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
+++ b/OpenOats/Sources/OpenOats/Transcription/BatchAudioTranscriber.swift
@@ -315,6 +315,11 @@ actor BatchAudioTranscriber {
         activeSessionID = sessionID
         isImporting = false
 
+        // Guard the stems against the retention sweep and user deletion for the
+        // whole run: batchAudioURLs is captured once at the start and sys.caf is
+        // re-read minutes later, so a mid-run removal is unrecoverable.
+        await sessionRepository.beginBatchAudioAccess(sessionID: sessionID)
+
         let task = Task { [weak self] in
             guard let self else { return }
             do {
@@ -341,6 +346,8 @@ actor BatchAudioTranscriber {
         }
         currentTask = task
         await task.value
+
+        await sessionRepository.endBatchAudioAccess(sessionID: sessionID)
     }
 
     func cancel() async {

--- a/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
+++ b/OpenOats/Sources/OpenOats/Views/MeetingDetailPane.swift
@@ -50,6 +50,7 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
     private let sessionFolderMenuItems: (SessionIndex) -> SessionFolderMenuItems
 
     @State private var confirmRestoreOriginalTranscript = false
+    @State private var confirmDeleteRetainedAudio = false
     @State private var appleNotesSyncState: AppleNotesSyncState = .idle
     @State private var appleNotesLastSyncDate: Date? = nil
     @State private var meetingFamilyBottomTab: MeetingFamilyBottomTab = .history
@@ -126,6 +127,18 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("This replaces the current transcript with the saved pre-batch version for this session.")
+            }
+            .confirmationDialog(
+                "Delete retained audio?",
+                isPresented: $confirmDeleteRetainedAudio,
+                titleVisibility: .visible
+            ) {
+                Button("Delete Retained Audio", role: .destructive) {
+                    controller.deleteRetainedBatchAudio()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("This removes the audio kept for re-transcribing this session. Transcripts and notes are kept, but re-transcription will no longer be available.")
             }
             .sheet(isPresented: $isAddTranscriptPresented) {
                 addTranscriptSheet(controller: controller)
@@ -2051,6 +2064,15 @@ struct MeetingDetailPane<SessionFolderMenuItems: View>: View {
                     systemImage: settings.enableDiarization ? "person.2" : "person.2.slash"
                 )
                 .foregroundStyle(.secondary)
+
+                Divider()
+
+                Button(role: .destructive) {
+                    confirmDeleteRetainedAudio = true
+                } label: {
+                    Label("Delete retained audio", systemImage: "trash")
+                }
+                .disabled(isBatchBusy)
             }
 
             if state.hasOriginalTranscriptBackup {

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -437,6 +437,7 @@ private struct GeneralSettingsTab: View {
 
 private struct TranscriptionSettingsTab: View {
     @Bindable var settings: AppSettings
+    @Environment(AppCoordinator.self) private var coordinator
     @State private var inputDevices: [(id: AudioDeviceID, name: String)] = []
     @State private var outputDevices: [(id: AudioDeviceID, name: String)] = []
     @State private var isValidatingElevenLabsKey = false
@@ -658,7 +659,12 @@ private struct TranscriptionSettingsTab: View {
                             }
                         }
                         .font(.system(size: 12))
-                        Text("Audio kept for re-transcription uses about 23 MB per meeting minute (roughly 1 GB for a 75-minute meeting). Older audio is deleted automatically; transcripts and notes are never affected.")
+                        .onChange(of: settings.retainedBatchAudioRetention) {
+                            // The copy promises automatic deletion; apply the new
+                            // window now instead of waiting for the next 6h tick.
+                            Task { await coordinator.sessionRepository.sweepExpiredRetainedBatchAudio() }
+                        }
+                        Text("Audio kept for re-transcription can use up to about 23 MB per meeting minute; one real 75-minute meeting measured 1.0 GB. Older audio is deleted automatically; transcripts and notes are never affected.")
                             .font(.system(size: 11))
                             .foregroundStyle(.secondary)
                     }

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -651,6 +651,16 @@ private struct TranscriptionSettingsTab: View {
                             }
                         }
                         .font(.system(size: 12))
+
+                        Picker("Keep Audio For", selection: $settings.retainedBatchAudioRetention) {
+                            ForEach(RetainedBatchAudioRetention.allCases) { option in
+                                Text(option.displayName).tag(option)
+                            }
+                        }
+                        .font(.system(size: 12))
+                        Text("Audio kept for re-transcription uses about 23 MB per meeting minute (roughly 1 GB for a 75-minute meeting). Older audio is deleted automatically; transcripts and notes are never affected.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
                     }
                 }
 

--- a/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotesControllerTests.swift
@@ -218,6 +218,48 @@ final class NotesControllerTests: XCTestCase {
         XCTAssertTrue(controller.state.hasOriginalTranscriptBackup)
     }
 
+    func testRetentionSweepRefreshDoesNotApplyToASessionDeselectedMidRefresh() async throws {
+        let (root, _) = makeTempDirs()
+        let (controller, coordinator) = makeController(root: root)
+        let sessionID = "session_test_sweep_refresh_deselect"
+
+        await seedSession(coordinator: coordinator, sessionID: sessionID)
+
+        let audioDir = coordinator.sessionRepository.sessionsDirectoryURL
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        try FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
+        try Data("sys".utf8).write(to: audioDir.appendingPathComponent("sys.caf"))
+
+        controller.selectSession(sessionID)
+        try? await Task.sleep(for: .milliseconds(200))
+        XCTAssertTrue(controller.state.canRetranscribeSelectedSession)
+        XCTAssertFalse(controller.state.availableAudioSources.isEmpty)
+
+        // The sweep refresh awaits the repository before it writes. One yield
+        // lets it start and park on that hop; the selection then changes while
+        // it is suspended, which is the interleaving the guards must survive.
+        controller.handleRetainedAudioSwept(sessionIDs: [sessionID])
+        await Task.yield()
+        controller.selectSession(nil)
+
+        try? await Task.sleep(for: .milliseconds(200))
+
+        XCTAssertNil(controller.state.selectedSessionID)
+        XCTAssertTrue(
+            controller.state.availableAudioSources.isEmpty,
+            "Swept session's audio sources leaked into the cleared selection"
+        )
+        XCTAssertNil(
+            controller.state.audioFileURL,
+            "Swept session's audio URL leaked into the cleared selection"
+        )
+        XCTAssertFalse(
+            controller.state.canRetranscribeSelectedSession,
+            "Swept session's re-transcribe availability leaked into the cleared selection"
+        )
+    }
+
     func testRestoreOriginalTranscriptReloadsSelectedSession() async {
         let (root, _) = makeTempDirs()
         let (controller, coordinator) = makeController(root: root)

--- a/OpenOats/Tests/OpenOatsTests/RetainedBatchAudioSweepTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/RetainedBatchAudioSweepTests.swift
@@ -273,6 +273,168 @@ final class RetainedBatchAudioSweepTests: XCTestCase {
         XCTAssertFalse(fm.fileExists(atPath: micURL.path), "sweep must apply once the batch run ends")
     }
 
+    // MARK: - Fail-open guards
+    //
+    // The sweep unlinks user audio on a timer, so every path that cannot
+    // establish the facts it needs must keep rather than delete.
+
+    func testUnreadableStemDateKeepsStemsDespiteExpiredMetadata() {
+        let old = Date(timeIntervalSinceNow: -days(30))
+        let cutoff = Date(timeIntervalSinceNow: -days(7))
+
+        // Stems are present on disk but their dates could not be read, so
+        // `stems` is nil for the same reason "no stems left" would be. Only the
+        // metadata date is known, and it is expired.
+        let unreadable = SessionRepository.RetainedBatchAudioDates(
+            stems: nil,
+            metadata: old,
+            hasUnreadable: true
+        )
+        XCTAssertFalse(
+            SessionRepository.retainedBatchAudioIsExpired(unreadable, cutoff: cutoff),
+            "Stems whose age was never established must be kept, not removed on the metadata's age"
+        )
+
+        // Same dates, but the stems really are gone: the lone batch-meta.json
+        // must still be collected, or it lives forever.
+        let genuinelyAbsent = SessionRepository.RetainedBatchAudioDates(
+            stems: nil,
+            metadata: old,
+            hasUnreadable: false
+        )
+        XCTAssertTrue(
+            SessionRepository.retainedBatchAudioIsExpired(genuinelyAbsent, cutoff: cutoff),
+            "An expired lone batch-meta.json is still collectable"
+        )
+    }
+
+    func testUnreadableMetadataDateKeepsExpiredStems() {
+        let old = Date(timeIntervalSinceNow: -days(30))
+        let cutoff = Date(timeIntervalSinceNow: -days(7))
+        let dates = SessionRepository.RetainedBatchAudioDates(
+            stems: old,
+            metadata: nil,
+            hasUnreadable: true
+        )
+        XCTAssertFalse(
+            SessionRepository.retainedBatchAudioIsExpired(dates, cutoff: cutoff),
+            "An unreadable artifact may be the newest one, so its session's age is unknown"
+        )
+    }
+
+    func testExpiryUsesNewestArtifactWhenEverythingIsReadable() {
+        let cutoff = Date(timeIntervalSinceNow: -days(7))
+        let expired = SessionRepository.RetainedBatchAudioDates(
+            stems: Date(timeIntervalSinceNow: -days(30)),
+            metadata: Date(timeIntervalSinceNow: -days(29)),
+            hasUnreadable: false
+        )
+        XCTAssertTrue(SessionRepository.retainedBatchAudioIsExpired(expired, cutoff: cutoff))
+
+        let freshMetadata = SessionRepository.RetainedBatchAudioDates(
+            stems: Date(timeIntervalSinceNow: -days(30)),
+            metadata: Date(timeIntervalSinceNow: -days(1)),
+            hasUnreadable: false
+        )
+        XCTAssertFalse(
+            SessionRepository.retainedBatchAudioIsExpired(freshMetadata, cutoff: cutoff),
+            "The newest artifact decides expiry"
+        )
+
+        let nothing = SessionRepository.RetainedBatchAudioDates(
+            stems: nil,
+            metadata: nil,
+            hasUnreadable: false
+        )
+        XCTAssertFalse(SessionRepository.retainedBatchAudioIsExpired(nothing, cutoff: cutoff))
+    }
+
+    /// End-to-end companion: an unreadable `audio/` must leave the stems in
+    /// place. Deliberately weaker than the cases above, because the permission
+    /// block that hides the dates also blocks the removal, so this guards the
+    /// wiring rather than the rule.
+    func testSweepKeepsSessionWhoseAudioDirectoryCannotBeRead() throws {
+        let fm = FileManager.default
+        let old = Date(timeIntervalSinceNow: -days(30))
+        let sessionDir = try makeSession(
+            named: "session_unreadable",
+            canonicalFiles: ["mic.caf": old, "sys.caf": old],
+            legacyFiles: ["batch-meta.json": old]
+        )
+        let audioDir = sessionDir.appendingPathComponent("audio", isDirectory: true)
+        try fm.setAttributes([.posixPermissions: 0o000], ofItemAtPath: audioDir.path)
+        defer { try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: audioDir.path) }
+
+        let dates = SessionRepository.retainedBatchAudioDates(inSessionDirectory: sessionDir)
+        try XCTSkipUnless(dates.hasUnreadable, "Test needs an unreadable stem date; running as root defeats it")
+
+        let removed = SessionRepository.cleanupExpiredRetainedBatchAudio(in: sessionsDir, olderThan: days(7))
+        XCTAssertFalse(removed.contains("session_unreadable"))
+
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: audioDir.path)
+        XCTAssertTrue(exists(audioDir.appendingPathComponent("mic.caf")))
+    }
+
+    func testModificationDateDistinguishesAbsentFromUnreadable() throws {
+        let fm = FileManager.default
+        let sessionDir = try makeSession(named: "session_probe", canonicalFiles: ["mic.caf": Date()])
+        let audioDir = sessionDir.appendingPathComponent("audio", isDirectory: true)
+
+        XCTAssertEqual(
+            SessionRepository.modificationDate(of: audioDir.appendingPathComponent("nope.caf")),
+            .absent
+        )
+
+        try fm.setAttributes([.posixPermissions: 0o000], ofItemAtPath: audioDir.path)
+        defer { try? fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: audioDir.path) }
+        let result = SessionRepository.modificationDate(of: audioDir.appendingPathComponent("mic.caf"))
+        try XCTSkipUnless(result == .unreadable, "Running as root defeats the permission block")
+        XCTAssertEqual(result, .unreadable)
+    }
+
+    func testSweepDoesNotDeleteThroughSymlinkedAudioDirectory() throws {
+        let fm = FileManager.default
+        let old = Date(timeIntervalSinceNow: -days(30))
+
+        // Real audio on "another volume", reached through <session>/audio.
+        let elsewhere = sessionsDir.appendingPathComponent("elsewhere", isDirectory: true)
+        try fm.createDirectory(at: elsewhere, withIntermediateDirectories: true)
+        let realMic = elsewhere.appendingPathComponent("mic.caf")
+        fm.createFile(atPath: realMic.path, contents: Data("audio".utf8))
+        try fm.setAttributes([.modificationDate: old], ofItemAtPath: realMic.path)
+
+        let sessionDir = sessionsDir.appendingPathComponent("session_symlinked", isDirectory: true)
+        try fm.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        fm.createFile(atPath: sessionDir.appendingPathComponent("session.json").path, contents: Data("{}".utf8))
+        try fm.createSymbolicLink(
+            at: sessionDir.appendingPathComponent("audio", isDirectory: true),
+            withDestinationURL: elsewhere
+        )
+
+        let removed = SessionRepository.cleanupExpiredRetainedBatchAudio(in: sessionsDir, olderThan: days(7))
+
+        XCTAssertTrue(exists(realMic), "removeItem resolves audio/, so a symlinked audio/ must be refused")
+        XCTAssertFalse(removed.contains("session_symlinked"), "A refused session must not be reported as swept")
+    }
+
+    func testPerSessionDeleteRefusesSymlinkedAudioDirectory() throws {
+        let fm = FileManager.default
+        let elsewhere = sessionsDir.appendingPathComponent("elsewhere2", isDirectory: true)
+        try fm.createDirectory(at: elsewhere, withIntermediateDirectories: true)
+        let realMic = elsewhere.appendingPathComponent("mic.caf")
+        fm.createFile(atPath: realMic.path, contents: Data("audio".utf8))
+
+        let sessionDir = sessionsDir.appendingPathComponent("session_manual", isDirectory: true)
+        try fm.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        try fm.createSymbolicLink(
+            at: sessionDir.appendingPathComponent("audio", isDirectory: true),
+            withDestinationURL: elsewhere
+        )
+
+        XCTAssertFalse(SessionRepository.removeRetainedBatchAudio(inSessionDirectory: sessionDir))
+        XCTAssertTrue(exists(realMic))
+    }
+
     func testSweepIgnoresNonSessionDirectories() throws {
         let stemDate = Date(timeIntervalSinceNow: -days(8))
         let sessionDir = try makeSession(

--- a/OpenOats/Tests/OpenOatsTests/RetainedBatchAudioSweepTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/RetainedBatchAudioSweepTests.swift
@@ -171,6 +171,108 @@ final class RetainedBatchAudioSweepTests: XCTestCase {
         XCTAssertTrue(exists(sessionDir.appendingPathComponent("session.json")))
     }
 
+    func testSweepRemovesLoneExpiredBatchMeta() throws {
+        // With no stems left, a lone batch-meta.json must not live forever;
+        // its own modification date governs.
+        let sessionDir = try makeSession(
+            canonicalFiles: ["batch-meta.json": Date(timeIntervalSinceNow: -days(8))]
+        )
+
+        let removed = SessionRepository.cleanupExpiredRetainedBatchAudio(
+            in: sessionsDir,
+            olderThan: days(7)
+        )
+
+        XCTAssertEqual(removed, ["session_test"])
+        XCTAssertFalse(
+            exists(sessionDir.appendingPathComponent("audio").appendingPathComponent("batch-meta.json"))
+        )
+        XCTAssertTrue(exists(sessionDir.appendingPathComponent("session.json")))
+    }
+
+    func testSweepKeepsLoneFreshBatchMeta() throws {
+        let sessionDir = try makeSession(
+            canonicalFiles: ["batch-meta.json": Date(timeIntervalSinceNow: -days(1))]
+        )
+
+        SessionRepository.cleanupExpiredRetainedBatchAudio(in: sessionsDir, olderThan: days(7))
+
+        XCTAssertTrue(
+            exists(sessionDir.appendingPathComponent("audio").appendingPathComponent("batch-meta.json"))
+        )
+    }
+
+    func testSweepSkipsSessionsWithActiveBatchAccess() throws {
+        let sessionDir = try makeSession(
+            named: "session_active",
+            canonicalFiles: ["mic.caf": Date(timeIntervalSinceNow: -days(8))]
+        )
+
+        let removed = SessionRepository.cleanupExpiredRetainedBatchAudio(
+            in: sessionsDir,
+            olderThan: days(7),
+            excluding: ["session_active"]
+        )
+
+        XCTAssertTrue(removed.isEmpty)
+        XCTAssertTrue(
+            exists(sessionDir.appendingPathComponent("audio").appendingPathComponent("mic.caf"))
+        )
+    }
+
+    func testSweepDoesNotFollowSymlinkedSessionDirectories() throws {
+        // resourceValues follows symlinks: a symlink named session_* must not
+        // delete its target's stems.
+        let target = try makeSession(
+            named: "target_dir",
+            canonicalFiles: ["mic.caf": Date(timeIntervalSinceNow: -days(8))]
+        )
+        let link = sessionsDir.appendingPathComponent("session_link", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+        SessionRepository.cleanupExpiredRetainedBatchAudio(in: sessionsDir, olderThan: days(7))
+
+        XCTAssertTrue(
+            exists(target.appendingPathComponent("audio").appendingPathComponent("mic.caf"))
+        )
+    }
+
+    func testBatchAccessGuardBlocksSweepAndUserDeleteUntilEnded() async throws {
+        let fm = FileManager.default
+        let root = sessionsDir!
+
+        // Construct the repository first so the init-time sweep runs on an
+        // empty directory; then lay down the expired stems.
+        let retention = days(7)
+        let repo = SessionRepository(rootDirectory: root, batchAudioRetention: { retention })
+
+        let sessionID = "session_guarded"
+        let audioDir = root
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("audio", isDirectory: true)
+        try fm.createDirectory(at: audioDir, withIntermediateDirectories: true)
+        let micURL = audioDir.appendingPathComponent("mic.caf")
+        fm.createFile(atPath: micURL.path, contents: Data("audio".utf8))
+        try fm.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: -days(8))],
+            ofItemAtPath: micURL.path
+        )
+
+        await repo.beginBatchAudioAccess(sessionID: sessionID)
+
+        await repo.sweepExpiredRetainedBatchAudio()
+        XCTAssertTrue(fm.fileExists(atPath: micURL.path), "sweep must skip an active batch session")
+
+        let removedWhileActive = await repo.cleanupBatchAudio(sessionID: sessionID)
+        XCTAssertFalse(removedWhileActive, "user delete must refuse while a batch run holds the stems")
+        XCTAssertTrue(fm.fileExists(atPath: micURL.path))
+
+        await repo.endBatchAudioAccess(sessionID: sessionID)
+        await repo.sweepExpiredRetainedBatchAudio()
+        XCTAssertFalse(fm.fileExists(atPath: micURL.path), "sweep must apply once the batch run ends")
+    }
+
     func testSweepIgnoresNonSessionDirectories() throws {
         let stemDate = Date(timeIntervalSinceNow: -days(8))
         let sessionDir = try makeSession(

--- a/OpenOats/Tests/OpenOatsTests/RetainedBatchAudioSweepTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/RetainedBatchAudioSweepTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+@testable import OpenOatsKit
+
+/// Covers expiry-date selection and sweep behavior for retained batch audio.
+/// The reference date must come from the retained files themselves, never from
+/// the session directory, whose modification date is bumped by unrelated
+/// metadata writes (notes edits, speaker renames) and would reset the TTL.
+final class RetainedBatchAudioSweepTests: XCTestCase {
+    private var sessionsDir: URL!
+
+    override func setUpWithError() throws {
+        sessionsDir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("RetainedBatchAudioSweepTests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: sessionsDir)
+    }
+
+    private func days(_ count: Double) -> TimeInterval { count * 24 * 3600 }
+
+    @discardableResult
+    private func makeSession(
+        named name: String = "session_test",
+        canonicalFiles: [String: Date] = [:],
+        legacyFiles: [String: Date] = [:],
+        directoryDate: Date? = nil
+    ) throws -> URL {
+        let fm = FileManager.default
+        let sessionDir = sessionsDir.appendingPathComponent(name, isDirectory: true)
+        let audioDir = sessionDir.appendingPathComponent("audio", isDirectory: true)
+        try fm.createDirectory(at: audioDir, withIntermediateDirectories: true)
+        fm.createFile(atPath: sessionDir.appendingPathComponent("session.json").path, contents: Data("{}".utf8))
+
+        for (fileName, date) in canonicalFiles {
+            let url = audioDir.appendingPathComponent(fileName)
+            fm.createFile(atPath: url.path, contents: Data("audio".utf8))
+            try fm.setAttributes([.modificationDate: date], ofItemAtPath: url.path)
+        }
+        for (fileName, date) in legacyFiles {
+            let url = sessionDir.appendingPathComponent(fileName)
+            fm.createFile(atPath: url.path, contents: Data("audio".utf8))
+            try fm.setAttributes([.modificationDate: date], ofItemAtPath: url.path)
+        }
+        if let directoryDate {
+            try fm.setAttributes([.modificationDate: directoryDate], ofItemAtPath: sessionDir.path)
+        }
+        return sessionDir
+    }
+
+    private func exists(_ url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path)
+    }
+
+    // MARK: - Reference date selection
+
+    func testReferenceDateComesFromAudioFilesNotSessionDirectory() throws {
+        let stemDate = Date(timeIntervalSinceNow: -days(10))
+        let sessionDir = try makeSession(
+            canonicalFiles: ["mic.caf": stemDate, "sys.caf": stemDate],
+            directoryDate: Date()  // a metadata write just bumped the directory
+        )
+
+        let reference = SessionRepository.newestRetainedBatchAudioModificationDate(
+            inSessionDirectory: sessionDir
+        )
+
+        let unwrapped = try XCTUnwrap(reference)
+        XCTAssertEqual(unwrapped.timeIntervalSince1970, stemDate.timeIntervalSince1970, accuracy: 2)
+    }
+
+    func testReferenceDateIsTheNewestRetainedFile() throws {
+        let oldDate = Date(timeIntervalSinceNow: -days(10))
+        let newDate = Date(timeIntervalSinceNow: -days(1))
+        let sessionDir = try makeSession(
+            canonicalFiles: ["mic.caf": oldDate, "sys.caf": newDate, "batch-meta.json": oldDate]
+        )
+
+        let reference = SessionRepository.newestRetainedBatchAudioModificationDate(
+            inSessionDirectory: sessionDir
+        )
+
+        let unwrapped = try XCTUnwrap(reference)
+        XCTAssertEqual(unwrapped.timeIntervalSince1970, newDate.timeIntervalSince1970, accuracy: 2)
+    }
+
+    func testReferenceDateIsNilWithoutAudioStems() throws {
+        let sessionDir = try makeSession(
+            canonicalFiles: ["batch-meta.json": Date(timeIntervalSinceNow: -days(10))]
+        )
+
+        XCTAssertNil(
+            SessionRepository.newestRetainedBatchAudioModificationDate(inSessionDirectory: sessionDir)
+        )
+    }
+
+    // MARK: - Sweep
+
+    func testSweepDeletesExpiredAudioEvenWhenSessionDirectoryIsFresh() throws {
+        // Defect regression: session directory touched today, stems 8 days old.
+        let stemDate = Date(timeIntervalSinceNow: -days(8))
+        let sessionDir = try makeSession(
+            canonicalFiles: ["mic.caf": stemDate, "sys.caf": stemDate, "batch-meta.json": stemDate],
+            directoryDate: Date()
+        )
+        let audioDir = sessionDir.appendingPathComponent("audio", isDirectory: true)
+
+        SessionRepository.cleanupExpiredRetainedBatchAudio(in: sessionsDir, olderThan: days(7))
+
+        XCTAssertFalse(exists(audioDir.appendingPathComponent("mic.caf")))
+        XCTAssertFalse(exists(audioDir.appendingPathComponent("sys.caf")))
+        XCTAssertFalse(exists(audioDir.appendingPathComponent("batch-meta.json")))
+        XCTAssertTrue(exists(sessionDir.appendingPathComponent("session.json")))
+        XCTAssertTrue(exists(sessionDir))
+    }
+
+    func testSweepKeepsAudioInsideTheRetentionWindow() throws {
+        // Inverse defect: a stale directory date must not expire fresh stems.
+        let sessionDir = try makeSession(
+            canonicalFiles: ["mic.caf": Date(timeIntervalSinceNow: -days(2))],
+            directoryDate: Date(timeIntervalSinceNow: -days(30))
+        )
+
+        SessionRepository.cleanupExpiredRetainedBatchAudio(in: sessionsDir, olderThan: days(7))
+
+        XCTAssertTrue(
+            exists(sessionDir.appendingPathComponent("audio").appendingPathComponent("mic.caf"))
+        )
+    }
+
+    func testSweepKeepsExpiredStemsWhenAnyRetainedFileIsFresh() throws {
+        let sessionDir = try makeSession(
+            canonicalFiles: [
+                "mic.caf": Date(timeIntervalSinceNow: -days(10)),
+                "sys.caf": Date(timeIntervalSinceNow: -days(1)),
+            ]
+        )
+
+        SessionRepository.cleanupExpiredRetainedBatchAudio(in: sessionsDir, olderThan: days(7))
+
+        let audioDir = sessionDir.appendingPathComponent("audio", isDirectory: true)
+        XCTAssertTrue(exists(audioDir.appendingPathComponent("mic.caf")))
+        XCTAssertTrue(exists(audioDir.appendingPathComponent("sys.caf")))
+    }
+
+    func testSweepKeepsEverythingWhenRetentionIsForever() throws {
+        let sessionDir = try makeSession(
+            canonicalFiles: ["mic.caf": Date(timeIntervalSinceNow: -days(30))]
+        )
+
+        SessionRepository.cleanupExpiredRetainedBatchAudio(in: sessionsDir, olderThan: nil)
+
+        XCTAssertTrue(
+            exists(sessionDir.appendingPathComponent("audio").appendingPathComponent("mic.caf"))
+        )
+    }
+
+    func testSweepCleansLegacyLayout() throws {
+        let stemDate = Date(timeIntervalSinceNow: -days(8))
+        let sessionDir = try makeSession(
+            legacyFiles: ["mic.caf": stemDate, "batch-meta.json": stemDate],
+            directoryDate: Date()
+        )
+
+        SessionRepository.cleanupExpiredRetainedBatchAudio(in: sessionsDir, olderThan: days(7))
+
+        XCTAssertFalse(exists(sessionDir.appendingPathComponent("mic.caf")))
+        XCTAssertFalse(exists(sessionDir.appendingPathComponent("batch-meta.json")))
+        XCTAssertTrue(exists(sessionDir.appendingPathComponent("session.json")))
+    }
+
+    func testSweepIgnoresNonSessionDirectories() throws {
+        let stemDate = Date(timeIntervalSinceNow: -days(8))
+        let sessionDir = try makeSession(
+            named: "imported_thing",
+            canonicalFiles: ["mic.caf": stemDate]
+        )
+
+        SessionRepository.cleanupExpiredRetainedBatchAudio(in: sessionsDir, olderThan: days(7))
+
+        XCTAssertTrue(
+            exists(sessionDir.appendingPathComponent("audio").appendingPathComponent("mic.caf"))
+        )
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -1559,8 +1559,17 @@ final class SessionRepositoryTests: XCTestCase {
         return sessionDir
     }
 
+    /// Backdates the retained batch artifacts (which decide expiry) and the
+    /// session directory itself (which must not).
     private func setModificationDate(_ date: Date, forSessionDirectory sessionDir: URL) throws {
-        try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: sessionDir.path)
+        let fm = FileManager.default
+        let audioDir = sessionDir.appendingPathComponent("audio", isDirectory: true)
+        for fileName in ["mic.caf", "sys.caf", "batch-meta.json"] {
+            let path = audioDir.appendingPathComponent(fileName).path
+            guard fm.fileExists(atPath: path) else { continue }
+            try fm.setAttributes([.modificationDate: date], ofItemAtPath: path)
+        }
+        try fm.setAttributes([.modificationDate: date], ofItemAtPath: sessionDir.path)
     }
 
     // MARK: - End session clears state

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -1453,7 +1453,10 @@ final class SessionRepositoryTests: XCTestCase {
             forSessionDirectory: sessionDir
         )
 
-        let freshRepo = SessionRepository(rootDirectory: rootDir)
+        let freshRepo = SessionRepository(
+            rootDirectory: rootDir,
+            batchAudioRetention: { SessionRepository.retainedBatchAudioLifetime }
+        )
         let urls = await freshRepo.batchAudioURLs(sessionID: sessionID)
         let meta = await freshRepo.loadBatchMeta(sessionID: sessionID)
 
@@ -1470,13 +1473,35 @@ final class SessionRepositoryTests: XCTestCase {
             forSessionDirectory: sessionDir
         )
 
-        let freshRepo = SessionRepository(rootDirectory: rootDir)
+        let freshRepo = SessionRepository(
+            rootDirectory: rootDir,
+            batchAudioRetention: { SessionRepository.retainedBatchAudioLifetime }
+        )
         let urls = await freshRepo.batchAudioURLs(sessionID: sessionID)
         let meta = await freshRepo.loadBatchMeta(sessionID: sessionID)
 
         XCTAssertNil(urls.mic)
         XCTAssertNil(urls.sys)
         XCTAssertNil(meta)
+    }
+
+    func testInitWithoutRetentionWiringNeverDeletes() async throws {
+        // Fail closed: a constructor path that does not wire the retention
+        // setting must keep audio forever, not inherit a 7-day deleter.
+        let sessionID = "session_unwired_retention"
+        let sessionDir = try makeSessionWithBatchAudio(sessionID: sessionID)
+        try setModificationDate(
+            Date().addingTimeInterval(-(30 * 24 * 3600)),
+            forSessionDirectory: sessionDir
+        )
+
+        let freshRepo = SessionRepository(rootDirectory: rootDir)
+        let urls = await freshRepo.batchAudioURLs(sessionID: sessionID)
+        let meta = await freshRepo.loadBatchMeta(sessionID: sessionID)
+
+        XCTAssertNotNil(urls.mic)
+        XCTAssertNotNil(urls.sys)
+        XCTAssertNotNil(meta)
     }
 
     func testAudioSourcesExposeRawBatchAudioFiles() async throws {

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -339,6 +339,22 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.retainedBatchAudioRetention, .sevenDays)
     }
 
+    func testRetainedBatchAudioRetentionDecodeFallbacks() {
+        // Genuinely unset key → the shipped 7-day default.
+        XCTAssertEqual(makeStore().retainedBatchAudioRetention, .sevenDays)
+
+        // Unknown raw value (e.g. written by a newer version) → fail closed
+        // to keep-forever; deletion must never come from unknown state.
+        let garbage = UserDefaults(suiteName: "com.openoats.test.\(UUID().uuidString)")!
+        garbage.set("everyFortnight", forKey: "retainedBatchAudioRetention")
+        XCTAssertEqual(makeStore(defaults: garbage).retainedBatchAudioRetention, .forever)
+
+        // Non-string value → fail closed to keep-forever.
+        let corrupt = UserDefaults(suiteName: "com.openoats.test.\(UUID().uuidString)")!
+        corrupt.set(42, forKey: "retainedBatchAudioRetention")
+        XCTAssertEqual(makeStore(defaults: corrupt).retainedBatchAudioRetention, .forever)
+    }
+
     func testRetainedBatchAudioRetentionRoundTrip() {
         let suiteName = "com.openoats.test.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -369,6 +369,57 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(reopened.retainedBatchAudioRetention, .forever)
     }
 
+    func testRetainedBatchAudioRetentionIntervalTracksTheSetting() {
+        let store = makeStore()
+        XCTAssertEqual(store.retainedBatchAudioRetentionInterval, 7 * 24 * 3600)
+
+        store.retainedBatchAudioRetention = .thirtyDays
+        XCTAssertEqual(store.retainedBatchAudioRetentionInterval, 30 * 24 * 3600)
+
+        store.retainedBatchAudioRetention = .threeDays
+        XCTAssertEqual(store.retainedBatchAudioRetentionInterval, 3 * 24 * 3600)
+
+        // Keep-forever must reach the sweep as "no retention window".
+        store.retainedBatchAudioRetention = .forever
+        XCTAssertNil(store.retainedBatchAudioRetentionInterval)
+    }
+
+    func testRetainedBatchAudioRetentionIntervalFailsClosedOnUnknownStoredValue() {
+        let garbage = UserDefaults(suiteName: "com.openoats.test.\(UUID().uuidString)")!
+        garbage.set("everyFortnight", forKey: "retainedBatchAudioRetention")
+        XCTAssertNil(makeStore(defaults: garbage).retainedBatchAudioRetentionInterval)
+    }
+
+    /// The repository's sweep reads this off the main actor while the settings
+    /// picker writes it on the main actor. Reading the backing storage without
+    /// synchronisation is a data race on the value, not just a stale read, so
+    /// hammer both sides together. Under `--sanitize=thread` this test is the
+    /// one that reports the race.
+    func testRetainedBatchAudioRetentionIntervalIsSafeToReadOffTheMainActor() async {
+        let store = makeStore()
+        let legalIntervals: Set<TimeInterval> = Set(
+            RetainedBatchAudioRetention.allCases.compactMap(\.timeInterval)
+        )
+
+        let reader = Task.detached {
+            var observed: [TimeInterval?] = []
+            for _ in 0..<2_000 {
+                observed.append(store.retainedBatchAudioRetentionInterval)
+            }
+            return observed
+        }
+
+        let cases = RetainedBatchAudioRetention.allCases
+        for index in 0..<2_000 {
+            store.retainedBatchAudioRetention = cases[index % cases.count]
+        }
+
+        for value in await reader.value {
+            guard let value else { continue }
+            XCTAssertTrue(legalIntervals.contains(value), "Observed a torn retention value: \(value)")
+        }
+    }
+
     func testDiagnosticLoggingRoundTrip() {
         let store = makeStore()
         XCTAssertFalse(store.diagnosticLoggingEnabled)

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -334,6 +334,25 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(reopened.enableBatchRetranscription)
     }
 
+    func testDefaultRetainedBatchAudioRetention() {
+        let store = makeStore()
+        XCTAssertEqual(store.retainedBatchAudioRetention, .sevenDays)
+    }
+
+    func testRetainedBatchAudioRetentionRoundTrip() {
+        let suiteName = "com.openoats.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+
+        let store = makeStore(defaults: defaults)
+        store.retainedBatchAudioRetention = .forever
+
+        XCTAssertEqual(defaults.string(forKey: "retainedBatchAudioRetention"), "forever")
+
+        let reopened = makeStore(defaults: defaults)
+        XCTAssertEqual(reopened.retainedBatchAudioRetention, .forever)
+    }
+
     func testDiagnosticLoggingRoundTrip() {
         let store = makeStore()
         XCTAssertFalse(store.diagnosticLoggingEnabled)


### PR DESCRIPTION
## Problem

When `enableBatchRetranscription` is on, `stashAudioForBatch` moves `mic.caf`/`sys.caf` into `<session>/audio/` permanently (`Storage/SessionRepository.swift:1387`, moves at `:1397`/`:1401`). Retained audio is 48kHz Float32 mono, two stems — up to about **23 MB per meeting minute** in theory; one real 75-minute session measured **1.0 GB** on disk (232 MB mic + 869 MB sys). A 7-day TTL sweep exists (`cleanupExpiredRetainedBatchAudio` at `SessionRepository.swift:2116`, constant at `:180`), but it has two defects that let audio grow without bound in practice:

1. **Wrong mtime source.** `SessionRepository.swift:2126-2127` reads `contentModificationDateKey` off the *session directory*, not the audio files. Any metadata write — a notes edit, a speaker rename — bumps the directory mtime and resets the TTL. A session you keep touching never sheds its audio.
2. **Launch-only.** The sweep's single call site is the repository initializer (`SessionRepository.swift:230`). A menu-bar app that stays running for weeks never prunes.

Additionally, `cleanupBatchAudio` (`SessionRepository.swift:1467`) — the per-session removal helper — had zero call sites, and there was no user-facing retention control (`Views/SettingsView.swift:580-595` only had the batch toggle and model picker).

## Changes

- **Expiry judged by the retained files themselves.** `newestRetainedBatchAudioModificationDate(inSessionDirectory:)` takes the newest mtime among `mic.caf`/`sys.caf`/`batch-meta.json` (canonical and legacy layouts); the session directory's date is deliberately ignored. The sweep deletes only when that newest artifact is past the retention window.
- **Periodic sweep.** The init-time sweep stays; the repository also runs the sweep every 6 hours via a repeating `Task` owned by the actor, cancelled in `deinit`. Changing the retention setting also triggers an immediate sweep.
- **User-configurable retention.** New `RetainedBatchAudioRetention` setting (3/7/14/30 days or *Keep forever*), default **7 days** — current behavior preserved. Stored in UserDefaults following the existing `SettingsStore` pattern; surfaced next to the batch toggle in Settings → Transcript Quality. The sweep re-reads the value each pass, so changes apply without a relaunch.
- **Per-session "Delete retained audio".** First call site for `cleanupBatchAudio`: a destructive action (with confirmation) in the transcript maintenance menu next to the re-transcribe affordance in `Views/MeetingDetailPane.swift`. It stops playback of a stem before unlinking it, refreshes playback sources, clears the post-meeting "Re-transcribe" banner offer, and flips `canRetranscribeSelectedSession` off (the `hasRetainedBatchAudio` gate at `App/NotesController.swift:347`).

## Revised after self-review

An adversarial pass over the first version found fail-open paths in a destructive feature. Principle applied throughout: **unknown state must mean keep, never delete.**

- **Fail-closed default.** `SessionRepository.init`'s `batchAudioRetention` closure now defaults to `{ nil }` (keep forever). Previously it defaulted to the 7-day lifetime, so every constructor path that did not wire the setting (the plain test/UI-test constructors, any future call site) silently became an unconditional deleter. Only the wired `AppContainer` path supplies a real retention, threaded from the actual `SettingsStore` instance (not a hardcoded `UserDefaults.standard`).
- **Fail-closed decode.** An unknown raw value (downgrade path) or a non-string in UserDefaults previously decoded to the 7-day default — turning a user's "Keep forever" into deletion. Unknown/corrupt now decodes to `.forever`; only a genuinely-unset key gets the 7-day default (`RetainedBatchAudioRetention.stored(in:)` and the `SettingsStore` accessor twin).
- **Sweep vs. in-flight batch run.** `BatchAudioTranscriber` captures stem URLs once at the start of a run and re-opens `sys.caf` minutes later; a sweep tick mid-run would make the batch fail unretryably with the audio already gone. Rather than a cross-actor status read, `process()` now brackets the run with `beginBatchAudioAccess`/`endBatchAudioAccess` on the repository actor itself (counted, so overlapping runs for the same session keep the guard up). The sweep skips guarded sessions and `cleanupBatchAudio` refuses (returns `false`) while a run holds the stems. This is covered by an actor-level test; no cross-actor read is needed because the repository is already the party both sides talk to.
- **Action-time re-gating.** The delete menu item's `.disabled(isBatchBusy)` is render-time only; `deleteRetainedBatchAudio()` now re-checks `coordinator.batchStatus == .idle` when invoked, and the repository-side refusal above backstops the remaining race.
- **State consistency.** Deleting audio clears `lastEndedSessionCanRetranscribe`, so the post-meeting banner cannot offer a re-transcribe that would no-op. Periodic-sweep removals notify the UI (repository callback → `.retainedBatchAudioSwept` notification), and open detail panes re-derive audio sources and the re-transcribe gate — the same code path as the manual delete.
- **Playback ordering.** Playback of a doomed stem stops *before* unlinking; the user's selected audio source is kept when it survives the deletion instead of being reset.
- **Symlink guard.** The sweep skips symlinks: `resourceValues` follows links, so a symlink named `session_*` would have deleted its *target's* stems.
- **Orphan metadata.** A lone `batch-meta.json` with no stems used to survive forever (no reference date); it is now removed once its own mtime passes the window.
- **Honest size math.** The settings copy and this PR now say "up to about 23 MB per meeting minute; one real 75-minute meeting measured 1.0 GB" — the earlier "roughly 1 GB" phrasing implied 23×75, which is ~1.7 GB theoretical, not the measured figure.

**Considered and rejected: grandfathering pre-upgrade sessions to "Keep forever" on first launch.** The 7-day deletion at launch is the already-shipped default contract; the directory-mtime bug merely exempted recently-touched sessions from it. This PR makes the existing contract hold uniformly rather than introducing a new one. If you'd prefer a migration that pins existing sessions' audio, happy to add it.

## Tests

- `Tests/OpenOatsTests/RetainedBatchAudioSweepTests.swift` (14 tests): reference-date selection (audio-file mtime wins over a freshly-bumped directory; newest file wins; nil without stems), sweep regression for the directory-mtime defect and its inverse, keep-forever, legacy layout, non-session directories, lone expired/fresh `batch-meta.json`, active-batch exclusion, symlink skip, and the actor-level begin/end guard (sweep and user delete both refuse until the run ends).
- `SettingsStoreTests`: default, round-trip, and decode fallbacks (unset → 7 days; garbage string → forever; non-string → forever).
- `SessionRepositoryTests`: init-sweep tests now inject the retention explicitly; a new test proves the unwired constructor path never deletes.

`swift build -c debug`, `swift test` (**745 tests, 0 failures**), and `swift build -c release` all pass.

## Second review pass

An independent review of the revised branch raised two more issues in this diff. Both were real; both are fixed in `a24e97e`.

- **Re-check the selected session after each await.** `refreshRetainedAudioDependentState` (`App/NotesController.swift`) validated `state.selectedSessionID` once, before its two repository awaits. Either await yields the main actor, so a selection change while the sweep refresh is suspended applied the swept session's audio sources, audio URL and re-transcribe availability to whatever was selected on resume. The refresh now re-checks after each hop and bails rather than writing. Covered by `testRetentionSweepRefreshDoesNotApplyToASessionDeselectedMidRefresh`, which fails on the previous commit with all three leak assertions.

- **The retention setting was a real data race, not a stale read.** The sweep runs on the `SessionRepository` actor and reads the window through the `nonisolated` `retainedBatchAudioRetentionInterval`, which read `nonisolated(unsafe) private var _retainedBatchAudioRetention: String` while the main-actor picker setter wrote the same storage. ThreadSanitizer confirms it — `data race SettingsStore.swift:807` (setter) against `SettingsStore.swift:816` (getter), with the test process aborting on the report. Changing the picker during a sweep is enough to hit it. The backing storage is now an `OSAllocatedUnfairLock<String>`, the same primitive already used in `MicCapture` and `SystemAudioCapture`, so the escape hatch is removed rather than the window narrowed. Both accessors go through the lock, so there is still one source of truth. TSan is clean afterwards.

`handleRetainedAudioSwept` lost its `private` so the sweep path can be driven directly from a test.

## Merge order

Merge before #710. Both branches edit `SessionRepository.swift` and conflict there (3 hunks plus tests):
this PR adds the audio-retention sweep, #710 adds the mirror-retry ledger. Order is not important to the
behaviour, only to the rebase — taking this one first means #710 rebases onto the retention changes.

Happy to rebase whichever way suits your merge queue.

