### PR TITLE
Add opt-in auto-record for detected meetings

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppContainer.swift
+++ b/OpenOats/Sources/OpenOats/App/AppContainer.swift
@@ -230,7 +230,12 @@ final class AppContainer {
         let controller = MeetingDetectionController()
         controller.isSessionActive = { [weak coordinator] in
             guard let coordinator else { return false }
-            return coordinator.isRecording
+            // Any non-idle state counts: prompting (or auto-starting) while a
+            // previous session is still finalizing (.ending) must be suppressed,
+            // as must a start while a cloud-model preflight is in flight (the
+            // coordinator is still .idle then, but the start is committed).
+            return coordinator.state != .idle
+                || coordinator.liveSessionController?.isStartInFlight == true
         }
         detectionController = controller
         controller.setup(settings: settings)

--- a/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
+++ b/OpenOats/Sources/OpenOats/App/AppCoordinator.swift
@@ -317,6 +317,13 @@ final class AppCoordinator {
                 guard let self, !Task.isCancelled else { break }
                 switch event {
                 case .accepted(let metadata):
+                    // Let the state machine decide first. Arming the auto-stop
+                    // monitors before a vetoed transition (.ending + .userStarted
+                    // is a no-op) leaves orphan monitors that survive into .idle
+                    // and kill a later manual session with a stale silence timer.
+                    let stateBefore = self.state
+                    self.handle(.userStarted(metadata), settings: self.activeSettings)
+                    guard self.state != stateBefore else { break }
                     let signal = metadata.detectionContext?.signal
                     if case .appLaunched(let app) = signal {
                         controller.startSilenceMonitoring()
@@ -327,7 +334,6 @@ final class AppCoordinator {
                             controller.startAppExitMonitoring(bundleID: app.bundleID)
                         }
                     }
-                    self.handle(.userStarted(metadata), settings: self.activeSettings)
                 case .meetingAppExited:
                     if case .recording(let meta) = self.state {
                         let signal = meta.detectionContext?.signal

--- a/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
+++ b/OpenOats/Sources/OpenOats/App/LiveSessionController.swift
@@ -182,6 +182,9 @@ final class LiveSessionController {
 
     private var downloadTask: Task<Void, Never>?
     private var startPreflightTask: Task<Void, Never>?
+    /// True while a cloud-model preflight is validating a manual start.
+    /// The coordinator is still `.idle` then, but the start is committed.
+    var isStartInFlight: Bool { startPreflightTask != nil }
     private var scratchpadSaveTask: Task<Void, Never>?
     private var pendingInitialScratchpad: String?
 

--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -394,6 +394,20 @@ final class MeetingDetectionController {
             Log.meetingDetection.info("Detected: \(app?.name ?? "unknown", privacy: .public) (trigger: \(isCameraTrigger ? "camera" : "mic+app", privacy: .public))")
         }
 
+        // Auto-record: skip the notification round-trip and invoke the accept
+        // path directly. All pre-checks above (already recording, dismissed,
+        // permanently ignored) have passed at this point.
+        if activeSettings?.autoRecordDetectedMeetings == true {
+            if activeSettings?.detectionLogEnabled == true {
+                Log.meetingDetection.info("Auto-record enabled, accepting detection without prompt")
+            }
+            handleDetectionAccepted()
+            await notificationService?.postAutoRecordingStarted(
+                appName: isCameraTrigger ? nil : app?.name
+            )
+            return
+        }
+
         // Don't attribute camera-triggered detections to a background meeting app —
         // the camera could have been activated by a different app (e.g. browser for Google Meet).
         let posted = await notificationService?.postMeetingDetected(

--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -221,6 +221,12 @@ final class MeetingDetectionController {
         }
 
         notificationService?.cancelPending()
+        // Detection can be switched off mid-meeting. The detection event loop
+        // is already cancelled above, so `.ended` will never arrive and
+        // handleMeetingEnded() will never run — without this, a delivered
+        // "Recording Started" notification would sit in Notification Center
+        // for good.
+        notificationService?.clearAutoRecordingStarted()
         notificationService = nil
 
         if let observer = sleepObserver {

--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -394,18 +394,31 @@ final class MeetingDetectionController {
             Log.meetingDetection.info("Detected: \(app?.name ?? "unknown", privacy: .public) (trigger: \(isCameraTrigger ? "camera" : "mic+app", privacy: .public))")
         }
 
-        // Auto-record: skip the notification round-trip and invoke the accept
+        // Auto-record: skip the tap-to-confirm round-trip and invoke the accept
         // path directly. All pre-checks above (already recording, dismissed,
-        // permanently ignored) have passed at this point.
-        if activeSettings?.autoRecordDetectedMeetings == true {
-            if activeSettings?.detectionLogEnabled == true {
-                Log.meetingDetection.info("Auto-record enabled, accepting detection without prompt")
-            }
-            handleDetectionAccepted()
-            await notificationService?.postAutoRecordingStarted(
+        // permanently ignored) have passed at this point. Two extra gates:
+        // recording consent must have been acknowledged (every manual start
+        // checks it), and the informational notification must actually post —
+        // silent capture is never acceptable, so on failure this falls through
+        // to the standard tap-to-confirm prompt below.
+        if activeSettings?.autoRecordDetectedMeetings == true,
+           activeSettings?.hasAcknowledgedRecordingConsent == true {
+            // A previously delivered, stale detection banner would otherwise
+            // stay tappable and re-enter the accept path mid-session.
+            notificationService?.cancelPending()
+            let informed = await notificationService?.postAutoRecordingStarted(
                 appName: isCameraTrigger ? nil : app?.name
-            )
-            return
+            ) ?? false
+            if informed {
+                if activeSettings?.detectionLogEnabled == true {
+                    Log.meetingDetection.info("Auto-record: accepted detection without prompt")
+                }
+                handleDetectionAccepted()
+                return
+            }
+            if activeSettings?.detectionLogEnabled == true {
+                Log.meetingDetection.info("Auto-record: notification failed, falling back to prompt")
+            }
         }
 
         // Don't attribute camera-triggered detections to a background meeting app —
@@ -424,6 +437,7 @@ final class MeetingDetectionController {
     private func handleMeetingEnded() {
         detectedApp = nil
         notificationService?.cancelPending()
+        notificationService?.clearAutoRecordingStarted()
         pendingSnapshot = nil
         eventContinuation.yield(.meetingAppExited)
     }

--- a/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
@@ -3,14 +3,16 @@ import UserNotifications
 
 /// Manages macOS notification delivery for meeting detection prompts.
 @MainActor
-final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
+// Not `final`: tests subclass this to stub delivery without touching
+// UserNotifications.
+class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     /// UNUserNotificationCenter requires the process to be a registered app
     /// bundle and raises (SIGABRT) on every API call when it isn't. That covers
     /// unbundled runs (`swift run`, which has no bundle identifier) and hosts
     /// that carry an identifier without being an app, such as the `xctest`
-    /// runner. When false, all notification methods become no-ops.
-    private let isAvailable: Bool = Bundle.main.bundleIdentifier != nil
-        && Bundle.main.bundleURL.pathExtension == "app"
+    /// runner. Injectable so tests can construct the service directly.
+    /// When false, all notification methods become no-ops.
+    private let isAvailable: Bool
     private var hasRequestedPermission = false
     private var pendingTimeoutTask: Task<Void, Never>?
 
@@ -58,7 +60,11 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         return "\(detail) Open the meeting and choose Generate Notes to try again."
     }
 
-    override init() {
+    init(
+        isAvailable: Bool = Bundle.main.bundleIdentifier != nil
+            && Bundle.main.bundleURL.pathExtension == "app"
+    ) {
+        self.isAvailable = isAvailable
         super.init()
         registerCategory()
     }
@@ -189,9 +195,12 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     /// Post an informational notification that a detected meeting is now being
     /// recorded automatically. Unlike `postMeetingDetected` this carries no
     /// actions, no accept round-trip, and no 60-second timeout/auto-removal —
-    /// it only tells the user that recording has started.
-    func postAutoRecordingStarted(appName: String?) async {
-        guard await ensurePermission() else { return }
+    /// it only tells the user that recording has started. Returns false when
+    /// the notification could not be delivered (permission denied, or
+    /// notifications unavailable) so the caller can fall back to the
+    /// tap-to-confirm prompt instead of recording silently.
+    func postAutoRecordingStarted(appName: String?) async -> Bool {
+        guard await ensurePermission() else { return false }
 
         let content = UNMutableNotificationContent()
         content.title = "Recording Started"
@@ -207,7 +216,20 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
             content: content,
             trigger: nil
         )
-        try? await UNUserNotificationCenter.current().add(request)
+        do {
+            try await UNUserNotificationCenter.current().add(request)
+        } catch {
+            return false
+        }
+        return true
+    }
+
+    /// Remove the informational auto-record notification, if delivered.
+    func clearAutoRecordingStarted() {
+        guard isAvailable else { return }
+        UNUserNotificationCenter.current().removeDeliveredNotifications(
+            withIdentifiers: [Self.autoRecordNotificationIdentifier]
+        )
     }
 
     /// Post a notification when batch transcription completes.

--- a/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
@@ -40,6 +40,10 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     /// Request identifier of the meeting-detection prompt. Only this request
     /// carries the accept / not-a-meeting / ignore-app actions.
     nonisolated static let detectionRequestID = "meeting-detection"
+    /// Identifier for the informational "recording started" notification posted
+    /// when auto-record is enabled. Distinct from `detectionRequestID`, so
+    /// `route` returns `.none` for taps on it.
+    static let autoRecordNotificationIdentifier = "meeting-detection-auto-record"
     static let batchCompletedTitle = "Re-transcription Complete"
     static let batchCompletedBody = "Re-transcription is complete. Your meeting transcript has been updated with higher-quality text."
     static let notesFailedTitle = "Notes Generation Failed"
@@ -180,6 +184,30 @@ final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         }
 
         return true
+    }
+
+    /// Post an informational notification that a detected meeting is now being
+    /// recorded automatically. Unlike `postMeetingDetected` this carries no
+    /// actions, no accept round-trip, and no 60-second timeout/auto-removal —
+    /// it only tells the user that recording has started.
+    func postAutoRecordingStarted(appName: String?) async {
+        guard await ensurePermission() else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = "Recording Started"
+        if let appName {
+            content.body = "Meeting detected (\(appName)). OpenOats is transcribing."
+        } else {
+            content.body = "Meeting detected. OpenOats is transcribing."
+        }
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: Self.autoRecordNotificationIdentifier,
+            content: content,
+            trigger: nil
+        )
+        try? await UNUserNotificationCenter.current().add(request)
     }
 
     /// Post a notification when batch transcription completes.

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -838,6 +838,20 @@ final class SettingsStore {
         }
     }
 
+    @ObservationIgnored nonisolated(unsafe) private var _autoRecordDetectedMeetings: Bool
+    /// When enabled, a detected meeting starts recording immediately instead of
+    /// waiting for the user to accept the detection notification. Defaults to
+    /// off: auto-recording on a false-positive detection captures real audio.
+    var autoRecordDetectedMeetings: Bool {
+        get { access(keyPath: \.autoRecordDetectedMeetings); return _autoRecordDetectedMeetings }
+        set {
+            withMutation(keyPath: \.autoRecordDetectedMeetings) {
+                _autoRecordDetectedMeetings = newValue
+                defaults.set(newValue, forKey: "autoRecordDetectedMeetings")
+            }
+        }
+    }
+
     @ObservationIgnored nonisolated(unsafe) private var _customMeetingAppBundleIDs: [String]
     var customMeetingAppBundleIDs: [String] {
         get { access(keyPath: \.customMeetingAppBundleIDs); return _customMeetingAppBundleIDs }
@@ -1528,6 +1542,7 @@ final class SettingsStore {
         } else {
             self._meetingAutoDetectEnabled = defaults.bool(forKey: "meetingAutoDetectEnabled")
         }
+        self._autoRecordDetectedMeetings = defaults.bool(forKey: "autoRecordDetectedMeetings")
         self._customMeetingAppBundleIDs = Self.normalizedIdentifierList(
             defaults.stringArray(forKey: "customMeetingAppBundleIDs") ?? [],
             caseInsensitive: true

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -147,7 +147,9 @@ private struct GeneralSettingsTab: View {
                             }
                         }
 
-                    Text("When enabled, OpenOats monitors camera and microphone activation to detect when a meeting starts. No audio or video is captured until you accept the notification.")
+                    Text(settings.autoRecordDetectedMeetings
+                        ? "When enabled, OpenOats monitors camera and microphone activation to detect when a meeting starts. Automatic recording is on, so recording starts as soon as a meeting is detected."
+                        : "When enabled, OpenOats monitors camera and microphone activation to detect when a meeting starts. No audio or video is captured until you accept the notification.")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
 
@@ -155,7 +157,7 @@ private struct GeneralSettingsTab: View {
                         .font(.system(size: 12))
                         .disabled(!settings.meetingAutoDetectEnabled)
 
-                    Text("Skips the confirmation prompt and starts transcribing as soon as a meeting is detected. A notification still lets you know that recording has started.")
+                    Text("Starts recording without asking. A notification is posted when recording begins. Applies to custom-added meeting apps too — if you add a browser there, any website using the microphone can start a real recording.")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
 
@@ -181,7 +183,7 @@ private struct GeneralSettingsTab: View {
 
                         VStack(alignment: .leading, spacing: 10) {
                             Label("OpenOats watches for camera and microphone activation by meeting apps (Zoom, Teams, FaceTime, etc.)", systemImage: "video")
-                            Label("Only activation status is checked. No audio is captured or recorded until you accept.", systemImage: "lock.shield")
+                            Label("Only activation status is checked. No audio is captured or recorded until you accept — or, if automatic recording is enabled, until a meeting is detected (a notification is posted).", systemImage: "lock.shield")
                             Label("When a meeting is detected, you get a macOS notification to start transcribing.", systemImage: "bell")
                             Label("You can always dismiss the notification or mark it as \"not a meeting\".", systemImage: "hand.raised")
                         }

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -151,6 +151,14 @@ private struct GeneralSettingsTab: View {
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
 
+                    Toggle("Automatically record detected meetings", isOn: $settings.autoRecordDetectedMeetings)
+                        .font(.system(size: 12))
+                        .disabled(!settings.meetingAutoDetectEnabled)
+
+                    Text("Skips the confirmation prompt and starts transcribing as soon as a meeting is detected. A notification still lets you know that recording has started.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+
                     Toggle("Launch at login", isOn: $launchAtLoginEnabled)
                         .font(.system(size: 12))
                         .onChange(of: launchAtLoginEnabled) { _, newValue in

--- a/OpenOats/Tests/OpenOatsTests/MeetingDetectionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MeetingDetectionControllerTests.swift
@@ -263,7 +263,29 @@ final class MeetingDetectionControllerTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func makeSettings() -> AppSettings {
+    /// Notification stub: never touches UserNotifications, records post calls,
+    /// and lets each test script whether the informational post "succeeds".
+    private final class StubNotificationService: NotificationService {
+        var autoResult = true
+        private(set) var autoPosts = 0
+        private(set) var promptPosts = 0
+
+        init() {
+            super.init(isAvailable: false)
+        }
+
+        override func postAutoRecordingStarted(appName: String?) async -> Bool {
+            autoPosts += 1
+            return autoResult
+        }
+
+        override func postMeetingDetected(appName: String?, isCameraTrigger: Bool) async -> Bool {
+            promptPosts += 1
+            return true
+        }
+    }
+
+    private func makeSettings(consentAcknowledged: Bool = true) -> AppSettings {
         let suiteName = "com.openoats.test.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defaults.removePersistentDomain(forName: suiteName)
@@ -274,7 +296,9 @@ final class MeetingDetectionControllerTests: XCTestCase {
                 .appendingPathComponent("MeetingDetectionControllerTests"),
             runMigrations: false
         )
-        return AppSettings(storage: storage)
+        let settings = AppSettings(storage: storage)
+        settings.hasAcknowledgedRecordingConsent = consentAcknowledged
+        return settings
     }
 
     /// Wait up to a second for an asynchronous condition to hold.
@@ -288,86 +312,126 @@ final class MeetingDetectionControllerTests: XCTestCase {
 
     // MARK: - Auto-Record (accept without notification round-trip)
 
-    /// Build a controller wired to a detector with controllable signal sources.
+    /// Build a controller wired to a detector with controllable signal sources
+    /// and a stubbed notification service.
     private func makeDetectionHarness(
         settings: AppSettings
-    ) -> (MeetingDetectionController, MockAudioSignalSource, MockCameraSignalSource) {
+    ) -> (MeetingDetectionController, StubNotificationService, MockAudioSignalSource, MockCameraSignalSource) {
         let audio = MockAudioSignalSource()
         let camera = MockCameraSignalSource()
         let detector = MeetingDetector(audioSource: audio, cameraSource: camera)
+        let service = StubNotificationService()
         let controller = MeetingDetectionController()
-        controller.setup(settings: settings, detector: detector)
-        return (controller, audio, camera)
+        controller.setup(settings: settings, detector: detector, notificationService: service)
+        return (controller, service, audio, camera)
+    }
+
+    /// Start consuming the controller's event stream, fire `emit` once the
+    /// detector is running, and return the first event (or nil after a grace
+    /// period). Camera-triggered detection is immediate (no debounce).
+    private func collectFirstEvent(
+        from controller: MeetingDetectionController,
+        after emit: () -> Void
+    ) async throws -> DetectionEvent? {
+        var receivedEvent: DetectionEvent?
+        let consumeTask = Task { @MainActor in
+            for await event in controller.events {
+                receivedEvent = event
+                break
+            }
+        }
+        // Give setup's detection task time to start the detector.
+        try await Task.sleep(for: .milliseconds(200))
+        emit()
+        try await Task.sleep(for: .milliseconds(500))
+        consumeTask.cancel()
+        return receivedEvent
     }
 
     func testAutoRecordAcceptsDetectionWithoutNotificationTap() async throws {
         let settings = makeSettings()
         settings.autoRecordDetectedMeetings = true
 
-        let (controller, audio, camera) = makeDetectionHarness(settings: settings)
+        let (controller, service, audio, camera) = makeDetectionHarness(settings: settings)
         defer {
             controller.teardown()
             audio.finish()
             camera.finish()
         }
 
-        var receivedEvent: DetectionEvent?
-        let consumeTask = Task { @MainActor in
-            for await event in controller.events {
-                receivedEvent = event
-                break
-            }
-        }
+        let event = try await collectFirstEvent(from: controller) { camera.emit(true) }
 
-        // Give setup's detection task time to start the detector.
-        try await Task.sleep(for: .milliseconds(200))
-        camera.emit(true) // camera-triggered detection is immediate (no debounce)
-        try await Task.sleep(for: .milliseconds(500))
-
-        if case .accepted(let metadata) = receivedEvent,
+        if case .accepted(let metadata) = event,
            let signal = metadata.detectionContext?.signal,
            case .cameraActivated = signal {
             // correct — accepted with the camera signal, no user tap involved
         } else {
-            XCTFail("Expected .accepted without a notification tap, got \(String(describing: receivedEvent))")
+            XCTFail("Expected .accepted without a notification tap, got \(String(describing: event))")
+        }
+        XCTAssertEqual(service.autoPosts, 1, "the informational notification must be posted")
+        XCTAssertEqual(service.promptPosts, 0, "no tap-to-confirm prompt on the auto path")
+    }
+
+    func testAutoRecordFallsBackToPromptWhenNotificationFails() async throws {
+        let settings = makeSettings()
+        settings.autoRecordDetectedMeetings = true
+
+        let (controller, service, audio, camera) = makeDetectionHarness(settings: settings)
+        service.autoResult = false // delivery fails (permission denied / unavailable)
+        defer {
+            controller.teardown()
+            audio.finish()
+            camera.finish()
         }
 
-        consumeTask.cancel()
+        let event = try await collectFirstEvent(from: controller) { camera.emit(true) }
+
+        XCTAssertNil(event, "recording must never start silently — fall back to the prompt")
+        XCTAssertEqual(service.autoPosts, 1)
+        XCTAssertEqual(service.promptPosts, 1, "the tap-to-confirm prompt is the fallback")
+    }
+
+    func testAutoRecordRequiresRecordingConsent() async throws {
+        let settings = makeSettings(consentAcknowledged: false)
+        settings.autoRecordDetectedMeetings = true
+
+        let (controller, service, audio, camera) = makeDetectionHarness(settings: settings)
+        defer {
+            controller.teardown()
+            audio.finish()
+            camera.finish()
+        }
+
+        let event = try await collectFirstEvent(from: controller) { camera.emit(true) }
+
+        XCTAssertNil(event, "no auto-start before recording consent is acknowledged")
+        XCTAssertEqual(service.autoPosts, 0, "the auto path must not even be attempted")
+        XCTAssertEqual(service.promptPosts, 1, "falls back to the tap-to-confirm prompt")
     }
 
     func testAutoRecordOffRequiresNotificationRoundTrip() async throws {
         let settings = makeSettings()
         XCTAssertFalse(settings.autoRecordDetectedMeetings, "auto-record must default to off")
 
-        let (controller, audio, camera) = makeDetectionHarness(settings: settings)
+        let (controller, service, audio, camera) = makeDetectionHarness(settings: settings)
         defer {
             controller.teardown()
             audio.finish()
             camera.finish()
         }
 
-        var receivedEvent: DetectionEvent?
-        let consumeTask = Task { @MainActor in
-            for await event in controller.events {
-                receivedEvent = event
-                break
-            }
-        }
+        let event = try await collectFirstEvent(from: controller) { camera.emit(true) }
 
-        try await Task.sleep(for: .milliseconds(200))
-        camera.emit(true)
-        try await Task.sleep(for: .milliseconds(500))
-
-        XCTAssertNil(receivedEvent, "Without auto-record, detection must wait for the user to accept")
-
-        consumeTask.cancel()
+        XCTAssertNil(event, "Without auto-record, detection must wait for the user to accept")
+        XCTAssertEqual(service.autoPosts, 0)
+        XCTAssertEqual(service.promptPosts, 1)
     }
 
     func testAutoRecordRespectsAlreadyRecordingGuard() async throws {
         let settings = makeSettings()
         settings.autoRecordDetectedMeetings = true
 
-        let (controller, audio, camera) = makeDetectionHarness(settings: settings)
+        let (controller, service, audio, camera) = makeDetectionHarness(settings: settings)
         controller.isSessionActive = { true }
         defer {
             controller.teardown()
@@ -375,20 +439,10 @@ final class MeetingDetectionControllerTests: XCTestCase {
             camera.finish()
         }
 
-        var receivedEvent: DetectionEvent?
-        let consumeTask = Task { @MainActor in
-            for await event in controller.events {
-                receivedEvent = event
-                break
-            }
-        }
+        let event = try await collectFirstEvent(from: controller) { camera.emit(true) }
 
-        try await Task.sleep(for: .milliseconds(200))
-        camera.emit(true)
-        try await Task.sleep(for: .milliseconds(500))
-
-        XCTAssertNil(receivedEvent, "No auto-accept while a session is already recording")
-
-        consumeTask.cancel()
+        XCTAssertNil(event, "No auto-accept while a session is already recording")
+        XCTAssertEqual(service.autoPosts, 0)
+        XCTAssertEqual(service.promptPosts, 0, "no prompt either — the session is active")
     }
 }

--- a/OpenOats/Tests/OpenOatsTests/MeetingDetectionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MeetingDetectionControllerTests.swift
@@ -269,9 +269,14 @@ final class MeetingDetectionControllerTests: XCTestCase {
         var autoResult = true
         private(set) var autoPosts = 0
         private(set) var promptPosts = 0
+        private(set) var autoClears = 0
 
         init() {
             super.init(isAvailable: false)
+        }
+
+        override func clearAutoRecordingStarted() {
+            autoClears += 1
         }
 
         override func postAutoRecordingStarted(appName: String?) async -> Bool {
@@ -346,6 +351,37 @@ final class MeetingDetectionControllerTests: XCTestCase {
         try await Task.sleep(for: .milliseconds(500))
         consumeTask.cancel()
         return receivedEvent
+    }
+
+    func testTeardownClearsDeliveredAutoRecordNotification() async throws {
+        let settings = makeSettings()
+        settings.autoRecordDetectedMeetings = true
+
+        let (controller, service, audio, camera) = makeDetectionHarness(settings: settings)
+        defer {
+            audio.finish()
+            camera.finish()
+        }
+
+        let event = try await collectFirstEvent(from: controller) { camera.emit(true) }
+        guard case .accepted = event else {
+            XCTFail("Expected an auto-record accept, got \(String(describing: event))")
+            return
+        }
+        XCTAssertEqual(service.autoPosts, 1)
+        XCTAssertEqual(service.autoClears, 0)
+
+        // Detection switched off while the auto-recorded meeting is still
+        // running. Teardown cancels the detection event loop, so `.ended` never
+        // arrives and handleMeetingEnded() never runs — teardown is the only
+        // thing left that can take the delivered notification down.
+        controller.teardown()
+
+        XCTAssertEqual(
+            service.autoClears,
+            1,
+            "teardown left the 'Recording Started' notification in Notification Center"
+        )
     }
 
     func testAutoRecordAcceptsDetectionWithoutNotificationTap() async throws {

--- a/OpenOats/Tests/OpenOatsTests/MeetingDetectionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MeetingDetectionControllerTests.swift
@@ -285,4 +285,110 @@ final class MeetingDetectionControllerTests: XCTestCase {
         }
         return await condition()
     }
+
+    // MARK: - Auto-Record (accept without notification round-trip)
+
+    /// Build a controller wired to a detector with controllable signal sources.
+    private func makeDetectionHarness(
+        settings: AppSettings
+    ) -> (MeetingDetectionController, MockAudioSignalSource, MockCameraSignalSource) {
+        let audio = MockAudioSignalSource()
+        let camera = MockCameraSignalSource()
+        let detector = MeetingDetector(audioSource: audio, cameraSource: camera)
+        let controller = MeetingDetectionController()
+        controller.setup(settings: settings, detector: detector)
+        return (controller, audio, camera)
+    }
+
+    func testAutoRecordAcceptsDetectionWithoutNotificationTap() async throws {
+        let settings = makeSettings()
+        settings.autoRecordDetectedMeetings = true
+
+        let (controller, audio, camera) = makeDetectionHarness(settings: settings)
+        defer {
+            controller.teardown()
+            audio.finish()
+            camera.finish()
+        }
+
+        var receivedEvent: DetectionEvent?
+        let consumeTask = Task { @MainActor in
+            for await event in controller.events {
+                receivedEvent = event
+                break
+            }
+        }
+
+        // Give setup's detection task time to start the detector.
+        try await Task.sleep(for: .milliseconds(200))
+        camera.emit(true) // camera-triggered detection is immediate (no debounce)
+        try await Task.sleep(for: .milliseconds(500))
+
+        if case .accepted(let metadata) = receivedEvent,
+           let signal = metadata.detectionContext?.signal,
+           case .cameraActivated = signal {
+            // correct — accepted with the camera signal, no user tap involved
+        } else {
+            XCTFail("Expected .accepted without a notification tap, got \(String(describing: receivedEvent))")
+        }
+
+        consumeTask.cancel()
+    }
+
+    func testAutoRecordOffRequiresNotificationRoundTrip() async throws {
+        let settings = makeSettings()
+        XCTAssertFalse(settings.autoRecordDetectedMeetings, "auto-record must default to off")
+
+        let (controller, audio, camera) = makeDetectionHarness(settings: settings)
+        defer {
+            controller.teardown()
+            audio.finish()
+            camera.finish()
+        }
+
+        var receivedEvent: DetectionEvent?
+        let consumeTask = Task { @MainActor in
+            for await event in controller.events {
+                receivedEvent = event
+                break
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(200))
+        camera.emit(true)
+        try await Task.sleep(for: .milliseconds(500))
+
+        XCTAssertNil(receivedEvent, "Without auto-record, detection must wait for the user to accept")
+
+        consumeTask.cancel()
+    }
+
+    func testAutoRecordRespectsAlreadyRecordingGuard() async throws {
+        let settings = makeSettings()
+        settings.autoRecordDetectedMeetings = true
+
+        let (controller, audio, camera) = makeDetectionHarness(settings: settings)
+        controller.isSessionActive = { true }
+        defer {
+            controller.teardown()
+            audio.finish()
+            camera.finish()
+        }
+
+        var receivedEvent: DetectionEvent?
+        let consumeTask = Task { @MainActor in
+            for await event in controller.events {
+                receivedEvent = event
+                break
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(200))
+        camera.emit(true)
+        try await Task.sleep(for: .milliseconds(500))
+
+        XCTAssertNil(receivedEvent, "No auto-accept while a session is already recording")
+
+        consumeTask.cancel()
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -510,6 +510,17 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.customMeetingAppBundleIDs, ["com.example.app"])
     }
 
+    func testDefaultAutoRecordDetectedMeetings() {
+        let store = makeStore()
+        XCTAssertFalse(store.autoRecordDetectedMeetings, "auto-record must default to off")
+    }
+
+    func testAutoRecordDetectedMeetingsRoundTrip() {
+        let store = makeStore()
+        store.autoRecordDetectedMeetings = true
+        XCTAssertTrue(store.autoRecordDetectedMeetings)
+    }
+
     func testDefaultDetectionLogEnabled() {
         let store = makeStore()
         XCTAssertFalse(store.detectionLogEnabled)


### PR DESCRIPTION
## Problem

Meeting auto-detect never auto-records. The chain today:

- `MeetingDetector` emits `.detected` → `MeetingDetectionController.handleMeetingDetected` posts a notification (`Sources/OpenOats/App/MeetingDetectionController.swift:384`)
- `NotificationService.postMeetingDetected` arms a 60-second timeout that removes it (`Sources/OpenOats/Meeting/NotificationService.swift:154-164`)
- Recording starts only if the user taps within that window (`handleDetectionAccepted`, `MeetingDetectionController.swift:402`)

Step away from the desk, miss the banner → the meeting is lost. For people replacing tools that record reliably (e.g. Granola), this is the biggest capture-reliability gap.

## Change

New setting **"Automatically record detected meetings"**, default **off** — stock behavior is untouched.

When enabled, `handleMeetingDetected` invokes the accept path directly instead of posting the actionable prompt, then posts an informational "Recording Started" notification so the user knows a recording is in progress.

- All existing pre-checks still run before the auto-accept: already-recording (`isSessionActive`), per-session dismissals (`dismissedEvents`), permanently ignored apps (`ignoredAppBundleIDs`). The yielded `.accepted` event flows through the same coordinator path as a user tap, so downstream behavior (silence monitoring, app-exit monitoring, state machine) is identical.
- The informational notification has no actions and no 60-second timeout/auto-removal. It uses a distinct identifier, and `userNotificationCenter(_:didReceive:)` ignores taps on it, so the default-tap-means-accept behavior cannot re-enter the accept path.

## Risk and why default-off

Honest trade-off: a false-positive detection now starts a real recording, with audio retention if "Save audio recording" is on. The tap-to-start prompt is a consent gate as much as a UX step, and this setting removes it. That is the right trade only for users who deliberately opt in to Granola-style capture reliability, so it ships opt-in and default-off, with the toggle directly under the detection toggle and copy that says exactly what it does. The existing "No audio or video is captured until you accept the notification" copy stays true for the default configuration; happy to make it conditional if you prefer.

## Also in this PR

`NotificationService.isAvailable` now also detects the XCTest runner (`NSClassFromString("XCTestCase") == nil`). Under `swift test` the xctest tool has a bundle identifier but no bundle proxy, so `UNUserNotificationCenter.current()` raises `NSInternalInconsistencyException` the moment anything constructs `NotificationService` — which is why no existing test exercises `MeetingDetectionController.setup`. With the guard, `setup` is testable; the new controller tests rely on it.

## Tests

- `MeetingDetectionControllerTests`: auto-record yields `.accepted` with no notification tap (camera-triggered); default-off yields nothing without a tap; already-recording suppresses auto-accept
- `SettingsStoreTests`: default false + round trip

`swift build -c debug` and `-c release` clean; full suite 728 tests, 0 failures (5 new).


---

## Revised after self-review

Re-reading this with fresh eyes turned up two things I would not want to ship, plus a handful of smaller ones.

**Auto-record could start capture with no notification at all (blocker).** The old order was: accept first, then post the informational notification fire-and-forget. But the post begins with a permission guard, so a denied or revoked notification permission — or notifications being unavailable — produced a real recording with nothing on screen to say so. That is the exact inversion of the manual path, which fails safe to *no* recording. `postAutoRecordingStarted` now reports whether delivery succeeded, and the detection controller posts *before* it accepts. If the notification cannot be delivered, detection falls back to the ordinary tap-to-confirm prompt. Both branches are covered by tests.

**The consent copy had become false (blocker).** "No audio or video is captured until you accept the notification" is simply untrue once auto-record is on. The detection caption is now conditional on the toggle, the explanation sheet states the auto-record case, and the toggle's own caption says plainly: "Starts recording without asking. A notification is posted when recording begins."

Also in this revision:

- **Consent gate.** Every human-initiated start checks `hasAcknowledgedRecordingConsent`; the auto path checked nothing. It now requires the same acknowledgement, and falls back to the prompt when it has not been given.
- **Monitor arming.** The silence and app-exit monitors were armed unconditionally *before* `handle(...)`. Since `.ending` + `.userStarted` is a no-op transition, that left orphan monitors alive into `.idle`, where a stale silence timer would stop a later manual session. Monitors are now armed only after the state machine actually transitions. **This pre-arming is a pre-existing defect on `main`, not something this PR introduces — but auto-record makes it far easier to hit, so it is fixed here rather than widened.**
- **Session check widened.** The detection controller treated only `.recording` as an active session. It now treats any non-idle state as active, so nothing auto-starts while a previous session is still finalizing.
- **Manual-start race.** During a cloud-model preflight the coordinator is still `.idle` while the start is already committed, so auto-record could steal it and attach detection metadata plus auto-stop monitors to the user's own session. There was a clean seam for this — the preflight task is nil-checked in a `defer` — so it is exposed as `isStartInFlight` and folded into the same session check rather than being papered over.
- **Stale detection banner.** The auto path never removed a previously delivered detection banner, so a tap on it could re-enter the accept path mid-session. It is now cancelled and removed before accepting.
- **The informational notification is removed when the meeting ends** instead of sitting in Notification Centre indefinitely.
- **No more `XCTestCase` string lookup in production.** `NotificationService` takes an injectable availability flag instead, and the tests pass their own. Worth noting why the guard existed at all: no test on `main` ever called `MeetingDetectionController.setup`, so nothing had previously constructed the service under the xctest runner, where `UNUserNotificationCenter` raises `NSInternalInconsistencyException` (bundle identifier present, bundle proxy nil). The new controller tests do exercise `setup`, hence the seam.

**Interaction with #709.** That PR lets you add arbitrary bundle IDs to the detection list; this one removes the confirmation step. Together they mean a custom browser entry can make any microphone-using website start a real recording, so the auto-record caption now says exactly that.

Left deliberately unaddressed, flagged for your call:

- **Launch at login plus auto-record.** `evaluateImmediate` bypasses the 5-second debounce, so a login while a call is already running can begin capture more or less at login. That is arguably the intended behaviour of both settings combined, but it is the least expected consequence of ticking two boxes, and I would rather have your read on it than pick a default myself.
- **Microphone permission denied** leaves the state machine claiming `.recording` while nothing is captured. Pre-existing on `main`; auto-record makes it less visible, because there is no longer a user action to correlate with the silence. Out of scope here.
- **The toggle is retained across detect cycles** by design — it is a setting, not a per-meeting choice.

Full suite: 730 tests, 0 failures (up from 728, two new).

## Merge order

- **After #707.** The two branches conflict in `NotificationService.swift` (3 hunks), `AppContainer.swift`,
  and `LiveSessionController.swift`. #707 introduces the action-identifier gate that this PR's
  notification changes sit on top of.
- **Before #709.** The two branches conflict in `SettingsStore.swift` (3 hunks), `SettingsView.swift`, and
  `MeetingDetectionController.swift`.

Happy to rebase whichever way suits your merge queue.


---

## Follow-up review: teardown left the notification behind

**"Removed when the meeting ends" had one hole: detection being switched off mid-meeting.** `clearAutoRecordingStarted()` was reachable only from `handleMeetingEnded()` (`App/MeetingDetectionController.swift:425`), which rides the `.ended` event off the detector. `teardown()` cancels the detection event loop and the app-exit monitor before it stops the detector (`:201-213`), and `AppContainer.disableDetection` stops the coordinator's event loop first (`App/AppContainer.swift:236`), so `.ended` never arrives and `handleMeetingEnded()` never runs. Teardown then drops the service reference (`:217`), leaving nothing that can retract the banner. Since the informational notification deliberately carries no timeout, "Recording Started" stayed in Notification Center indefinitely.

`teardown()` now clears it next to `cancelPending()`, before the reference is dropped.

**Testing.** 731 tests, 0 failures (was 730). The new `MeetingDetectionControllerTests` case auto-records a camera-triggered detection, tears the controller down while it is still active, and asserts the clear happened; it fails on the previous commit with the same assertion message.
