### PR TITLE
Re-resolve the calendar event at finalize against the session's real interval

### DIFF
--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -781,7 +781,22 @@ final class LiveSessionController {
         } else {
             endingMetadata = nil
         }
-        let metadataTitle = endingMetadata?.title ?? endingMetadata?.calendarEvent?.title
+        // 3b. Re-resolve the calendar binding now that the session's real
+        // interval is known. The binding made at start came from a window
+        // around minute zero and can point at the wrong event once the actual
+        // span is visible.
+        let endedAt = Date()
+        let calendarEvent = resolvedFinalizeCalendarEvent(
+            endingMetadata: endingMetadata,
+            endedAt: endedAt,
+            settings: settings
+        )
+        // Titles derive from the final binding, not the start-time one, so a
+        // rebound session is not persisted under the old event's name.
+        // `endingMetadata?.title` covers sessions with no calendar event
+        // (e.g. titled by the detected meeting app); an explicit live topic
+        // still wins below.
+        let metadataTitle = calendarEvent?.title ?? endingMetadata?.title
         let title = coordinator.transcriptStore.conversationState.currentTopic.isEmpty
             ? metadataTitle : coordinator.transcriptStore.conversationState.currentTopic
         let meetingAppName = endingMetadata?.detectionContext?.meetingApp?.name
@@ -805,17 +820,6 @@ final class LiveSessionController {
         )
         let transcriptIssue = Self.transcriptIssue(for: recordingHealthInput)
         let emptySessionClassification = Self.emptySessionDiagnosticClassification(for: recordingHealthInput)
