### PR TITLE
Surface auto notes-generation failures instead of failing silently

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppContainer.swift
+++ b/OpenOats/Sources/OpenOats/App/AppContainer.swift
@@ -19,6 +19,21 @@ final class AppContainer {
     /// even when detection is not enabled.
     private(set) var notificationService: NotificationService?
 
+    /// Notification service for alerts that are not tied to meeting detection,
+    /// such as a post-meeting notes failure.
+    ///
+    /// `notificationService` is only populated once detection has been enabled,
+    /// so users who record manually would otherwise get no alert at all. Reuse
+    /// the detection controller's instance when there is one and create a
+    /// standalone service otherwise; `NotificationService` no-ops on its own
+    /// when notifications are unavailable (unbundled builds).
+    func alertNotificationService() -> NotificationService {
+        if let notificationService { return notificationService }
+        let service = NotificationService()
+        notificationService = service
+        return service
+    }
+
     /// Calendar manager for looking up current events.
     /// Created when the calendar integration setting is enabled.
     private(set) var calendarManager: CalendarManager?

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -1121,65 +1121,156 @@ final class LiveSessionController {
         )
         let scratchpad = await coordinator.sessionRepository.loadScratchpad(sessionID: sessionID)
 
+        let generatedMarkdown: String
         do {
-            let generatedMarkdown: String
-            do {
-                generatedMarkdown = try await coordinator.notesEngine.generateMarkdownDetached(
-                    transcript: sessionData.transcript,
-                    template: template,
-                    settings: settings,
-                    calendarEvent: sessionData.calendarEvent,
-                    scratchpad: scratchpad.isEmpty ? nil : scratchpad,
-                    customGuidance: customGuidance
-                )
-            } catch {
-                // One retry after a short backoff: notes calls fail transiently
-                // (local LLM server warming up, brief network drop).
-                DiagnosticsSupport.record(
-                    category: "meeting",
-                    message: "Auto-generated post-meeting notes attempt failed for \(sessionID), retrying: \(error.localizedDescription)"
-                )
-                try await Task.sleep(for: .seconds(3))
-                generatedMarkdown = try await coordinator.notesEngine.generateMarkdownDetached(
-                    transcript: sessionData.transcript,
-                    template: template,
-                    settings: settings,
-                    calendarEvent: sessionData.calendarEvent,
-                    scratchpad: scratchpad.isEmpty ? nil : scratchpad,
-                    customGuidance: customGuidance
-                )
-            }
-
-            let notes = GeneratedNotes(
-                template: coordinator.templateStore.snapshot(of: template),
-                generatedAt: Date(),
-                markdown: GeneratedNotes.normalizedMarkdown(
-                    generatedMarkdown,
-                    title: session.title,
-                    date: session.startedAt
-                )
+            generatedMarkdown = try await generateNotesMarkdownWithRetry(
+                sessionID: sessionID,
+                transcript: sessionData.transcript,
+                template: template,
+                settings: settings,
+                calendarEvent: sessionData.calendarEvent,
+                scratchpad: scratchpad.isEmpty ? nil : scratchpad,
+                customGuidance: customGuidance
             )
-
-            await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
-            await coordinator.loadHistory()
-
-            if coordinator.lastEndedSession?.id == sessionID {
-                coordinator.lastEndedSession = await coordinator.sessionRepository.loadSession(id: sessionID).index
-            }
-
-            syncProjectedState(settings: settings)
+        } catch is CancellationError {
+            // Torn down mid-flight (app quitting, backoff interrupted). Nothing
+            // failed from the user's point of view, so stay quiet.
             DiagnosticsSupport.record(
                 category: "meeting",
-                message: "Auto-generated post-meeting notes for \(sessionID)"
+                message: "Auto-generated post-meeting notes cancelled for \(sessionID)"
             )
+            return
         } catch {
             DiagnosticsSupport.record(
                 category: "meeting",
                 message: "Auto-generated post-meeting notes failed for \(sessionID): \(error.localizedDescription)"
             )
-            if let notifService = container.notificationService {
-                await notifService.postNotesFailed(sessionID: sessionID)
+            await container.alertNotificationService().postNotesFailed(
+                sessionID: sessionID,
+                reason: error.localizedDescription
+            )
+            return
+        }
+
+        // Generation can take minutes, and a retry widens that window further.
+        // Re-read the session before writing: the user may have deleted the
+        // meeting, or written notes by hand while this was in flight.
+        guard await coordinator.sessionRepository.sessionExists(id: sessionID) else {
+            DiagnosticsSupport.record(
+                category: "meeting",
+                message: "Discarded auto-generated notes for \(sessionID): session was deleted"
+            )
+            return
+        }
+
+        let currentSession = await coordinator.sessionRepository.loadSession(id: sessionID).index
+        guard !currentSession.hasNotes else {
+            DiagnosticsSupport.record(
+                category: "meeting",
+                message: "Discarded auto-generated notes for \(sessionID): notes already exist"
+            )
+            return
+        }
+
+        let notes = GeneratedNotes(
+            template: coordinator.templateStore.snapshot(of: template),
+            generatedAt: Date(),
+            markdown: GeneratedNotes.normalizedMarkdown(
+                generatedMarkdown,
+                title: currentSession.title,
+                date: currentSession.startedAt
+            )
+        )
+
+        await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
+        await coordinator.loadHistory()
+
+        if coordinator.lastEndedSession?.id == sessionID {
+            coordinator.lastEndedSession = await coordinator.sessionRepository.loadSession(id: sessionID).index
+        }
+
+        syncProjectedState(settings: settings)
+        DiagnosticsSupport.record(
+            category: "meeting",
+            message: "Auto-generated post-meeting notes for \(sessionID)"
+        )
+    }
+
+    /// Seconds to wait before the single notes retry.
+    ///
+    /// The streaming client already allows 300s between bytes because local
+    /// model servers routinely take more than 60s to produce a first token. A
+    /// short backoff just re-hits a server that has not finished warming up.
+    static let notesRetryBackoffSeconds = 15
+
+    /// Failures worth a second attempt: the request never reached a working
+    /// server, or the server said "not now". A missing API key, a malformed
+    /// base URL, a rejected key, or a model that returned nothing all fail the
+    /// same way on a retry, so those go straight to the notification.
+    static func isRetriableNotesFailure(_ error: Error) -> Bool {
+        if error is CancellationError { return false }
+
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut,
+                 .cannotConnectToHost,
+                 .cannotFindHost,
+                 .dnsLookupFailed,
+                 .networkConnectionLost,
+                 .notConnectedToInternet,
+                 .secureConnectionFailed,
+                 .resourceUnavailable:
+                return true
+            default:
+                return false
             }
+        }
+
+        if let routerError = error as? OpenRouterClient.OpenRouterError,
+           case .httpError(let statusCode, _) = routerError {
+            // 429 and 5xx are the server asking to be tried again;
+            // 401 / 403 / 404 are settled answers.
+            return statusCode == 429 || (500...599).contains(statusCode)
+        }
+
+        return false
+    }
+
+    /// Generates notes markdown, retrying once for transport-class failures only.
+    private func generateNotesMarkdownWithRetry(
+        sessionID: String,
+        transcript: [SessionRecord],
+        template: MeetingTemplate,
+        settings: AppSettings,
+        calendarEvent: CalendarEvent?,
+        scratchpad: String?,
+        customGuidance: String?
+    ) async throws -> String {
+        do {
+            return try await coordinator.notesEngine.generateMarkdownDetached(
+                transcript: transcript,
+                template: template,
+                settings: settings,
+                calendarEvent: calendarEvent,
+                scratchpad: scratchpad,
+                customGuidance: customGuidance
+            )
+        } catch {
+            guard Self.isRetriableNotesFailure(error) else { throw error }
+
+            DiagnosticsSupport.record(
+                category: "meeting",
+                message: "Auto-generated post-meeting notes attempt failed for \(sessionID), retrying in \(Self.notesRetryBackoffSeconds)s: \(error.localizedDescription)"
+            )
+            try await Task.sleep(for: .seconds(Self.notesRetryBackoffSeconds))
+            return try await coordinator.notesEngine.generateMarkdownDetached(
+                transcript: transcript,
+                template: template,
+                settings: settings,
+                calendarEvent: calendarEvent,
+                scratchpad: scratchpad,
+                customGuidance: customGuidance
+            )
         }
     }
 

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -1153,36 +1153,35 @@ final class LiveSessionController {
         }
 
         // Generation can take minutes, and a retry widens that window further.