-
-        // 3b. Re-resolve the calendar binding now that the session's real
-        // interval is known. The binding made at start came from a window
-        // around minute zero and can point at the wrong event once the actual
-        // span is visible.
-        let endedAt = Date()
-        let calendarEvent = resolvedFinalizeCalendarEvent(
-            endingMetadata: endingMetadata,
-            endedAt: endedAt,
-            settings: settings
-        )
 
         // 4. Finalize: closes file handle, backfills cleaned text, writes session.json
         await coordinator.sessionRepository.finalizeSession(
@@ -1071,9 +1075,9 @@ final class LiveSessionController {
     /// (`CalendarManager.currentEvent`), so a recording that started early can
     /// bind to the preceding event, and a meeting that ran long may look
     /// nothing like the event picked at start. Once the real interval is
-    /// known, prefer the event that best overlaps it. An event the user picked
-    /// explicitly is never second-guessed, and the start-time binding is kept
-    /// when re-resolution finds nothing.
+    /// known, that binding competes against the events overlapping the
+    /// interval under one ranking — see `CalendarEventMatcher.finalBinding`.
+    /// An event the user picked explicitly is never second-guessed.
     private func resolvedFinalizeCalendarEvent(
         endingMetadata: MeetingMetadata?,
         endedAt: Date,
@@ -1086,11 +1090,16 @@ final class LiveSessionController {
         guard let settings, settings.calendarIntegrationEnabled else { return startBinding }
         guard endedAt > endingMetadata.startedAt else { return startBinding }
 
-        let reResolved = container.calendarManager?.bestEvent(
-            overlapping: DateInterval(start: endingMetadata.startedAt, end: endedAt),
-            excludingCalendarIDs: settings.excludedCalendarIDs
+        let interval = DateInterval(start: endingMetadata.startedAt, end: endedAt)
+        return CalendarEventMatcher.finalBinding(
+            startBinding: startBinding,
+            isUserChosen: endingMetadata.calendarEventIsUserChosen,
+            candidates: container.calendarManager?.events(
+                overlapping: interval,
+                excludingCalendarIDs: settings.excludedCalendarIDs
+            ) ?? [],
+            interval: interval
         )
-        return reResolved ?? startBinding
     }
 
     private func scheduleAutoNotesIfNeeded(

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -359,7 +359,10 @@ final class LiveSessionController {
             message: "Start requested (calendarEvent=\(calEvent == nil ? "no" : "yes"))"
         )
         pendingInitialScratchpad = initialScratchpad?.trimmingCharacters(in: .newlines)
-        let metadata = MeetingMetadata.manual(calendarEvent: calEvent)
+        let metadata = MeetingMetadata.manual(
+            calendarEvent: calEvent,
+            calendarEventIsUserChosen: calendarEventOverride != nil
+        )
 
         if settings.transcriptionModel.isCloud {
             state.errorMessage = nil
@@ -803,11 +806,22 @@ final class LiveSessionController {
         let transcriptIssue = Self.transcriptIssue(for: recordingHealthInput)
         let emptySessionClassification = Self.emptySessionDiagnosticClassification(for: recordingHealthInput)
 
+        // 3b. Re-resolve the calendar binding now that the session's real
+        // interval is known. The binding made at start came from a window
+        // around minute zero and can point at the wrong event once the actual
+        // span is visible.
+        let endedAt = Date()
+        let calendarEvent = resolvedFinalizeCalendarEvent(
+            endingMetadata: endingMetadata,
+            endedAt: endedAt,
+            settings: settings
+        )
+
         // 4. Finalize: closes file handle, backfills cleaned text, writes session.json
         await coordinator.sessionRepository.finalizeSession(
             sessionID: sessionID,
             metadata: SessionFinalizeMetadata(
-                endedAt: Date(),
+                endedAt: endedAt,
                 utteranceCount: utteranceCount,
                 title: title,
                 language: transcriptionLanguage,
@@ -815,13 +829,13 @@ final class LiveSessionController {
                 engine: engineName,
                 templateSnapshot: coordinator.sessionTemplateSnapshot,
                 utterances: utterancesSnapshot,
-                calendarEvent: endingMetadata?.calendarEvent,
+                calendarEvent: calendarEvent,
                 transcriptIssue: transcriptIssue
             )
         )
 
         if let settings,
-           let event = endingMetadata?.calendarEvent,
+           let event = calendarEvent,
            let folderPath = settings.meetingFamilyPreferences(for: event)?.folderPath {
             await coordinator.sessionRepository.updateSessionFolder(sessionID: sessionID, folderPath: folderPath)
         }
@@ -830,7 +844,7 @@ final class LiveSessionController {
         let index = SessionIndex(
             id: sessionID,
             startedAt: utterancesSnapshot.first?.timestamp ?? endingMetadata?.startedAt ?? Date(),
-            endedAt: Date(),
+            endedAt: endedAt,
             templateSnapshot: coordinator.sessionTemplateSnapshot,
             title: title,
             utteranceCount: utteranceCount,
@@ -1049,6 +1063,34 @@ final class LiveSessionController {
                 )
             }
         }
+    }
+
+    /// The calendar event the finished session should be bound to.
+    ///
+    /// The binding made at start is chosen from a window around minute zero
+    /// (`CalendarManager.currentEvent`), so a recording that started early can
+    /// bind to the preceding event, and a meeting that ran long may look
+    /// nothing like the event picked at start. Once the real interval is
+    /// known, prefer the event that best overlaps it. An event the user picked
+    /// explicitly is never second-guessed, and the start-time binding is kept
+    /// when re-resolution finds nothing.
+    private func resolvedFinalizeCalendarEvent(
+        endingMetadata: MeetingMetadata?,
+        endedAt: Date,
+        settings: AppSettings?
+    ) -> CalendarEvent? {
+        let startBinding = endingMetadata?.calendarEvent
+        guard let endingMetadata, !endingMetadata.calendarEventIsUserChosen else {
+            return startBinding
+        }
+        guard let settings, settings.calendarIntegrationEnabled else { return startBinding }
+        guard endedAt > endingMetadata.startedAt else { return startBinding }
+
+        let reResolved = container.calendarManager?.bestEvent(
+            overlapping: DateInterval(start: endingMetadata.startedAt, end: endedAt),
+            excludingCalendarIDs: settings.excludedCalendarIDs
+        )
+        return reResolved ?? startBinding
     }
 
     private func scheduleAutoNotesIfNeeded(

--- a/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
+++ b/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
@@ -290,11 +290,18 @@ enum MeetingHistoryResolver {
 struct MeetingMetadata: Sendable, Equatable, Codable {
     let detectionContext: DetectionContext?
     let calendarEvent: CalendarEvent?
+    /// True when the user explicitly picked `calendarEvent` for this session.
+    /// Finalization re-resolves automatic bindings against the session's real
+    /// interval, but never second-guesses an explicit choice.
+    var calendarEventIsUserChosen: Bool = false
     let title: String?
     let startedAt: Date
     var endedAt: Date?
 
-    static func manual(calendarEvent: CalendarEvent? = nil) -> MeetingMetadata {
+    static func manual(
+        calendarEvent: CalendarEvent? = nil,
+        calendarEventIsUserChosen: Bool = false
+    ) -> MeetingMetadata {
         let now = Date()
         return MeetingMetadata(
             detectionContext: DetectionContext(
@@ -304,6 +311,7 @@ struct MeetingMetadata: Sendable, Equatable, Codable {
                 calendarEvent: calendarEvent
             ),
             calendarEvent: calendarEvent,
+            calendarEventIsUserChosen: calendarEventIsUserChosen,
             title: calendarEvent?.title,
             startedAt: now, endedAt: nil
         )

--- a/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
+++ b/OpenOats/Sources/OpenOats/Domain/MeetingTypes.swift
@@ -317,3 +317,37 @@ struct MeetingMetadata: Sendable, Equatable, Codable {
         )
     }
 }
+
+extension MeetingMetadata {
+    private enum CodingKeys: String, CodingKey {
+        case detectionContext
+        case calendarEvent
+        case calendarEventIsUserChosen
+        case title
+        case startedAt
+        case endedAt
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            detectionContext: try container.decodeIfPresent(DetectionContext.self, forKey: .detectionContext),
+            calendarEvent: try container.decodeIfPresent(CalendarEvent.self, forKey: .calendarEvent),
+            // Payloads written before this field existed decode as false.
+            calendarEventIsUserChosen: try container.decodeIfPresent(Bool.self, forKey: .calendarEventIsUserChosen) ?? false,
+            title: try container.decodeIfPresent(String.self, forKey: .title),
+            startedAt: try container.decode(Date.self, forKey: .startedAt),
+            endedAt: try container.decodeIfPresent(Date.self, forKey: .endedAt)
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(detectionContext, forKey: .detectionContext)
+        try container.encodeIfPresent(calendarEvent, forKey: .calendarEvent)
+        try container.encode(calendarEventIsUserChosen, forKey: .calendarEventIsUserChosen)
+        try container.encodeIfPresent(title, forKey: .title)
+        try container.encode(startedAt, forKey: .startedAt)
+        try container.encodeIfPresent(endedAt, forKey: .endedAt)
+    }
+}

--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -82,30 +82,27 @@ final class CalendarManager {
         return CalendarEventMatcher.bestMatch(among: candidates, at: date)
     }
 
-    /// Find the calendar event a finished recording most likely belongs to,
-    /// given the recording's real interval. Unlike `currentEvent(at:)`, which
-    /// ranks by proximity to a single instant, this prefers the event that
-    /// covers the most of the interval — see
-    /// `CalendarEventMatcher.bestMatch(among:overlapping:)`.
-    /// Returns nil if no event is found or access is not authorized.
-    func bestEvent(
+    /// All non-all-day calendar events overlapping the given interval, for
+    /// finalize-time re-resolution of a finished recording's binding. The
+    /// ranking itself lives in `CalendarEventMatcher.finalBinding` so it can
+    /// be tested without an `EKEventStore`.
+    /// Returns an empty array if access is not authorized.
+    func events(
         overlapping interval: DateInterval,
         excludingCalendarIDs: [String] = []
-    ) -> CalendarEvent? {
-        guard accessState == .authorized else { return nil }
+    ) -> [CalendarEvent] {
+        guard accessState == .authorized else { return [] }
         let calendars = eventCalendars(excludingCalendarIDs: Set(excludingCalendarIDs))
-        guard !calendars.isEmpty else { return nil }
+        guard !calendars.isEmpty else { return [] }
 
         let predicate = store.predicateForEvents(
             withStart: interval.start,
             end: interval.end,
             calendars: calendars
         )
-        let candidates = store.events(matching: predicate)
+        return store.events(matching: predicate)
             .filter { !$0.isAllDay }
             .map { CalendarEvent(from: $0) }
-
-        return CalendarEventMatcher.bestMatch(among: candidates, overlapping: interval)
     }
 
     /// Upcoming calendar events starting within the given time window, ordered by start date.
@@ -275,9 +272,9 @@ enum CalendarEventMatcher {
 
     /// Returns the best match for a finished recording spanning `interval`, or
     /// nil when there are no candidates. Unlike `bestMatch(among:at:)`, which
-    /// ranks by proximity to a single instant, this ranks by how much of the
-    /// interval each event covers — a meeting overlapping the whole recording
-    /// outranks one that merely shares its start.
+    /// ranks by proximity to a single instant, this ranks by how much of each
+    /// event the recording covers, so the meeting the session actually spans
+    /// outranks one it only clipped.
     static func bestMatch(
         among events: [CalendarEvent],
         overlapping interval: DateInterval
@@ -285,6 +282,42 @@ enum CalendarEventMatcher {
         events.min { lhs, rhs in
             sortKey(for: lhs, overlapping: interval) < sortKey(for: rhs, overlapping: interval)
         }
+    }
+
+    /// The calendar event a finished recording should be bound to, given the
+    /// binding made at session start and the events overlapping the
+    /// recording's real interval.
+    ///
+    /// The start-time binding competes with the challengers under the same
+    /// ranking, so a meeting-like incumbent can never lose to a personal
+    /// block that merely overlaps more of the recording. An event the user
+    /// picked explicitly is never replaced. Candidates that do not actually
+    /// overlap the interval are dropped (EventKit's predicate bounds are
+    /// inclusive, so a back-to-back neighbour can slip in with zero overlap)
+    /// — but never the incumbent, which competes regardless. A recording with
+    /// no start-time binding only gains one when the winner looks like a real
+    /// meeting: an ad-hoc recording must not be relocated or re-titled by the
+    /// personal block that happens to contain it.
+    static func finalBinding(
+        startBinding: CalendarEvent?,
+        isUserChosen: Bool,
+        candidates: [CalendarEvent],
+        interval: DateInterval
+    ) -> CalendarEvent? {
+        if isUserChosen { return startBinding }
+
+        var pool = candidates.filter { overlapDuration(of: $0, with: interval) > 0 }
+        if let startBinding, !pool.contains(where: { $0.id == startBinding.id }) {
+            pool.append(startBinding)
+        }
+
+        guard let winner = bestMatch(among: pool, overlapping: interval) else {
+            return startBinding
+        }
+        if startBinding == nil, !isLikelyMeeting(winner) {
+            return nil
+        }
+        return winner
     }
 
     /// Lexicographic ranking key, lowest wins: real meetings first, then the
@@ -303,20 +336,36 @@ enum CalendarEventMatcher {
     }
 
     /// Lexicographic ranking key for interval matching, lowest wins: real
-    /// meetings first, then the largest overlap with the recording, then the
-    /// closest start, then the shorter event. `startDate` keeps ties
+    /// meetings first, then the event most fully covered by the recording,
+    /// then the closest start, then the shorter event. `startDate` keeps ties
     /// deterministic rather than dependent on EventKit's ordering.
     private static func sortKey(
         for event: CalendarEvent,
         overlapping interval: DateInterval
-    ) -> (Int, TimeInterval, TimeInterval, TimeInterval, Date) {
+    ) -> (Int, Int, TimeInterval, TimeInterval, Date) {
         (
             isLikelyMeeting(event) ? 0 : 1,
-            -overlapDuration(of: event, with: interval),
+            -coverageBucket(of: event, within: interval),
             abs(event.startDate.timeIntervalSince(interval.start)),
             event.endDate.timeIntervalSince(event.startDate),
             event.startDate
         )
+    }
+
+    /// How much of the event the recording covers, as a fraction of the
+    /// event's own duration, quantized to five buckets (0...4). The fraction
+    /// keeps a fully-covered 30-minute meeting ahead of a three-hour block
+    /// the recording merely dips into (raw overlap seconds would prefer the
+    /// block), and the quantization stops one extra second of overlap from
+    /// flipping the winner — near-ties fall through to start proximity.
+    private static func coverageBucket(
+        of event: CalendarEvent,
+        within interval: DateInterval
+    ) -> Int {
+        let duration = event.endDate.timeIntervalSince(event.startDate)
+        guard duration > 0 else { return 0 }
+        let fraction = overlapDuration(of: event, with: interval) / duration
+        return Int((fraction * 4).rounded())
     }
 
     private static func overlapDuration(

--- a/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/CalendarManager.swift
@@ -82,6 +82,32 @@ final class CalendarManager {
         return CalendarEventMatcher.bestMatch(among: candidates, at: date)
     }
 
+    /// Find the calendar event a finished recording most likely belongs to,
+    /// given the recording's real interval. Unlike `currentEvent(at:)`, which
+    /// ranks by proximity to a single instant, this prefers the event that
+    /// covers the most of the interval — see
+    /// `CalendarEventMatcher.bestMatch(among:overlapping:)`.
+    /// Returns nil if no event is found or access is not authorized.
+    func bestEvent(
+        overlapping interval: DateInterval,
+        excludingCalendarIDs: [String] = []
+    ) -> CalendarEvent? {
+        guard accessState == .authorized else { return nil }
+        let calendars = eventCalendars(excludingCalendarIDs: Set(excludingCalendarIDs))
+        guard !calendars.isEmpty else { return nil }
+
+        let predicate = store.predicateForEvents(
+            withStart: interval.start,
+            end: interval.end,
+            calendars: calendars
+        )
+        let candidates = store.events(matching: predicate)
+            .filter { !$0.isAllDay }
+            .map { CalendarEvent(from: $0) }
+
+        return CalendarEventMatcher.bestMatch(among: candidates, overlapping: interval)
+    }
+
     /// Upcoming calendar events starting within the given time window, ordered by start date.
     /// Returns an empty array if access is not authorized.
     func upcomingEvents(
@@ -247,6 +273,20 @@ enum CalendarEventMatcher {
         }
     }
 
+    /// Returns the best match for a finished recording spanning `interval`, or
+    /// nil when there are no candidates. Unlike `bestMatch(among:at:)`, which
+    /// ranks by proximity to a single instant, this ranks by how much of the
+    /// interval each event covers — a meeting overlapping the whole recording
+    /// outranks one that merely shares its start.
+    static func bestMatch(
+        among events: [CalendarEvent],
+        overlapping interval: DateInterval
+    ) -> CalendarEvent? {
+        events.min { lhs, rhs in
+            sortKey(for: lhs, overlapping: interval) < sortKey(for: rhs, overlapping: interval)
+        }
+    }
+
     /// Lexicographic ranking key, lowest wins: real meetings first, then the
     /// closest start, then the shorter event. `startDate` keeps ties deterministic
     /// rather than dependent on EventKit's ordering.
@@ -260,6 +300,32 @@ enum CalendarEventMatcher {
             event.endDate.timeIntervalSince(event.startDate),
             event.startDate
         )
+    }
+
+    /// Lexicographic ranking key for interval matching, lowest wins: real
+    /// meetings first, then the largest overlap with the recording, then the
+    /// closest start, then the shorter event. `startDate` keeps ties
+    /// deterministic rather than dependent on EventKit's ordering.
+    private static func sortKey(
+        for event: CalendarEvent,
+        overlapping interval: DateInterval
+    ) -> (Int, TimeInterval, TimeInterval, TimeInterval, Date) {
+        (
+            isLikelyMeeting(event) ? 0 : 1,
+            -overlapDuration(of: event, with: interval),
+            abs(event.startDate.timeIntervalSince(interval.start)),
+            event.endDate.timeIntervalSince(event.startDate),
+            event.startDate
+        )
+    }
+
+    private static func overlapDuration(
+        of event: CalendarEvent,
+        with interval: DateInterval
+    ) -> TimeInterval {
+        guard event.endDate > event.startDate else { return 0 }
+        let eventInterval = DateInterval(start: event.startDate, end: event.endDate)
+        return interval.intersection(with: eventInterval)?.duration ?? 0
     }
 }
 

--- a/OpenOats/Tests/OpenOatsTests/CalendarEventMatcherTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/CalendarEventMatcherTests.swift
@@ -185,26 +185,58 @@ final class CalendarEventMatcherTests: XCTestCase {
         }
     }
 
-    func testIntervalMatchPrefersEventCoveringTheSessionOverOneSharingItsStart() {
-        let shortBlock = makeEvent(
-            id: "short",
+    // Back-to-back meetings with the session spanning both: both events are
+    // fully covered, so their coverage buckets tie, start proximity decides,
+    // and the meeting the user pressed record for — the first — is kept. Raw
+    // overlap seconds would have flipped this to the longer second meeting.
+    func testIntervalMatchKeepsFirstOfBackToBackMeetingsWhenSessionSpansBoth() {
+        let first = makeEvent(
+            id: "first",
             title: "Standup",
             start: noon,
-            durationMinutes: 15,
+            durationMinutes: 30,
             isOnlineMeeting: true
         )
-        let fullMeeting = makeEvent(
-            id: "full",
-            title: "Design Review",
-            start: noon,
-            durationMinutes: 50,
+        let second = makeEvent(
+            id: "second",
+            title: "Planning",
+            start: noon.addingTimeInterval(30 * 60),
+            durationMinutes: 60,
             isOnlineMeeting: true
         )
-        let session = DateInterval(start: noon, end: noon.addingTimeInterval(50 * 60))
+        let session = DateInterval(start: noon, end: noon.addingTimeInterval(90 * 60))
 
-        for candidates in [[shortBlock, fullMeeting], [fullMeeting, shortBlock]] {
+        for candidates in [[first, second], [second, first]] {
             let best = CalendarEventMatcher.bestMatch(among: candidates, overlapping: session)
-            XCTAssertEqual(best?.id, "full")
+            XCTAssertEqual(best?.id, "first")
+        }
+    }
+
+    // A 30-minute meeting the recording fully covers must not lose to a
+    // three-hour meeting-like workshop the moment the session overruns by
+    // five minutes: coverage is a fraction of each event's own duration
+    // (meeting 1800/1800 → bucket 4, workshop 2100/10800 → bucket 1), not raw
+    // overlap seconds (2100 > 1800 would pick the workshop).
+    func testIntervalMatchPrefersContainedMeetingOverLongWorkshopOnOverrun() {
+        let workshop = makeEvent(
+            id: "workshop",
+            title: "All-hands workshop",
+            start: noon,
+            durationMinutes: 180,
+            isOnlineMeeting: true
+        )
+        let meeting = makeEvent(
+            id: "meeting",
+            title: "Weekly sync",
+            start: noon,
+            durationMinutes: 30,
+            participants: [Participant(name: "Ada", email: "ada@example.com")]
+        )
+        let session = DateInterval(start: noon, end: noon.addingTimeInterval(35 * 60))
+
+        for candidates in [[workshop, meeting], [meeting, workshop]] {
+            let best = CalendarEventMatcher.bestMatch(among: candidates, overlapping: session)
+            XCTAssertEqual(best?.id, "meeting")
         }
     }
 
@@ -233,38 +265,10 @@ final class CalendarEventMatcherTests: XCTestCase {
         }
     }
 
-    func testIntervalMatchFallsBackToStartProximityWhenOverlapsTie() {
-        let outer = makeEvent(
-            id: "outer",
-            title: "Team block",
-            start: noon,
-            durationMinutes: 60,
-            isOnlineMeeting: true
-        )
-        let inner = makeEvent(
-            id: "inner",
-            title: "Check-in",
-            start: noon.addingTimeInterval(5 * 60),
-            durationMinutes: 40,
-            isOnlineMeeting: true
-        )
-        // Both events cover the whole recording, so overlaps tie and the
-        // closer start wins.
-        let session = DateInterval(
-            start: noon.addingTimeInterval(10 * 60),
-            end: noon.addingTimeInterval(40 * 60)
-        )
-
-        for candidates in [[outer, inner], [inner, outer]] {
-            let best = CalendarEventMatcher.bestMatch(among: candidates, overlapping: session)
-            XCTAssertEqual(best?.id, "inner")
-        }
-    }
-
     // Recording an in-person meeting nobody was invited to is still supported:
-    // with no meeting-like candidate, the block that contains most of the
-    // recording wins.
-    func testIntervalMatchRanksPersonalBlocksByOverlapWhenNoCandidateLooksLikeAMeeting() {
+    // with no meeting-like candidate, the block the recording covers most
+    // fully wins.
+    func testIntervalMatchRanksPersonalBlocksByCoverageWhenNoCandidateLooksLikeAMeeting() {
         let errand = makeEvent(
             id: "errand",
             title: "Errand",
@@ -293,5 +297,189 @@ final class CalendarEventMatcherTests: XCTestCase {
             among: [],
             overlapping: DateInterval(start: noon, duration: 30 * 60)
         ))
+    }
+
+    // MARK: - Final binding (finalize-time decision)
+
+    func testFinalBindingRespectsUserChosenEvent() {
+        let chosen = makeEvent(
+            id: "chosen",
+            title: "1:1",
+            start: noon,
+            durationMinutes: 15,
+            isOnlineMeeting: true
+        )
+        let better = makeEvent(
+            id: "better",
+            title: "Quarterly Review",
+            start: noon,
+            durationMinutes: 60,
+            participants: [Participant(name: "Ada", email: "ada@example.com")]
+        )
+        let session = DateInterval(start: noon, end: noon.addingTimeInterval(60 * 60))
+
+        let result = CalendarEventMatcher.finalBinding(
+            startBinding: chosen,
+            isUserChosen: true,
+            candidates: [better],
+            interval: session
+        )
+
+        XCTAssertEqual(result?.id, "chosen")
+    }
+
+    // The incumbent competes under the same ranking instead of being replaced
+    // by any challenger: a session recorded just before its standup overlaps
+    // only a personal block, and the meeting-like binding from start must win.
+    func testFinalBindingKeepsMeetingIncumbentOverNonMeetingChallenger() {
+        let standup = makeEvent(
+            id: "standup",
+            title: "Standup",
+            start: noon,
+            durationMinutes: 15,
+            isOnlineMeeting: true
+        )
+        let focus = makeEvent(
+            id: "focus",
+            title: "Focus time",
+            start: noon.addingTimeInterval(-60 * 60),
+            durationMinutes: 60
+        )
+        // Recorded from ten to two minutes before the hour: zero overlap with
+        // the standup, full overlap with the personal block.
+        let session = DateInterval(
+            start: noon.addingTimeInterval(-10 * 60),
+            end: noon.addingTimeInterval(-2 * 60)
+        )
+
+        let result = CalendarEventMatcher.finalBinding(
+            startBinding: standup,
+            isUserChosen: false,
+            candidates: [focus],
+            interval: session
+        )
+
+        XCTAssertEqual(result?.id, "standup")
+    }
+
+    func testFinalBindingRebindsToBetterOverlappingMeeting() {
+        let previous = makeEvent(
+            id: "previous",
+            title: "1:1",
+            start: noon.addingTimeInterval(-15 * 60),
+            durationMinutes: 15,
+            isOnlineMeeting: true
+        )
+        let actual = makeEvent(
+            id: "actual",
+            title: "Quarterly Review",
+            start: noon,
+            durationMinutes: 60,
+            participants: [Participant(name: "Ada", email: "ada@example.com")]
+        )
+        let session = DateInterval(
+            start: noon.addingTimeInterval(-10 * 60),
+            end: noon.addingTimeInterval(55 * 60)
+        )
+
+        let result = CalendarEventMatcher.finalBinding(
+            startBinding: previous,
+            isUserChosen: false,
+            candidates: [previous, actual],
+            interval: session
+        )
+
+        XCTAssertEqual(result?.id, "actual")
+    }
+
+    // A binding must not be lost to a meeting-like neighbour that only
+    // touches the recording at its boundary — EventKit's inclusive predicate
+    // bounds can admit zero-overlap events.
+    func testFinalBindingIgnoresZeroOverlapChallengers() {
+        let block = makeEvent(
+            id: "block",
+            title: "Working session",
+            start: noon,
+            durationMinutes: 60
+        )
+        let previous = makeEvent(
+            id: "previous",
+            title: "1:1",
+            start: noon.addingTimeInterval(-15 * 60),
+            durationMinutes: 15,
+            isOnlineMeeting: true
+        )
+        let session = DateInterval(start: noon, end: noon.addingTimeInterval(40 * 60))
+
+        let result = CalendarEventMatcher.finalBinding(
+            startBinding: block,
+            isUserChosen: false,
+            candidates: [previous, block],
+            interval: session
+        )
+
+        XCTAssertEqual(result?.id, "block")
+    }
+
+    func testFinalBindingDoesNotAttachNonMeetingEventToAdHocRecording() {
+        let lunch = makeEvent(
+            id: "lunch",
+            title: "Lunch",
+            start: noon,
+            durationMinutes: 60
+        )
+        let session = DateInterval(start: noon, end: noon.addingTimeInterval(30 * 60))
+
+        let result = CalendarEventMatcher.finalBinding(
+            startBinding: nil,
+            isUserChosen: false,
+            candidates: [lunch],
+            interval: session
+        )
+
+        XCTAssertNil(result)
+    }
+
+    func testFinalBindingAttachesMeetingEventToAdHocRecording() {
+        let meeting = makeEvent(
+            id: "meeting",
+            title: "Standup",
+            start: noon,
+            durationMinutes: 30,
+            isOnlineMeeting: true
+        )
+        let session = DateInterval(start: noon, end: noon.addingTimeInterval(30 * 60))
+
+        let result = CalendarEventMatcher.finalBinding(
+            startBinding: nil,
+            isUserChosen: false,
+            candidates: [meeting],
+            interval: session
+        )
+
+        XCTAssertEqual(result?.id, "meeting")
+    }
+
+    func testFinalBindingKeepsIncumbentWhenNothingOverlaps() {
+        let standup = makeEvent(
+            id: "standup",
+            title: "Standup",
+            start: noon,
+            durationMinutes: 15,
+            isOnlineMeeting: true
+        )
+        let session = DateInterval(
+            start: noon.addingTimeInterval(-10 * 60),
+            end: noon.addingTimeInterval(-2 * 60)
+        )
+
+        let result = CalendarEventMatcher.finalBinding(
+            startBinding: standup,
+            isUserChosen: false,
+            candidates: [],
+            interval: session
+        )
+
+        XCTAssertEqual(result?.id, "standup")
     }
 }

--- a/OpenOats/Tests/OpenOatsTests/CalendarEventMatcherTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/CalendarEventMatcherTests.swift
@@ -145,4 +145,153 @@ final class CalendarEventMatcherTests: XCTestCase {
         XCTAssertTrue(CalendarEventMatcher.isLikelyMeeting(invited))
         XCTAssertTrue(CalendarEventMatcher.isLikelyMeeting(online))
     }
+
+    // MARK: - Interval matching (finalize-time re-resolution)
+
+    // The regression interval ranking exists for: a recording that starts in
+    // the tail of the previous event binds to that event at start, because at
+    // minute zero the previous event is the closer candidate. Once the real
+    // interval is known, the meeting that actually spans the recording wins.
+    func testIntervalMatchRebindsSessionThatStartedDuringThePreviousEvent() {
+        let previous = makeEvent(
+            id: "previous",
+            title: "1:1",
+            start: noon.addingTimeInterval(-15 * 60),
+            durationMinutes: 15,
+            isOnlineMeeting: true
+        )
+        let actual = makeEvent(
+            id: "actual",
+            title: "Quarterly Review",
+            start: noon,
+            durationMinutes: 60,
+            participants: [Participant(name: "Ada", email: "ada@example.com")]
+        )
+        // Recording started ten minutes before the hour and ran to :55.
+        let sessionStart = noon.addingTimeInterval(-10 * 60)
+        let session = DateInterval(start: sessionStart, end: noon.addingTimeInterval(55 * 60))
+
+        // At the instant the recording started, the previous event was the
+        // closer candidate — this is the binding start-time matching gets wrong.
+        XCTAssertEqual(
+            CalendarEventMatcher.bestMatch(among: [previous, actual], at: sessionStart)?.id,
+            "previous"
+        )
+
+        // Both orderings must produce the same winner.
+        for candidates in [[previous, actual], [actual, previous]] {
+            let best = CalendarEventMatcher.bestMatch(among: candidates, overlapping: session)
+            XCTAssertEqual(best?.id, "actual")
+        }
+    }
+
+    func testIntervalMatchPrefersEventCoveringTheSessionOverOneSharingItsStart() {
+        let shortBlock = makeEvent(
+            id: "short",
+            title: "Standup",
+            start: noon,
+            durationMinutes: 15,
+            isOnlineMeeting: true
+        )
+        let fullMeeting = makeEvent(
+            id: "full",
+            title: "Design Review",
+            start: noon,
+            durationMinutes: 50,
+            isOnlineMeeting: true
+        )
+        let session = DateInterval(start: noon, end: noon.addingTimeInterval(50 * 60))
+
+        for candidates in [[shortBlock, fullMeeting], [fullMeeting, shortBlock]] {
+            let best = CalendarEventMatcher.bestMatch(among: candidates, overlapping: session)
+            XCTAssertEqual(best?.id, "full")
+        }
+    }
+
+    // Meeting-likeness stays the first key: a personal block that contains
+    // more of the recording still loses to a real meeting that overlaps it
+    // only partially.
+    func testIntervalMatchKeepsMeetingLikenessAheadOfOverlap() {
+        let personalBlock = makeEvent(
+            id: "personal",
+            title: "Focus time",
+            start: noon,
+            durationMinutes: 120
+        )
+        let meeting = makeEvent(
+            id: "meeting",
+            title: "Standup",
+            start: noon.addingTimeInterval(30 * 60),
+            durationMinutes: 30,
+            isOnlineMeeting: true
+        )
+        let session = DateInterval(start: noon, end: noon.addingTimeInterval(90 * 60))
+
+        for candidates in [[personalBlock, meeting], [meeting, personalBlock]] {
+            let best = CalendarEventMatcher.bestMatch(among: candidates, overlapping: session)
+            XCTAssertEqual(best?.id, "meeting")
+        }
+    }
+
+    func testIntervalMatchFallsBackToStartProximityWhenOverlapsTie() {
+        let outer = makeEvent(
+            id: "outer",
+            title: "Team block",
+            start: noon,
+            durationMinutes: 60,
+            isOnlineMeeting: true
+        )
+        let inner = makeEvent(
+            id: "inner",
+            title: "Check-in",
+            start: noon.addingTimeInterval(5 * 60),
+            durationMinutes: 40,
+            isOnlineMeeting: true
+        )
+        // Both events cover the whole recording, so overlaps tie and the
+        // closer start wins.
+        let session = DateInterval(
+            start: noon.addingTimeInterval(10 * 60),
+            end: noon.addingTimeInterval(40 * 60)
+        )
+
+        for candidates in [[outer, inner], [inner, outer]] {
+            let best = CalendarEventMatcher.bestMatch(among: candidates, overlapping: session)
+            XCTAssertEqual(best?.id, "inner")
+        }
+    }
+
+    // Recording an in-person meeting nobody was invited to is still supported:
+    // with no meeting-like candidate, the block that contains most of the
+    // recording wins.
+    func testIntervalMatchRanksPersonalBlocksByOverlapWhenNoCandidateLooksLikeAMeeting() {
+        let errand = makeEvent(
+            id: "errand",
+            title: "Errand",
+            start: noon.addingTimeInterval(-20 * 60),
+            durationMinutes: 30
+        )
+        let block = makeEvent(
+            id: "block",
+            title: "Working session",
+            start: noon,
+            durationMinutes: 60
+        )
+        let session = DateInterval(
+            start: noon.addingTimeInterval(-5 * 60),
+            end: noon.addingTimeInterval(50 * 60)
+        )
+
+        for candidates in [[errand, block], [block, errand]] {
+            let best = CalendarEventMatcher.bestMatch(among: candidates, overlapping: session)
+            XCTAssertEqual(best?.id, "block")
+        }
+    }
+
+    func testIntervalMatchReturnsNilWithoutCandidates() {
+        XCTAssertNil(CalendarEventMatcher.bestMatch(
+            among: [],
+            overlapping: DateInterval(start: noon, duration: 30 * 60)
+        ))
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/MeetingStateTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MeetingStateTests.swift
@@ -448,6 +448,26 @@ final class MeetingStateTests: XCTestCase {
         XCTAssertEqual(decoded.detectionContext?.meetingApp?.bundleID, "us.zoom.xos")
     }
 
+    // Payloads written before `calendarEventIsUserChosen` existed must keep
+    // decoding: the missing key defaults to false.
+    func testMeetingMetadataDecodesPayloadWithoutUserChosenFlag() throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(makeMetadataWithApp())
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any]
+        )
+        object.removeValue(forKey: "calendarEventIsUserChosen")
+        let legacyData = try JSONSerialization.data(withJSONObject: object)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(MeetingMetadata.self, from: legacyData)
+
+        XCTAssertFalse(decoded.calendarEventIsUserChosen)
+        XCTAssertEqual(decoded.detectionContext?.meetingApp?.bundleID, "us.zoom.xos")
+    }
+
     // -------------------------------------------------------------------------
     // MARK: - Edge Cases
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Opening this as the follow-up invited in #701's merge comment: *"Noted your follow-up about re-resolving the event at `finalizeSession` against the finished session's real interval. Agreed that it is a separate change and that this one stands on its own — please do open it if you want to take it."*

## Root cause

The session→calendar-event binding is resolved once, at session start, and never revisited:

- `App/LiveSessionController.swift:352-356` — a manual start resolves via `container.calendarManager?.currentEvent(...)` and packs the result into `MeetingMetadata` (line 362).
- `App/MeetingDetectionController.swift:413-415` — the auto-detect path does the same (metadata built at 433-439).
- At finalize, `LiveSessionController.finalizeCurrentSession` passes `calendarEvent: endingMetadata?.calendarEvent` (line 818) — the object chosen at minute zero — into `SessionFinalizeMetadata`.

`currentEvent` picks from a ±15-minute window around the start instant (`Meeting/CalendarManager.swift:70-71`), ranked by `CalendarEventMatcher.bestMatch(among:at:)` (line 244) — proximity to a single instant. That choice can be wrong once the real interval is known: a recording that starts in the tail of the previous event binds to *that* event, because at minute zero the previous event is the closer candidate; a session that runs long may look nothing like the 15-minute block it bound to at start.

This matters more than one stale field, because three consumers read the finalize-time binding and inherit a wrong one:

1. **Speaker-name seeding** — `Storage/SessionRepository.swift:446-454` seeds speaker names from `metadata.calendarEvent`'s invitees.
2. **Per-meeting-family folder routing** — `App/LiveSessionController.swift:823-827` (`meetingFamilyPreferences(for: event)?.folderPath`).
3. **Notes template selection + `meetingFamilyKey`** — post-meeting notes load the stored binding (`LiveSessionController.swift:1117-1121`, `resolvedNotesTemplate` at 1164), and `SessionRepository.swift:1979` derives `meetingFamilyKey` from it.

## Change

- **`CalendarManager.events(overlapping:excludingCalendarIDs:)`** — fetches the non-all-day events overlapping the recording's real `[startedAt, endedAt]` interval. It only fetches; all ranking lives in `CalendarEventMatcher` as pure functions over `CalendarEvent` (the separation that made #701 testable without an `EKEventStore`).
- **`CalendarEventMatcher.bestMatch(among:overlapping:)`** — interval ranking. The key preserves #701's semantics: meeting-likeness remains the *first* key — a personal block that contains more of the recording still loses to a real meeting — then **coverage fraction** (overlap ÷ the event's own duration, quantized to five buckets), then the closest start, then the shorter event, ending in `startDate` so the ordering stays total and independent of EventKit's ordering. Coverage is a fraction rather than raw overlap seconds so a fully-covered 30-minute meeting outranks a 3-hour block the recording merely dips into, and the bucket quantization keeps one extra second of overlap from flipping the winner — near-ties fall through to start proximity.
- **`CalendarEventMatcher.finalBinding(startBinding:isUserChosen:candidates:interval:)`** — the pure finalize-time decision. The start-time binding *competes* with the challengers under the same ranking key (it is appended to the candidate pool), so a meeting-like incumbent can never lose to a non-meeting-like challenger. Zero-overlap candidates are dropped before ranking (EventKit's predicate bounds are inclusive, so a back-to-back neighbour can slip in with 0s of overlap) — but the incumbent competes regardless. A recording with *no* start-time binding only gains one when the winner is meeting-like, so an ad-hoc recording is never relocated or re-titled by the personal block that happens to contain it. A user-chosen binding is always returned unchanged.
- **Finalization** (`LiveSessionController.finalizeCurrentSession`) calls this before deriving the persisted title, and the winner feeds `SessionFinalizeMetadata`, the folder routing, and — via the stored `session.json` — notes-template resolution. The title fallback now derives from the *final* binding rather than the start-time one, so a rebound session is not persisted under the old event's name (which would have corrupted `MeetingHistoryResolver` history keys and ghost reconciliation). An explicit live topic still wins; `endingMetadata?.title` still covers sessions titled by the detected app.
- **`MeetingMetadata.calendarEventIsUserChosen`** — one design addition the original sketch didn't have. `startSession(calendarEventOverride:)` collapses a user-picked event and an auto-resolved one into the same metadata shape, so provenance has to be carried explicitly for finalize to respect an explicit choice. The flag travels with the metadata through the state machine, so it survives every start path (detail-pane "record this event" and the external command set it; manual toggle and auto-detect default to false). Decoding is explicit (`decodeIfPresent ?? false`), so any payload written before the field existed still decodes.

Re-resolution runs only when calendar integration is enabled, the user did not pick the event, and the session interval is non-empty.

## Tests

Fourteen new cases, modeled on #701's style — ranking assertions run each tie in both input orderings:

Interval ranking (`CalendarEventMatcherTests`):
- `testIntervalMatchRebindsSessionThatStartedDuringThePreviousEvent` — also asserts that the point-in-time matcher picks the *previous* event at the recording's start instant, documenting the failure mode this PR fixes.
- `testIntervalMatchKeepsFirstOfBackToBackMeetingsWhenSessionSpansBoth` — both events fully covered → buckets tie → start proximity keeps the meeting the user pressed record for.
- `testIntervalMatchPrefersContainedMeetingOverLongWorkshopOnOverrun` — meeting 1800/1800 → bucket 4 beats workshop 2100/10800 → bucket 1, where raw overlap seconds (2100 > 1800) would have picked the workshop.
- `testIntervalMatchKeepsMeetingLikenessAheadOfOverlap` — #701's first key preserved.
- `testIntervalMatchRanksPersonalBlocksByCoverageWhenNoCandidateLooksLikeAMeeting` — in-person recordings with no meeting-like candidate still land on the containing block.
- `testIntervalMatchReturnsNilWithoutCandidates`

Finalize decision (`finalBinding`, all pure):
- `testFinalBindingRespectsUserChosenEvent`
- `testFinalBindingKeepsMeetingIncumbentOverNonMeetingChallenger` — session recorded 11:50–11:58 for a 12:00 standup overlaps only a "Focus time" block; the standup is retained.
- `testFinalBindingRebindsToBetterOverlappingMeeting`
- `testFinalBindingIgnoresZeroOverlapChallengers`
- `testFinalBindingDoesNotAttachNonMeetingEventToAdHocRecording`
- `testFinalBindingAttachesMeetingEventToAdHocRecording`
- `testFinalBindingKeepsIncumbentWhenNothingOverlaps`

Plus `testMeetingMetadataDecodesPayloadWithoutUserChosenFlag` (`MeetingStateTests`) for the legacy-payload decode.

`swift build -c debug`, `swift test` (737 tests, 0 failures), and `swift build -c release` are green locally. Existing `LiveSessionControllerTests` exercise `calendarEventOverride` through full start→stop→finalize (folder routing, ghost-session merge, family template selection) and pass unchanged.

## Risk

- The finalize-time EventKit query is one predicate over the session interval — same cost class as the start-time lookup, once per session.
- Behavior changes only where the interval ranking disagrees with the minute-zero ranking *and* the incumbent loses a fair fight under the same key — a strictly-worse challenger cannot displace it. Empty candidates fall back to the start binding.
- Two adjacent behaviors are noted but deliberately unchanged:
  - **Ghost-session merge** (`Storage/SessionRepository.swift:1102-1133`) can propagate a short ghost's re-resolved binding onto the surviving session it merges into. Known, low-frequency, and bounded by the same ranking; left as is.
  - **Cloud transcription models**: `endingMetadata.startedAt` slightly predates actual audio capture, so the re-resolution interval is marginally wider than the recording. Pre-existing timestamp semantics, unchanged here.

## Revised after self-review

An adversarial pass over the first version of this branch found one real bug and several sharp edges; this revision (second commit) addresses them:

1. **The start binding now competes instead of being replaced unconditionally.** v1 used `reResolved ?? startBinding`, so *any* challenger — including a strictly worse one — displaced the incumbent: a session recorded 11:50–11:58 for a 12:00 standup overlaps only a personal "Focus time" block and would have rebound from a real meeting to a non-meeting. The incumbent now joins the candidate pool under the same ranking key, so meeting-likeness protects it (`finalBinding`, with a regression test).
2. **Raw overlap seconds → coverage-fraction buckets.** v1's absolute-overlap key had containment bias: it flipped a session spanning back-to-back meetings onto the second (longer) meeting, and let a 3-hour workshop steal a fully-covered 30-minute meeting the moment the session overran by five minutes. Ranking now uses overlap ÷ event duration quantized to buckets 0–4; the quantization also removes the one-extra-second-of-overlap flip. Two of v1's tests encoded the absolute-overlap semantics and were replaced by the scenarios above.
3. **Title derives from the final binding.** v1 still derived the persisted title from the start-time event while writing the re-resolved event, so a rebound session could persist titled "A" with `calendarEvent` B — corrupting title-based history keys. Title derivation now follows re-resolution.
4. **Zero-overlap challengers are filtered** (inclusive predicate bounds), the **fresh-binding gate** stops ad-hoc recordings from being claimed by personal blocks, and the finalize decision was **extracted into pure `CalendarEventMatcher.finalBinding`** with direct unit tests — replacing v1's "exercised indirectly" caveat.
5. **Explicit `decodeIfPresent ?? false`** for the new metadata flag, with a legacy-payload decode test.