-        // Re-read the session before writing: the user may have deleted the
-        // meeting, or written notes by hand while this was in flight.
-        guard await coordinator.sessionRepository.sessionExists(id: sessionID) else {
+        // The user may have deleted the meeting, or written notes by hand,
+        // while this was in flight. Checking that from here would be a separate
+        // call into the repository actor, and a delete or a manual save can
+        // land in the gap before the write, so the repository checks and writes
+        // in a single operation.
+        let outcome = await coordinator.sessionRepository.saveGeneratedNotesIfAbsent(
+            sessionID: sessionID,
+            template: coordinator.templateStore.snapshot(of: template),
+            markdown: generatedMarkdown,
+            generatedAt: Date()
+        )
+
+        switch outcome {
+        case .sessionMissing:
             DiagnosticsSupport.record(
                 category: "meeting",
                 message: "Discarded auto-generated notes for \(sessionID): session was deleted"
             )
             return
-        }
-
-        let currentSession = await coordinator.sessionRepository.loadSession(id: sessionID).index
-        guard !currentSession.hasNotes else {
+        case .notesAlreadyExist:
             DiagnosticsSupport.record(
                 category: "meeting",
                 message: "Discarded auto-generated notes for \(sessionID): notes already exist"
             )
             return
+        case .written:
+            break
         }
 
-        let notes = GeneratedNotes(
-            template: coordinator.templateStore.snapshot(of: template),
-            generatedAt: Date(),
-            markdown: GeneratedNotes.normalizedMarkdown(
-                generatedMarkdown,
-                title: currentSession.title,
-                date: currentSession.startedAt
-            )
-        )
-
-        await coordinator.sessionRepository.saveNotes(sessionID: sessionID, notes: notes)
         await coordinator.loadHistory()
 
         if coordinator.lastEndedSession?.id == sessionID {

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -1122,14 +1122,33 @@ final class LiveSessionController {
         let scratchpad = await coordinator.sessionRepository.loadScratchpad(sessionID: sessionID)
 
         do {
-            let generatedMarkdown = try await coordinator.notesEngine.generateMarkdownDetached(
-                transcript: sessionData.transcript,
-                template: template,
-                settings: settings,
-                calendarEvent: sessionData.calendarEvent,
-                scratchpad: scratchpad.isEmpty ? nil : scratchpad,
-                customGuidance: customGuidance
-            )
+            let generatedMarkdown: String
+            do {
+                generatedMarkdown = try await coordinator.notesEngine.generateMarkdownDetached(
+                    transcript: sessionData.transcript,
+                    template: template,
+                    settings: settings,
+                    calendarEvent: sessionData.calendarEvent,
+                    scratchpad: scratchpad.isEmpty ? nil : scratchpad,
+                    customGuidance: customGuidance
+                )
+            } catch {
+                // One retry after a short backoff: notes calls fail transiently
+                // (local LLM server warming up, brief network drop).
+                DiagnosticsSupport.record(
+                    category: "meeting",
+                    message: "Auto-generated post-meeting notes attempt failed for \(sessionID), retrying: \(error.localizedDescription)"
+                )
+                try await Task.sleep(for: .seconds(3))
+                generatedMarkdown = try await coordinator.notesEngine.generateMarkdownDetached(
+                    transcript: sessionData.transcript,
+                    template: template,
+                    settings: settings,
+                    calendarEvent: sessionData.calendarEvent,
+                    scratchpad: scratchpad.isEmpty ? nil : scratchpad,
+                    customGuidance: customGuidance
+                )
+            }
 
             let notes = GeneratedNotes(
                 template: coordinator.templateStore.snapshot(of: template),
@@ -1158,6 +1177,9 @@ final class LiveSessionController {
                 category: "meeting",
                 message: "Auto-generated post-meeting notes failed for \(sessionID): \(error.localizedDescription)"
             )
+            if let notifService = container.notificationService {
+                await notifService.postNotesFailed(sessionID: sessionID)
+            }
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
+++ b/OpenOats/Sources/OpenOats/Intelligence/NotesEngine.swift
@@ -40,6 +40,10 @@ final class NotesEngine {
         set { withMutation(keyPath: \.error) { _error = newValue } }
     }
 
+    /// The error behind `error`, kept so callers can classify a failure instead
+    /// of pattern-matching a localized string. `error` stays the display copy.
+    @ObservationIgnored nonisolated(unsafe) private var underlyingError: Error?
+
     private let client = OpenRouterClient()
     private var currentTask: Task<Void, Never>?
     private let mode: Mode
@@ -82,6 +86,7 @@ final class NotesEngine {
         isGenerating = true
         generatedMarkdown = ""
         error = nil
+        underlyingError = nil
 
         switch mode {
         case .scripted(let markdown):
@@ -240,6 +245,7 @@ final class NotesEngine {
             } catch {
                 if !Task.isCancelled {
                     self?.error = error.localizedDescription
+                    self?.underlyingError = error
                 }
             }
             self?.isGenerating = false
@@ -275,7 +281,12 @@ final class NotesEngine {
                     continuation.resume(throwing: GenerationError.failed("Notes generation ended unexpectedly"))
                     return
                 }
-                if let error = self.error {
+                if let underlyingError = self.underlyingError {
+                    // Rethrow the original error so callers can tell a transport
+                    // blip from a rejected key. The message is unchanged: every
+                    // error on this path is a LocalizedError.
+                    continuation.resume(throwing: underlyingError)
+                } else if let error = self.error {
                     continuation.resume(throwing: GenerationError.failed(error))
                 } else {
                     continuation.resume(returning: self.generatedMarkdown)

--- a/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
@@ -31,14 +31,26 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
     private static let categoryWithAppID = "MEETING_DETECTED_WITH_APP"
     private static let categoryNoAppID = "MEETING_DETECTED_NO_APP"
-    private static let startAction = "START_TRANSCRIBING"
-    private static let notMeetingAction = "NOT_A_MEETING"
-    private static let ignoreAppAction = "IGNORE_APP"
-    private static let dismissAction = "DISMISS"
+    nonisolated static let startAction = "START_TRANSCRIBING"
+    nonisolated static let notMeetingAction = "NOT_A_MEETING"
+    nonisolated static let ignoreAppAction = "IGNORE_APP"
+    nonisolated static let dismissAction = "DISMISS"
+    /// Request identifier of the meeting-detection prompt. Only this request
+    /// carries the accept / not-a-meeting / ignore-app actions.
+    nonisolated static let detectionRequestID = "meeting-detection"
     static let batchCompletedTitle = "Re-transcription Complete"
     static let batchCompletedBody = "Re-transcription is complete. Your meeting transcript has been updated with higher-quality text."
     static let notesFailedTitle = "Notes Generation Failed"
-    static let notesFailedBody = "Meeting notes could not be generated. Open the meeting and choose Generate Notes to try again."
+    static let notesFailedFallbackReason = "Meeting notes could not be generated."
+
+    /// Body for the notes-failure notification. Leads with the specific reason —
+    /// a missing API key and an unreachable server need different responses from
+    /// the user — and ends with the manual remedy.
+    static func notesFailedBody(reason: String) -> String {
+        let trimmed = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+        let detail = trimmed.isEmpty ? notesFailedFallbackReason : trimmed
+        return "\(detail) Open the meeting and choose Generate Notes to try again."
+    }
 
     override init() {
         super.init()
@@ -118,7 +130,7 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
         // Remove previous detection notifications
         UNUserNotificationCenter.current().removeDeliveredNotifications(
-            withIdentifiers: ["meeting-detection"]
+            withIdentifiers: [Self.detectionRequestID]
         )
 
         let content = UNMutableNotificationContent()
@@ -142,7 +154,7 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         content.categoryIdentifier = appName != nil ? Self.categoryWithAppID : Self.categoryNoAppID
 
         let request = UNNotificationRequest(
-            identifier: "meeting-detection",
+            identifier: Self.detectionRequestID,
             content: content,
             trigger: nil
         )
@@ -161,7 +173,7 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
                 self?.onTimeout?()
             }
             UNUserNotificationCenter.current().removeDeliveredNotifications(
-                withIdentifiers: ["meeting-detection"]
+                withIdentifiers: [Self.detectionRequestID]
             )
         }
 
@@ -188,12 +200,12 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
     /// Post a notification when automatic post-meeting notes generation fails,
     /// so the failure is visible without opening the app.
-    func postNotesFailed(sessionID: String) async {
+    func postNotesFailed(sessionID: String, reason: String) async {
         guard await ensurePermission() else { return }
 
         let content = UNMutableNotificationContent()
         content.title = Self.notesFailedTitle
-        content.body = Self.notesFailedBody
+        content.body = Self.notesFailedBody(reason: reason)
         content.sound = .default
 
         let request = UNNotificationRequest(
@@ -211,8 +223,46 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         pendingTimeoutTask = nil
         guard isAvailable else { return }
         UNUserNotificationCenter.current().removeDeliveredNotifications(
-            withIdentifiers: ["meeting-detection"]
+            withIdentifiers: [Self.detectionRequestID]
         )
+    }
+
+    // MARK: - Response Routing
+
+    /// What a notification response should do.
+    enum ResponseRoute: Equatable {
+        case accept
+        case notAMeeting
+        case ignoreApp
+        case dismiss
+        /// Not a detection response — the delegate must do nothing at all.
+        case none
+    }
+
+    /// Routes a notification response by the request that produced it.
+    ///
+    /// Only the meeting-detection prompt owns the detection callbacks. Every
+    /// other notification this app posts (notes failure, batch completion) has
+    /// no actions of its own, so a tap on its body arrives as the default
+    /// action identifier. Routing on the action alone treated that as "accept"
+    /// and started a recording the user never asked for, and cancelled the
+    /// timeout of a detection prompt that might still be on screen.
+    nonisolated static func route(actionIdentifier: String, requestIdentifier: String) -> ResponseRoute {
+        guard requestIdentifier == detectionRequestID else { return .none }
+
+        switch actionIdentifier {
+        case startAction:
+            return .accept
+        case notMeetingAction:
+            return .notAMeeting
+        case ignoreAppAction:
+            return .ignoreApp
+        case dismissAction, UNNotificationDismissActionIdentifier:
+            return .dismiss
+        default:
+            // Default action: a tap on the detection prompt's body.
+            return .accept
+        }
     }
 
     // MARK: - UNUserNotificationCenterDelegate
@@ -222,26 +272,28 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         didReceive response: UNNotificationResponse,
         withCompletionHandler completionHandler: @escaping @Sendable () -> Void
     ) {
-        let actionID = response.actionIdentifier
+        let route = Self.route(
+            actionIdentifier: response.actionIdentifier,
+            requestIdentifier: response.notification.request.identifier
+        )
 
         Task { @MainActor [weak self] in
-            guard let self else { return }
+            guard let self, route != .none else { return }
 
             self.pendingTimeoutTask?.cancel()
             self.pendingTimeoutTask = nil
 
-            switch actionID {
-            case Self.startAction:
+            switch route {
+            case .accept:
                 self.onAccept?()
-            case Self.notMeetingAction:
+            case .notAMeeting:
                 self.onNotAMeeting?()
-            case Self.ignoreAppAction:
+            case .ignoreApp:
                 self.onIgnoreApp?()
-            case Self.dismissAction, UNNotificationDismissActionIdentifier:
+            case .dismiss:
                 self.onDismiss?()
-            default:
-                // Default action (tap on notification body) -- treat as accept
-                self.onAccept?()
+            case .none:
+                break
             }
         }
 

--- a/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
@@ -37,6 +37,8 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     private static let dismissAction = "DISMISS"
     static let batchCompletedTitle = "Re-transcription Complete"
     static let batchCompletedBody = "Re-transcription is complete. Your meeting transcript has been updated with higher-quality text."
+    static let notesFailedTitle = "Notes Generation Failed"
+    static let notesFailedBody = "Meeting notes could not be generated. Open the meeting and choose Generate Notes to try again."
 
     override init() {
         super.init()
@@ -177,6 +179,25 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
 
         let request = UNNotificationRequest(
             identifier: "batch-completed-\(sessionID)",
+            content: content,
+            trigger: nil
+        )
+
+        try? await UNUserNotificationCenter.current().add(request)
+    }
+
+    /// Post a notification when automatic post-meeting notes generation fails,
+    /// so the failure is visible without opening the app.
+    func postNotesFailed(sessionID: String) async {
+        guard await ensurePermission() else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = Self.notesFailedTitle
+        content.body = Self.notesFailedBody
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: "notes-failed-\(sessionID)",
             content: content,
             trigger: nil
         )

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -890,6 +890,19 @@ actor SessionRepository {
         return results.sorted { $0.startedAt > $1.startedAt }
     }
 
+    /// True when the session still has a record on disk.
+    ///
+    /// Writers check this before saving into a session directory: `saveNotes`
+    /// creates the directory it writes to, so a save that lands after the user
+    /// deleted the meeting would resurrect it as an empty shell.
+    func sessionExists(id: String) -> Bool {
+        let fm = FileManager.default
+        let canonical = sessionDirectory(for: id).appendingPathComponent("session.json")
+        if fm.fileExists(atPath: canonical.path) { return true }
+        // Legacy layout: <sessions>/<id>.jsonl beside an optional sidecar.
+        return fm.fileExists(atPath: sessionsDirectory.appendingPathComponent("\(id).jsonl").path)
+    }
+
     func loadSession(id: String) -> SessionDetail {
         let dir = sessionDirectory(for: id)
         let metaURL = dir.appendingPathComponent("session.json")

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -716,6 +716,52 @@ actor SessionRepository {
         scheduleMirror(sessionID: sessionID, notesMarkdown: notes.markdown)
     }
 
+    /// Result of a generated-notes write that had to inspect the session first.
+    enum GeneratedNotesWriteOutcome: Sendable, Equatable {
+        case written
+        /// The session was deleted before the write.
+        case sessionMissing
+        /// The session gained notes before the write.
+        case notesAlreadyExist
+    }
+
+    /// Write generated notes, but only while the session still exists and
+    /// still has no notes.
+    ///
+    /// Generation takes minutes, so the session can change underneath it: the
+    /// user may delete the meeting, or write notes by hand. A caller cannot
+    /// guard that itself, because every call into this actor is a suspension
+    /// point — a delete or a manual save can land between a caller's check and
+    /// its write, which resurrects a deleted session as an empty shell or
+    /// overwrites the user's own notes. The check and the write therefore
+    /// happen here, in one operation, with no suspension between them.
+    ///
+    /// The heading needs the session's current title and start date, so
+    /// normalization happens here too rather than against a stale read.
+    func saveGeneratedNotesIfAbsent(
+        sessionID: String,
+        template: TemplateSnapshot,
+        markdown: String,
+        generatedAt: Date
+    ) -> GeneratedNotesWriteOutcome {
+        guard sessionExists(id: sessionID) else { return .sessionMissing }
+
+        let session = loadSession(id: sessionID).index
+        guard !session.hasNotes else { return .notesAlreadyExist }
+
+        let notes = GeneratedNotes(
+            template: template,
+            generatedAt: generatedAt,
+            markdown: GeneratedNotes.normalizedMarkdown(
+                markdown,
+                title: session.title,
+                date: session.startedAt
+            )
+        )
+        saveNotes(sessionID: sessionID, notes: notes)
+        return .written
+    }
+
     func loadNotes(sessionID: String) -> GeneratedNotes? {
         let dir = sessionDirectory(for: sessionID)
         let mdURL = dir.appendingPathComponent("notes.md")

--- a/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/LiveSessionControllerTests.swift
@@ -1597,4 +1597,72 @@ final class LiveSessionControllerTests: XCTestCase {
         XCTAssertNotNil(coordinator.lastEndedSession)
         XCTAssertEqual(coordinator.lastEndedSession?.utteranceCount, 2)
     }
+
+    // MARK: - Notes retry classification
+
+    func testTransportFailuresAreRetried() {
+        for code in [
+            URLError.timedOut,
+            .cannotConnectToHost,
+            .cannotFindHost,
+            .dnsLookupFailed,
+            .networkConnectionLost,
+            .notConnectedToInternet,
+            .secureConnectionFailed,
+            .resourceUnavailable,
+        ] {
+            XCTAssertTrue(
+                LiveSessionController.isRetriableNotesFailure(URLError(code)),
+                "Expected \(code) to be retried"
+            )
+        }
+    }
+
+    func testDeterministicFailuresAreNotRetried() {
+        // A second attempt produces the same answer, so it only delays the
+        // notification the user needs.
+        XCTAssertFalse(
+            LiveSessionController.isRetriableNotesFailure(
+                OpenRouterClient.OpenRouterError.missingAPIKey(host: "openrouter.ai")
+            )
+        )
+        XCTAssertFalse(
+            LiveSessionController.isRetriableNotesFailure(
+                OpenRouterClient.OpenRouterError.httpError(401, host: "openrouter.ai")
+            )
+        )
+        XCTAssertFalse(
+            LiveSessionController.isRetriableNotesFailure(
+                OpenRouterClient.OpenRouterError.httpError(404, host: "localhost")
+            )
+        )
+        XCTAssertFalse(
+            LiveSessionController.isRetriableNotesFailure(URLError(.badURL))
+        )
+        XCTAssertFalse(
+            LiveSessionController.isRetriableNotesFailure(
+                NotesEngine.GenerationError.failed("Invalid OpenAI Compatible URL: not a url")
+            )
+        )
+        XCTAssertFalse(LiveSessionController.isRetriableNotesFailure(CancellationError()))
+    }
+
+    func testBusyServerResponsesAreRetried() {
+        XCTAssertTrue(
+            LiveSessionController.isRetriableNotesFailure(
+                OpenRouterClient.OpenRouterError.httpError(429, host: "openrouter.ai")
+            )
+        )
+        XCTAssertTrue(
+            LiveSessionController.isRetriableNotesFailure(
+                OpenRouterClient.OpenRouterError.httpError(503, host: "localhost")
+            )
+        )
+    }
+
+    func testNotesRetryBackoffOutlastsALocalModelColdStart() {
+        // The streaming client allows 300s between bytes precisely because local
+        // servers are slow to first token; a 3s backoff re-hits a cold server.
+        XCTAssertGreaterThanOrEqual(LiveSessionController.notesRetryBackoffSeconds, 15)
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/NotificationServiceTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotificationServiceTests.swift
@@ -1,3 +1,4 @@
+import UserNotifications
 import XCTest
 @testable import OpenOatsKit
 
@@ -15,8 +16,87 @@ final class NotificationServiceTests: XCTestCase {
     func testNotesFailedNotificationCopyPointsAtManualRegeneration() {
         XCTAssertEqual(NotificationService.notesFailedTitle, "Notes Generation Failed")
         XCTAssertEqual(
-            NotificationService.notesFailedBody,
+            NotificationService.notesFailedBody(reason: ""),
             "Meeting notes could not be generated. Open the meeting and choose Generate Notes to try again."
+        )
+    }
+
+    func testNotesFailedNotificationCopyLeadsWithTheSpecificReason() {
+        XCTAssertEqual(
+            NotificationService.notesFailedBody(reason: "  OpenRouter API key required  "),
+            "OpenRouter API key required Open the meeting and choose Generate Notes to try again."
+        )
+    }
+
+    // MARK: - Response routing
+
+    func testTapOnNotesFailedNotificationDoesNothing() {
+        // A tap on a notification body arrives as the default action. Routing on
+        // the action alone treated that as "start transcribing".
+        XCTAssertEqual(
+            NotificationService.route(
+                actionIdentifier: UNNotificationDefaultActionIdentifier,
+                requestIdentifier: "notes-failed-session_2026-01-01_10-00-00"
+            ),
+            .none
+        )
+    }
+
+    func testTapOnBatchCompletedNotificationDoesNothing() {
+        XCTAssertEqual(
+            NotificationService.route(
+                actionIdentifier: UNNotificationDefaultActionIdentifier,
+                requestIdentifier: "batch-completed-session_2026-01-01_10-00-00"
+            ),
+            .none
+        )
+    }
+
+    func testDismissOfANonDetectionNotificationDoesNothing() {
+        XCTAssertEqual(
+            NotificationService.route(
+                actionIdentifier: UNNotificationDismissActionIdentifier,
+                requestIdentifier: "notes-failed-session_2026-01-01_10-00-00"
+            ),
+            .none
+        )
+    }
+
+    func testTapOnDetectionNotificationAccepts() {
+        XCTAssertEqual(
+            NotificationService.route(
+                actionIdentifier: UNNotificationDefaultActionIdentifier,
+                requestIdentifier: NotificationService.detectionRequestID
+            ),
+            .accept
+        )
+    }
+
+    func testDetectionActionsRouteToTheirCallbacks() {
+        let detection = NotificationService.detectionRequestID
+
+        XCTAssertEqual(
+            NotificationService.route(actionIdentifier: NotificationService.startAction, requestIdentifier: detection),
+            .accept
+        )
+        XCTAssertEqual(
+            NotificationService.route(actionIdentifier: NotificationService.notMeetingAction, requestIdentifier: detection),
+            .notAMeeting
+        )
+        XCTAssertEqual(
+            NotificationService.route(actionIdentifier: NotificationService.ignoreAppAction, requestIdentifier: detection),
+            .ignoreApp
+        )
+        XCTAssertEqual(
+            NotificationService.route(actionIdentifier: NotificationService.dismissAction, requestIdentifier: detection),
+            .dismiss
+        )
+        XCTAssertEqual(
+            NotificationService.route(
+                actionIdentifier: UNNotificationDismissActionIdentifier,
+                requestIdentifier: detection
+            ),
+            .dismiss
         )
     }
 }

--- a/OpenOats/Tests/OpenOatsTests/NotificationServiceTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/NotificationServiceTests.swift
@@ -11,4 +11,12 @@ final class NotificationServiceTests: XCTestCase {
             "Re-transcription is complete. Your meeting transcript has been updated with higher-quality text."
         )
     }
+
+    func testNotesFailedNotificationCopyPointsAtManualRegeneration() {
+        XCTAssertEqual(NotificationService.notesFailedTitle, "Notes Generation Failed")
+        XCTAssertEqual(
+            NotificationService.notesFailedBody,
+            "Meeting notes could not be generated. Open the meeting and choose Generate Notes to try again."
+        )
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -1486,4 +1486,127 @@ final class SessionRepositoryTests: XCTestCase {
         XCTAssertEqual(decoded.kbHits, ["doc.md"])
         XCTAssertEqual(decoded.cleanedText, "Hello there.")
     }
+
+    // MARK: - saveGeneratedNotesIfAbsent
+
+    private func makeTemplateSnapshot(name: String = "Auto") -> TemplateSnapshot {
+        TemplateSnapshot(id: UUID(), name: name, icon: "star", systemPrompt: "Be helpful")
+    }
+
+    private func sessionDirectory(for sessionID: String) -> URL {
+        rootDir
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+    }
+
+    func testSaveGeneratedNotesIfAbsentWritesAndHeadsWithCurrentTitle() async {
+        let sessionID = "auto_notes_write"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date(),
+            title: "Customer Sync"
+        )
+
+        let outcome = await repo.saveGeneratedNotesIfAbsent(
+            sessionID: sessionID,
+            template: makeTemplateSnapshot(),
+            markdown: "Body without a heading.",
+            generatedAt: Date()
+        )
+
+        XCTAssertEqual(outcome, .written)
+        let loaded = await repo.loadNotes(sessionID: sessionID)
+        XCTAssertEqual(loaded?.markdown, "# Meeting Notes: Customer Sync\n\nBody without a heading.")
+
+        let sessions = await repo.listSessions()
+        XCTAssertEqual(sessions.first(where: { $0.id == sessionID })?.hasNotes, true)
+    }
+
+    func testSaveGeneratedNotesIfAbsentDoesNotResurrectDeletedSession() async {
+        let sessionID = "auto_notes_deleted"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date()
+        )
+        await repo.deleteSession(sessionID: sessionID)
+
+        let outcome = await repo.saveGeneratedNotesIfAbsent(
+            sessionID: sessionID,
+            template: makeTemplateSnapshot(),
+            markdown: "# Late Notes\n\nToo late.",
+            generatedAt: Date()
+        )
+
+        XCTAssertEqual(outcome, .sessionMissing)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: sessionDirectory(for: sessionID).path))
+    }
+
+    func testSaveGeneratedNotesIfAbsentKeepsNotesWrittenByHand() async {
+        let sessionID = "auto_notes_manual"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date()
+        )
+        await repo.saveNotes(
+            sessionID: sessionID,
+            notes: GeneratedNotes(
+                template: makeTemplateSnapshot(name: "Manual"),
+                generatedAt: Date(),
+                markdown: "# Handwritten\n\nMine."
+            )
+        )
+
+        let outcome = await repo.saveGeneratedNotesIfAbsent(
+            sessionID: sessionID,
+            template: makeTemplateSnapshot(),
+            markdown: "# Generated\n\nOverwrite attempt.",
+            generatedAt: Date()
+        )
+
+        XCTAssertEqual(outcome, .notesAlreadyExist)
+        let loaded = await repo.loadNotes(sessionID: sessionID)
+        XCTAssertEqual(loaded?.markdown, "# Handwritten\n\nMine.")
+        XCTAssertEqual(loaded?.template.name, "Manual")
+    }
+
+    /// The check and the write are one actor operation, so a concurrent delete
+    /// runs either wholly before it (nothing is written) or wholly after it
+    /// (the notes go with the session). Neither order can leave notes behind in
+    /// a session directory that no longer has metadata.
+    func testSaveGeneratedNotesIfAbsentRacingDeleteLeavesNoOrphanNotes() async {
+        let sessionID = "auto_notes_race"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date()
+        )
+
+        let repo = repo!
+        let template = makeTemplateSnapshot()
+        let generatedAt = Date()
+        async let write = repo.saveGeneratedNotesIfAbsent(
+            sessionID: sessionID,
+            template: template,
+            markdown: "# Racing Notes\n\nBody.",
+            generatedAt: generatedAt
+        )
+        async let delete: Void = repo.deleteSession(sessionID: sessionID)
+        let outcome = await write
+        await delete
+
+        let dir = sessionDirectory(for: sessionID)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: dir.appendingPathComponent("notes.md").path),
+            "notes survived the delete of their session"
+        )
+        if outcome == .sessionMissing {
+            XCTAssertFalse(
+                FileManager.default.fileExists(atPath: dir.appendingPathComponent("session.json").path),
+                "session was resurrected by a write that had already seen it deleted"
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Root cause

When automatic post-meeting notes generation fails, the `catch` in `generatePostMeetingNotes` (`OpenOats/Sources/OpenOats/App/LiveSessionController.swift:1156`) only records a diagnostics breadcrumb. `DiagnosticsBreadcrumbStore.record` gates all recording on the `diagnosticLoggingEnabled` pref, which defaults to off (`OpenOats/Sources/OpenOats/Utils/DiagnosticsSupport.swift:111`). So on a stock install a failed notes call writes nothing anywhere — no retry, no notification, no state change. The meeting's notes silently never appear.

## What changed

- One retry with a 3s backoff inside `generatePostMeetingNotes`. Transient failures (local LLM server warming up, brief network drop) recover without user involvement.
- On final failure, a user notification is posted via a new `NotificationService.postNotesFailed(sessionID:)`, modeled on `postBatchCompleted` (`Meeting/NotificationService.swift:170`): same `ensurePermission()` authorization handling, static copy constants, per-session identifier, `try?` delivery. It is a no-op in unbundled runs (`isAvailable` guard), like all other notifications.
- The existing diagnostics breadcrumb is kept; a second breadcrumb records the retried first attempt.
- No new UI. The notification copy points at the existing "Generate Notes" action (`Views/ContentView.swift:615`) for manual recovery.

## Testing

- New copy test in `NotificationServiceTests`, same shape as the existing batch-completed copy test.
- `swift build -c debug`, full `swift test` (724 tests, 0 failures), and `swift build -c release` pass locally (macOS, arm64).

## Risk

Low. The success path is unchanged. The retry adds at most one extra LLM call plus 3 seconds before the existing failure handling. Notification delivery is permission-guarded and fire-and-forget.


---

## Revised after self-review

**Blocker: tapping the notification started a recording.** The delegate routed responses on the action identifier alone (`NotificationService.swift:242-244`). A tap on a notification body arrives as `UNNotificationDefaultActionIdentifier`, which fell into `default: onAccept?()` → `handleDetectionAccepted` → a new recording — while this PR's own copy asked the user to open the meeting. The same tap also cleared `pendingTimeoutTask`, so a detection prompt still on screen would never time out.

Responses now route by the *request* identifier as well: only `meeting-detection` owns the accept / not-a-meeting / ignore-app / dismiss callbacks, and a response to any other notification is a no-op that touches no state. `postBatchCompleted` had the same latent bug — a tap on "Re-transcription Complete" would also have started a recording — and the same change fixes it.

**Coverage hole: manual recordings still got silence.** `container.notificationService` was only populated by `AppContainer.enableDetection` (`:223`), which `ContentView` calls only when auto-detect is on (`:346,355`). Anyone recording manually hit the exact pre-PR behaviour this PR set out to fix. `AppContainer.alertNotificationService()` now returns the detection controller's service when there is one and creates a standalone service otherwise. `NotificationService` already no-ops on unbundled builds via its `isAvailable` guard, so nothing changes there.

**Retry only what a retry can fix.** A missing API key, a malformed base URL, a 401/404, or a model that returns nothing produce the identical failure on a second attempt — retrying only delays the notification the user needs. `isRetriableNotesFailure` now retries transport-class failures (connection refused/reset, timeout, DNS, TLS) and busy-server responses (429, 5xx); everything else notifies immediately with its specific error. Getting there meant `NotesEngine` had to stop flattening errors into a display string: it keeps the underlying error and rethrows it, so the message users see is unchanged while callers can classify.

**Backoff is 15s, not 3s.** `streamCompletion` sets a 300s idle timeout with a comment noting that local model first-token latency routinely exceeds 60s. A 3s backoff re-hits a server that has not finished warming up, which was the exact case the retry was added for.

**The retry widened two races, so the write is re-checked.** `hasNotes` was read once at the top, before a request that can run for minutes plus a 15s backoff plus a second request. The session is now re-read immediately before `saveNotes`: if the user wrote notes by hand in that window, the generated notes are discarded silently rather than clobbering them. And because `saveNotes` calls `createDirectory`, saving into a session the user deleted mid-flight would resurrect it as an empty `sessions/<id>/` shell — a new `SessionRepository.sessionExists(id:)` check prevents that, with no notification since nothing failed.

**Cancellation is not a failure.** `CancellationError` from the backoff sleep (app quitting, task torn down) is caught explicitly and aborts quietly instead of posting "Notes Generation Failed".

**Copy carries the reason.** The notification body now leads with the specific error and then the manual remedy, because "OpenRouter API key required" and "The request timed out" call for different actions. If #704 also lands, the reasoning-only / empty-response message it introduces reaches users through this body.

**Testing.** 734 tests, 0 failures (was 724). New coverage: taps and dismissals on notes-failed and batch-completed notifications route to no-ops, every detection action still routes to its callback, the reason-bearing copy and its fallback, and the retry classifier across transport codes, deterministic errors, busy-server statuses, and cancellation.

## Merge order

- **After #704.** That PR adds `OpenRouterError.reasoningOnlyResponse`. The retry classifier here is an
  allowlist of transport-class failures, so the new error becomes non-retriable automatically once #704
  lands — no follow-up edit needed, but the behaviour is only complete with both.
- **Before #708.** The two branches conflict in `NotificationService.swift` (3 hunks), `AppContainer.swift`,
  and `LiveSessionController.swift`. Both rework how notification callbacks are routed; taking this one
  first keeps the action-identifier gate as the base that #708 builds on.

Happy to rebase whichever way suits your merge queue.


---

## Follow-up review: the re-check was not atomic

**A separate actor call is still a time-of-check/time-of-use gap.** The re-check added above ran as its own `await` into `SessionRepository` — `sessionExists`, then `loadSession`, then `saveNotes`, three calls into an `actor` from a `@MainActor` method. Every one of those is a suspension point, and the main actor is free while each is in flight. `NotesController.deleteSession` (`App/NotesController.swift:914-916`) and the manual save at `:610` both reach the same repository the same way, so either can land between the check and the write. The delete case is the one the check existed to prevent: `saveNotes` calls `createDirectory`, so it recreates `sessions/<id>/` as an empty shell. The manual-save case overwrites notes the user just typed.

**Both guards now live inside the write.** `SessionRepository.saveGeneratedNotesIfAbsent(sessionID:template:markdown:generatedAt:)` checks existence, checks `hasNotes`, normalizes the heading against the session's current title and start date, and writes — one actor operation, no suspension between the check and the write. The caller switches on the returned outcome (`.written` / `.sessionMissing` / `.notesAlreadyExist`) and records the same two diagnostics breadcrumbs as before, so user-visible behaviour is unchanged in every non-racing case. Heading normalization moved into the repository because it needs the same metadata read that decides whether to write at all.

**Testing.** 738 tests, 0 failures (was 734). New `SessionRepositoryTests` coverage: the write path including the heading derived from the current title; a deleted session is not resurrected; hand-written notes survive; and a delete racing the write leaves no orphan `notes.md` in either serialization order.
