### PR TITLE
Surface custom meeting apps in Settings and apply edits live

### DIFF
--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -208,10 +208,17 @@ final class MeetingDetectionController {
         appExitMonitorTask?.cancel()
         appExitMonitorTask = nil
 
-        Task {
-            await meetingDetector?.stop()
-        }
+        // Capture the detector first: the task body reads its captures when it
+        // runs, which is after this method returns, so reading the property
+        // there would find the nil below and stop nothing. The abandoned
+        // detector would keep its mic and camera monitors alive for the life of
+        // the process — once per detection restart, and editing the custom
+        // meeting-app list restarts detection.
+        let detector = meetingDetector
         meetingDetector = nil
+        Task {
+            await detector?.stop()
+        }
 
         notificationService?.cancelPending()
         notificationService = nil

--- a/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
+++ b/OpenOats/Sources/OpenOats/App/MeetingDetectionController.swift
@@ -231,6 +231,14 @@ final class MeetingDetectionController {
         Log.meetingDetection.info("Detection system stopped")
     }
 
+    /// Re-seed dismissals carried across a detector rebuild. Editing the custom
+    /// meeting-app list rebuilds the detector, but that is not a new session:
+    /// the "Not a Meeting" choices the user already made must survive it.
+    /// Turning auto-detect off is a real stop, and `teardown` still clears them.
+    func restoreDismissedEvents(_ events: Set<DismissKey>) {
+        dismissedEvents.formUnion(events)
+    }
+
     // MARK: - Sleep Observer
 
     private func installSleepObserver() {

--- a/OpenOats/Sources/OpenOats/Meeting/MeetingDetector.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/MeetingDetector.swift
@@ -157,7 +157,9 @@ actor MeetingDetector {
     private let knownApps: [MeetingAppEntry]
     private let customBundleIDs: [String]
     private let selfBundleID: String
-    private let knownBundleIDs: Set<String>
+    /// Resolved detection set: bundled defaults plus user additions, minus the
+    /// app's own bundle ID. Non-private so tests can assert the merge.
+    let knownBundleIDs: Set<String>
 
     /// Set to true once detection is confirmed.
     private(set) var isActive = false

--- a/OpenOats/Sources/OpenOats/Meeting/MeetingDetector.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/MeetingDetector.swift
@@ -157,9 +157,8 @@ actor MeetingDetector {
     private let knownApps: [MeetingAppEntry]
     private let customBundleIDs: [String]
     private let selfBundleID: String
-    /// Resolved detection set: bundled defaults plus user additions, minus the
-    /// app's own bundle ID. Non-private so tests can assert the merge.
-    let knownBundleIDs: Set<String>
+    /// Resolved detection set, case-folded. Built by `resolveKnownBundleIDs`.
+    private let knownBundleIDs: Set<String>
 
     /// Set to true once detection is confirmed.
     private(set) var isActive = false
@@ -200,8 +199,10 @@ actor MeetingDetector {
         self.selfBundleID = Bundle.main.bundleIdentifier ?? "com.openoats.app"
 
         self.knownApps = Self.defaultMeetingApps
-        self.knownBundleIDs = Set(Self.defaultMeetingApps.map(\.bundleID) + customBundleIDs)
-            .subtracting([selfBundleID])
+        self.knownBundleIDs = Self.resolveKnownBundleIDs(
+            custom: customBundleIDs,
+            selfID: selfBundleID
+        )
 
         var capturedContinuation: AsyncStream<MeetingDetectionEvent>.Continuation!
         self.events = AsyncStream { continuation in
@@ -362,9 +363,10 @@ actor MeetingDetector {
 
         for app in runningApps {
             guard let bundleID = app.bundleIdentifier else { continue }
-            if knownBundleIDs.contains(bundleID) {
+            let folded = bundleID.lowercased()
+            if knownBundleIDs.contains(folded) {
                 let name = app.localizedName
-                    ?? knownApps.first(where: { $0.bundleID == bundleID })?.displayName
+                    ?? knownApps.first(where: { $0.bundleID.lowercased() == folded })?.displayName
                     ?? bundleID
                 return MeetingApp(bundleID: bundleID, name: name)
             }
@@ -376,6 +378,28 @@ actor MeetingDetector {
 
     static var bundledMeetingApps: [MeetingAppEntry] {
         defaultMeetingApps
+    }
+
+    /// Merge the bundled defaults with the user's custom bundle identifiers and
+    /// drop the app's own identifier. Bundle identifiers are compared without
+    /// regard to case — "us.Zoom.xos" is the same app as "us.zoom.xos" — so the
+    /// result is case-folded, and every lookup folds the incoming identifier too.
+    /// Pure, so the merge can be tested without standing up a detector.
+    static func resolveKnownBundleIDs(
+        defaults: [MeetingAppEntry] = bundledMeetingApps,
+        custom: [String],
+        selfID: String
+    ) -> Set<String> {
+        let merged = defaults.map(\.bundleID) + custom
+        return Set(merged.map { $0.lowercased() }).subtracting([selfID.lowercased()])
+    }
+
+    /// True when the identifier is already one of the bundled defaults, so the
+    /// UI can refuse an addition that would look removable but never be removed
+    /// from detection. Case- and whitespace-insensitive.
+    static func isBundledMeetingApp(_ bundleID: String) -> Bool {
+        let folded = bundleID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return bundledMeetingApps.contains { $0.bundleID.lowercased() == folded }
     }
 
     private static let defaultMeetingApps: [MeetingAppEntry] = [

--- a/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
+++ b/OpenOats/Sources/OpenOats/Meeting/NotificationService.swift
@@ -4,11 +4,13 @@ import UserNotifications
 /// Manages macOS notification delivery for meeting detection prompts.
 @MainActor
 final class NotificationService: NSObject, UNUserNotificationCenterDelegate {
-    /// UNUserNotificationCenter requires a valid bundle identifier and will
-    /// assert (SIGABRT) on every API call when one isn't present. This is the
-    /// case when the app is built and run unbundled (e.g. `swift run`).
-    /// When false, all notification methods become no-ops.
+    /// UNUserNotificationCenter requires the process to be a registered app
+    /// bundle and raises (SIGABRT) on every API call when it isn't. That covers
+    /// unbundled runs (`swift run`, which has no bundle identifier) and hosts
+    /// that carry an identifier without being an app, such as the `xctest`
+    /// runner. When false, all notification methods become no-ops.
     private let isAvailable: Bool = Bundle.main.bundleIdentifier != nil
+        && Bundle.main.bundleURL.pathExtension == "app"
     private var hasRequestedPermission = false
     private var pendingTimeoutTask: Task<Void, Never>?
 

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -835,8 +835,9 @@ final class SettingsStore {
         get { access(keyPath: \.customMeetingAppBundleIDs); return _customMeetingAppBundleIDs }
         set {
             withMutation(keyPath: \.customMeetingAppBundleIDs) {
-                _customMeetingAppBundleIDs = newValue
-                defaults.set(newValue, forKey: "customMeetingAppBundleIDs")
+                let normalized = Self.normalizedIdentifierList(newValue)
+                _customMeetingAppBundleIDs = normalized
+                defaults.set(normalized, forKey: "customMeetingAppBundleIDs")
             }
         }
     }
@@ -1519,7 +1520,9 @@ final class SettingsStore {
         } else {
             self._meetingAutoDetectEnabled = defaults.bool(forKey: "meetingAutoDetectEnabled")
         }
-        self._customMeetingAppBundleIDs = defaults.stringArray(forKey: "customMeetingAppBundleIDs") ?? []
+        self._customMeetingAppBundleIDs = Self.normalizedIdentifierList(
+            defaults.stringArray(forKey: "customMeetingAppBundleIDs") ?? []
+        )
         self._ignoredAppBundleIDs = defaults.stringArray(forKey: "ignoredAppBundleIDs") ?? []
         // Canonical timeout is seconds; migrate from the legacy minutes key.
         let silenceSeconds: Int

--- a/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
+++ b/OpenOats/Sources/OpenOats/Settings/SettingsStore.swift
@@ -13,13 +13,21 @@ final class SettingsStore {
     private static let enableBatchRetranscriptionLegacyKey = "enableBatchRefinement"
     @ObservationIgnored private var loadedSecretKeys: Set<String> = []
 
-    private static func normalizedIdentifierList(_ values: [String]) -> [String] {
+    /// Trim, drop empties, and deduplicate an identifier list, preserving order.
+    /// Pass `caseInsensitive: true` for identifiers that are matched without
+    /// regard to case (bundle identifiers); calendar identifiers are opaque and
+    /// stay case-sensitive. The first-seen spelling is the one kept.
+    private static func normalizedIdentifierList(
+        _ values: [String],
+        caseInsensitive: Bool = false
+    ) -> [String] {
         var result: [String] = []
         var seen: Set<String> = []
         for rawValue in values {
             let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { continue }
-            guard seen.insert(trimmed).inserted else { continue }
+            let key = caseInsensitive ? trimmed.lowercased() : trimmed
+            guard seen.insert(key).inserted else { continue }
             result.append(trimmed)
         }
         return result
@@ -835,7 +843,7 @@ final class SettingsStore {
         get { access(keyPath: \.customMeetingAppBundleIDs); return _customMeetingAppBundleIDs }
         set {
             withMutation(keyPath: \.customMeetingAppBundleIDs) {
-                let normalized = Self.normalizedIdentifierList(newValue)
+                let normalized = Self.normalizedIdentifierList(newValue, caseInsensitive: true)
                 _customMeetingAppBundleIDs = normalized
                 defaults.set(normalized, forKey: "customMeetingAppBundleIDs")
             }
@@ -1521,7 +1529,8 @@ final class SettingsStore {
             self._meetingAutoDetectEnabled = defaults.bool(forKey: "meetingAutoDetectEnabled")
         }
         self._customMeetingAppBundleIDs = Self.normalizedIdentifierList(
-            defaults.stringArray(forKey: "customMeetingAppBundleIDs") ?? []
+            defaults.stringArray(forKey: "customMeetingAppBundleIDs") ?? [],
+            caseInsensitive: true
         )
         self._ignoredAppBundleIDs = defaults.stringArray(forKey: "ignoredAppBundleIDs") ?? []
         // Canonical timeout is seconds; migrate from the legacy minutes key.

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -21,6 +21,8 @@ struct ContentView: View {
     @State private var showOnboarding = false
     @State private var showConsentSheet = false
     @State private var pendingControlBarAction: ControlBarAction?
+    /// A custom meeting-app list edit made mid-recording, waiting for idle.
+    @State private var pendingDetectionAppListRestart = false
 
     var body: some View {
         bodyWithModifiers
@@ -365,10 +367,22 @@ struct ContentView: View {
             // MeetingDetector snapshots the custom app list at setup, so edits
             // only apply to a fresh detector. Restart detection to pick them up,
             // but never mid-recording — teardown would cancel the silence and
-            // app-exit monitors of the live session.
-            guard settings.meetingAutoDetectEnabled, !coordinator.isRecording else { return }
-            container.disableDetection(coordinator: coordinator)
-            container.enableDetection(settings: settings, coordinator: coordinator)
+            // app-exit monitors of the live session. Remember the edit instead
+            // and apply it when the session is over, rather than dropping it.
+            guard settings.meetingAutoDetectEnabled else { return }
+            guard coordinator.state == .idle else {
+                pendingDetectionAppListRestart = true
+                return
+            }
+            restartDetectionForAppListChange()
+        }
+        .onChange(of: coordinator.state) {
+            // Apply a custom-app-list edit that arrived while a session was
+            // running, now that the session has finished finalizing.
+            guard coordinator.state == .idle, pendingDetectionAppListRestart else { return }
+            pendingDetectionAppListRestart = false
+            guard settings.meetingAutoDetectEnabled else { return }
+            restartDetectionForAppListChange()
         }
         .onChange(of: settings.calendarIntegrationEnabled) {
             container.updateCalendarIntegration(enabled: settings.calendarIntegrationEnabled)
@@ -404,6 +418,22 @@ struct ContentView: View {
     }
 
     // MARK: - Actions
+
+    /// Rebuild the detector so a custom meeting-app list edit takes effect.
+    /// Dismissals carry across, because a list edit is not a new session. The
+    /// immediate re-evaluation matters most for the motivating case: a fresh
+    /// CoreAudioSignalSource only emits on transitions, so an app added while
+    /// its call is already running would go unnoticed until the microphone
+    /// next cycled.
+    private func restartDetectionForAppListChange() {
+        let preservedDismissals = container.detectionController?.dismissedEvents ?? []
+        container.disableDetection(coordinator: coordinator)
+        container.enableDetection(settings: settings, coordinator: coordinator)
+        container.detectionController?.restoreDismissedEvents(preservedDismissals)
+        Task {
+            await container.detectionController?.evaluateImmediate()
+        }
+    }
 
     private func startSession() {
         guard settings.hasAcknowledgedRecordingConsent else {

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -361,6 +361,15 @@ struct ContentView: View {
                 container.disableDetection(coordinator: coordinator)
             }
         }
+        .onChange(of: settings.customMeetingAppBundleIDs) {
+            // MeetingDetector snapshots the custom app list at setup, so edits
+            // only apply to a fresh detector. Restart detection to pick them up,
+            // but never mid-recording — teardown would cancel the silence and
+            // app-exit monitors of the live session.
+            guard settings.meetingAutoDetectEnabled, !coordinator.isRecording else { return }
+            container.disableDetection(coordinator: coordinator)
+            container.enableDetection(settings: settings, coordinator: coordinator)
+        }
         .onChange(of: settings.calendarIntegrationEnabled) {
             container.updateCalendarIntegration(enabled: settings.calendarIntegrationEnabled)
         }

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -68,6 +68,7 @@ private struct GeneralSettingsTab: View {
     @State private var showAutoDetectExplanation = false
     @State private var launchAtLoginEnabled = false
     @State private var showAdvancedDetection = false
+    @State private var newCustomMeetingAppBundleID = ""
     @State private var showWizard = false
     @State private var diagnosticsExportMessage: String?
     @State private var diagnosticsExportHadError = false
@@ -262,6 +263,40 @@ private struct GeneralSettingsTab: View {
                     }
                 }
 
+                if settings.meetingAutoDetectEnabled {
+                    Section("Custom Meeting Apps") {
+                        Text("Bundle identifiers treated as meeting apps for microphone-based detection, in addition to the built-in list — e.g. the browser you use for Google Meet or Teams. Browsers are not built in because any website using the microphone would trigger detection.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                        ForEach(settings.customMeetingAppBundleIDs, id: \.self) { bundleID in
+                            HStack {
+                                Text(bundleID)
+                                    .font(.system(size: 12, design: .monospaced))
+                                Spacer()
+                                Button {
+                                    settings.customMeetingAppBundleIDs.removeAll { $0 == bundleID }
+                                } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundStyle(.secondary)
+                                }
+                                .buttonStyle(.plain)
+                                .help("Remove this app")
+                            }
+                        }
+                        HStack {
+                            TextField("com.example.app", text: $newCustomMeetingAppBundleID)
+                                .font(.system(size: 12, design: .monospaced))
+                                .textFieldStyle(.roundedBorder)
+                                .onSubmit { addCustomMeetingApp() }
+                            Button("Add") { addCustomMeetingApp() }
+                                .disabled(
+                                    newCustomMeetingAppBundleID
+                                        .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                                )
+                        }
+                    }
+                }
+
                 Section("Privacy") {
                     Toggle("Hide from screen sharing", isOn: $settings.hideFromScreenShare)
                         .font(.system(size: 12))
@@ -331,6 +366,14 @@ private struct GeneralSettingsTab: View {
             )
             .frame(width: 500, height: 550)
         }
+    }
+
+    private func addCustomMeetingApp() {
+        let trimmed = newCustomMeetingAppBundleID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        // The settings setter normalizes the stored list (trims, dedupes).
+        settings.customMeetingAppBundleIDs = settings.customMeetingAppBundleIDs + [trimmed]
+        newCustomMeetingAppBundleID = ""
     }
 
     private func chooseNotesFolder() {

--- a/OpenOats/Sources/OpenOats/Views/SettingsView.swift
+++ b/OpenOats/Sources/OpenOats/Views/SettingsView.swift
@@ -69,6 +69,7 @@ private struct GeneralSettingsTab: View {
     @State private var launchAtLoginEnabled = false
     @State private var showAdvancedDetection = false
     @State private var newCustomMeetingAppBundleID = ""
+    @State private var customMeetingAppNotice: String?
     @State private var showWizard = false
     @State private var diagnosticsExportMessage: String?
     @State private var diagnosticsExportHadError = false
@@ -288,11 +289,19 @@ private struct GeneralSettingsTab: View {
                                 .font(.system(size: 12, design: .monospaced))
                                 .textFieldStyle(.roundedBorder)
                                 .onSubmit { addCustomMeetingApp() }
+                                .onChange(of: newCustomMeetingAppBundleID) {
+                                    customMeetingAppNotice = nil
+                                }
                             Button("Add") { addCustomMeetingApp() }
                                 .disabled(
                                     newCustomMeetingAppBundleID
                                         .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                                 )
+                        }
+                        if let customMeetingAppNotice {
+                            Text(customMeetingAppNotice)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
                         }
                     }
                 }
@@ -371,9 +380,17 @@ private struct GeneralSettingsTab: View {
     private func addCustomMeetingApp() {
         let trimmed = newCustomMeetingAppBundleID.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        // The settings setter normalizes the stored list (trims, dedupes).
+        // A built-in app would appear in this list with a remove button that
+        // cannot actually stop detecting it. Refuse the addition and say so.
+        guard !MeetingDetector.isBundledMeetingApp(trimmed) else {
+            customMeetingAppNotice = "\(trimmed) is already built in."
+            return
+        }
+        // The settings setter normalizes the stored list (trims, dedupes,
+        // case-insensitively).
         settings.customMeetingAppBundleIDs = settings.customMeetingAppBundleIDs + [trimmed]
         newCustomMeetingAppBundleID = ""
+        customMeetingAppNotice = nil
     }
 
     private func chooseNotesFolder() {

--- a/OpenOats/Tests/OpenOatsTests/MeetingDetectionControllerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MeetingDetectionControllerTests.swift
@@ -234,4 +234,55 @@ final class MeetingDetectionControllerTests: XCTestCase {
 
         consumeTask.cancel()
     }
+
+    // MARK: - Teardown Stops The Detector
+
+    /// Editing the custom meeting-app list rebuilds detection: `teardown` runs
+    /// and a fresh controller is built. If `teardown` fails to stop the detector
+    /// it started, that abandoned detector keeps its mic and camera monitors
+    /// running for the life of the process, and every edit adds another one.
+    func testTeardownStopsTheDetectorItStarted() async throws {
+        let camera = MockCameraSignalSource()
+        let detector = MeetingDetector(
+            audioSource: MockAudioSignalSource(),
+            cameraSource: camera
+        )
+        let controller = MeetingDetectionController()
+        controller.setup(settings: makeSettings(), detector: detector)
+
+        // Drive the detector into an active detection, which `stop()` clears.
+        camera.emit(true)
+        let becameActive = await poll { await detector.isActive }
+        XCTAssertTrue(becameActive, "Detector never became active, so the test cannot observe stop()")
+
+        controller.teardown()
+
+        let stopped = await poll { await detector.isActive == false }
+        XCTAssertTrue(stopped, "teardown() left the detector it started still monitoring")
+    }
+
+    // MARK: - Helpers
+
+    private func makeSettings() -> AppSettings {
+        let suiteName = "com.openoats.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        let storage = AppSettingsStorage(
+            defaults: defaults,
+            secretStore: .ephemeral,
+            defaultNotesDirectory: URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("MeetingDetectionControllerTests"),
+            runMigrations: false
+        )
+        return AppSettings(storage: storage)
+    }
+
+    /// Wait up to a second for an asynchronous condition to hold.
+    private func poll(_ condition: () async -> Bool) async -> Bool {
+        for _ in 0..<100 {
+            if await condition() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return await condition()
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/MeetingDetectorTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MeetingDetectorTests.swift
@@ -436,50 +436,61 @@ final class MeetingDetectorTests: XCTestCase {
         camera.finish()
     }
 
-    func testKnownBundleIDsMergeDefaultsAndCustom() async {
-        let audio = MockAudioSignalSource()
-        let camera = MockCameraSignalSource()
-        let detector = MeetingDetector(
-            audioSource: audio,
-            cameraSource: camera,
-            customBundleIDs: ["com.example.custom-meeting-app"]
+    func testResolveKnownBundleIDsMergesDefaultsAndCustom() {
+        let known = MeetingDetector.resolveKnownBundleIDs(
+            custom: ["com.example.custom-meeting-app"],
+            selfID: "com.openoats.app"
         )
 
-        let known = await detector.knownBundleIDs
         XCTAssertTrue(known.contains("us.zoom.xos"), "bundled defaults must remain detectable")
         XCTAssertTrue(
             known.contains("com.example.custom-meeting-app"),
             "user additions must be detectable"
         )
-
-        audio.finish()
-        camera.finish()
     }
 
-    func testKnownBundleIDsDedupeCustomAgainstDefaultsAndSelf() async {
-        let audio = MockAudioSignalSource()
-        let camera = MockCameraSignalSource()
-        let selfID = Bundle.main.bundleIdentifier ?? "com.openoats.app"
-        let detector = MeetingDetector(
-            audioSource: audio,
-            cameraSource: camera,
-            customBundleIDs: [
+    func testResolveKnownBundleIDsDedupesAgainstDefaultsAndSelf() {
+        let selfID = "com.openoats.app"
+        let known = MeetingDetector.resolveKnownBundleIDs(
+            custom: [
                 "us.zoom.xos", // duplicate of a bundled default
                 "com.example.custom-meeting-app", // listed twice by the user
                 "com.example.custom-meeting-app",
                 selfID, // never detect ourselves
-            ]
+            ],
+            selfID: selfID
         )
 
-        let known = await detector.knownBundleIDs
-        let defaultsCount = MeetingDetector.bundledMeetingApps.count
         XCTAssertEqual(
-            known.count, defaultsCount + 1,
+            known.count, MeetingDetector.bundledMeetingApps.count + 1,
             "duplicates of defaults and repeated custom entries collapse; self is excluded"
         )
         XCTAssertFalse(known.contains(selfID), "the app itself must never count as a meeting app")
+    }
 
-        audio.finish()
-        camera.finish()
+    func testResolveKnownBundleIDsFoldsCase() {
+        let known = MeetingDetector.resolveKnownBundleIDs(
+            custom: ["us.Zoom.xos", "COM.EXAMPLE.App"],
+            selfID: "Com.OpenOats.App"
+        )
+
+        XCTAssertEqual(
+            known.count, MeetingDetector.bundledMeetingApps.count + 1,
+            "a case variant of a bundled default is not a second app"
+        )
+        XCTAssertTrue(
+            known.contains("com.example.app"),
+            "the set is folded so a differently-cased running app still matches"
+        )
+        XCTAssertFalse(
+            known.contains("com.openoats.app"),
+            "self-exclusion must fold too, or a cased self ID would be detectable"
+        )
+    }
+
+    func testIsBundledMeetingAppIgnoresCaseAndWhitespace() {
+        XCTAssertTrue(MeetingDetector.isBundledMeetingApp("us.zoom.xos"))
+        XCTAssertTrue(MeetingDetector.isBundledMeetingApp("  us.Zoom.xos "))
+        XCTAssertFalse(MeetingDetector.isBundledMeetingApp("com.example.custom-meeting-app"))
     }
 }

--- a/OpenOats/Tests/OpenOatsTests/MeetingDetectorTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MeetingDetectorTests.swift
@@ -435,4 +435,51 @@ final class MeetingDetectorTests: XCTestCase {
         audio.finish()
         camera.finish()
     }
+
+    func testKnownBundleIDsMergeDefaultsAndCustom() async {
+        let audio = MockAudioSignalSource()
+        let camera = MockCameraSignalSource()
+        let detector = MeetingDetector(
+            audioSource: audio,
+            cameraSource: camera,
+            customBundleIDs: ["com.example.custom-meeting-app"]
+        )
+
+        let known = await detector.knownBundleIDs
+        XCTAssertTrue(known.contains("us.zoom.xos"), "bundled defaults must remain detectable")
+        XCTAssertTrue(
+            known.contains("com.example.custom-meeting-app"),
+            "user additions must be detectable"
+        )
+
+        audio.finish()
+        camera.finish()
+    }
+
+    func testKnownBundleIDsDedupeCustomAgainstDefaultsAndSelf() async {
+        let audio = MockAudioSignalSource()
+        let camera = MockCameraSignalSource()
+        let selfID = Bundle.main.bundleIdentifier ?? "com.openoats.app"
+        let detector = MeetingDetector(
+            audioSource: audio,
+            cameraSource: camera,
+            customBundleIDs: [
+                "us.zoom.xos", // duplicate of a bundled default
+                "com.example.custom-meeting-app", // listed twice by the user
+                "com.example.custom-meeting-app",
+                selfID, // never detect ourselves
+            ]
+        )
+
+        let known = await detector.knownBundleIDs
+        let defaultsCount = MeetingDetector.bundledMeetingApps.count
+        XCTAssertEqual(
+            known.count, defaultsCount + 1,
+            "duplicates of defaults and repeated custom entries collapse; self is excluded"
+        )
+        XCTAssertFalse(known.contains(selfID), "the app itself must never count as a meeting app")
+
+        audio.finish()
+        camera.finish()
+    }
 }

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -461,6 +461,35 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertEqual(store.customMeetingAppBundleIDs, ["com.example.app"])
     }
 
+    func testCustomMeetingAppBundleIDsNormalizeOnSet() {
+        let store = makeStore()
+        store.customMeetingAppBundleIDs = [
+            "  com.example.app  ",
+            "com.example.app",
+            "",
+            "   ",
+            "com.example.other",
+        ]
+        XCTAssertEqual(
+            store.customMeetingAppBundleIDs,
+            ["com.example.app", "com.example.other"],
+            "entries are trimmed, deduplicated, and empty entries dropped"
+        )
+    }
+
+    func testCustomMeetingAppBundleIDsNormalizeOnLoad() {
+        let name = "com.openoats.test.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: name)!
+        defaults.removePersistentDomain(forName: name)
+        defaults.set(
+            ["  com.example.app ", "com.example.app", ""],
+            forKey: "customMeetingAppBundleIDs"
+        )
+
+        let store = makeStore(defaults: defaults)
+        XCTAssertEqual(store.customMeetingAppBundleIDs, ["com.example.app"])
+    }
+
     func testDefaultDetectionLogEnabled() {
         let store = makeStore()
         XCTAssertFalse(store.detectionLogEnabled)

--- a/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SettingsStoreTests.swift
@@ -477,6 +477,26 @@ final class SettingsStoreTests: XCTestCase {
         )
     }
 
+    func testCustomMeetingAppBundleIDsDedupeCaseVariants() {
+        let store = makeStore()
+        store.customMeetingAppBundleIDs = ["us.Zoom.xos", "us.zoom.xos", "US.ZOOM.XOS"]
+        XCTAssertEqual(
+            store.customMeetingAppBundleIDs,
+            ["us.Zoom.xos"],
+            "bundle IDs match case-insensitively, so variants collapse to the first-seen form"
+        )
+    }
+
+    func testExcludedCalendarIDsKeepCaseVariants() {
+        let store = makeStore()
+        store.excludedCalendarIDs = ["ABC-123", "abc-123"]
+        XCTAssertEqual(
+            store.excludedCalendarIDs,
+            ["ABC-123", "abc-123"],
+            "calendar identifiers are opaque and stay case-sensitive"
+        )
+    }
+
     func testCustomMeetingAppBundleIDsNormalizeOnLoad() {
         let name = "com.openoats.test.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: name)!


### PR DESCRIPTION
## Problem

Microphone-based meeting detection only fires for a known meeting app: `handleMicSignal` guards on `scanForMeetingApp() != nil` (`Sources/OpenOats/Meeting/MeetingDetector.swift:333-334`), and the known list is the 12 hardcoded bundle IDs in `defaultMeetingApps` (`MeetingDetector.swift:379-392`). The only browser-shaped entry is the Google Meet PWA (`:390`). So a Meet/Teams/Zoom-web call in a normal browser tab is invisible to the mic path; the camera path (`MeetingDetector.swift:277-281`) is the only rescue, and camera-off browser calls are undetectable.

The plumbing to extend the list actually already exists — `SettingsStore.customMeetingAppBundleIDs` is wired into the detector via `MeetingDetectionController.setup` (`Sources/OpenOats/App/MeetingDetectionController.swift:131-133`) — but no UI reads or writes it. Today the only way to use it is `defaults write`, and even then the change needs an app relaunch because the detector snapshots the list at setup.

## Change

- **Settings UI**: a "Custom Meeting Apps" section next to the detection settings (monospaced list with remove buttons, plus an add field), shown while auto-detect is enabled. Mirrors the existing "Ignored Apps" section.
- **Normalization**: `customMeetingAppBundleIDs` is now trimmed and deduplicated on set and on load, reusing `normalizedIdentifierList` — the same treatment `excludedCalendarIDs` already gets.
- **Live application**: `ContentView` restarts detection when the list changes, guarded to run only while auto-detect is on and no recording is active (tearing down mid-recording would cancel the silence and app-exit monitors of the live session).
- `MeetingDetector.knownBundleIDs` loses `private` so tests can assert the merged set.

## Why browsers are not added to the default list

Deliberately not done, and worth being explicit about: mic-based detection would then fire for any website using the microphone — dictation, voice notes, browser games — a false-positive storm for every browser user. User extensibility is the right shape: people who live in browser meetings opt in deliberately, with the trade-off explained in the section's caption.

## Trade-offs

- Editing the list restarts detection; a pending detection notification at that moment is cancelled. Acceptable: the user is actively editing detection settings.
- Bundle IDs are free text. A typo simply never matches; entries are shown verbatim so mistakes are visible and removable.
- Detection restart is skipped during a recording, so an edit made mid-recording applies when detection next restarts (recording end toggles or next launch).

## Tests

- `MeetingDetectorTests`: merged set contains defaults + user additions; duplicates of defaults, repeated custom entries, and the app's own bundle ID all collapse/are excluded
- `SettingsStoreTests`: normalization on set and on load

`swift build -c debug` and `-c release` clean; full suite 727 tests, 0 failures (4 new).


---

## Revised after self-review

Going back over this, the headline problem was that the motivating use case did not actually work.

**Adding an app mid-call did nothing.** The restart on list change rebuilt the detector but never re-evaluated the current microphone and camera state, and a fresh `CoreAudioSignalSource` only emits on transitions. So adding your browser while the Meet call is already running changed nothing until the microphone next cycled — which, in a call, is when the call ends. The restart now calls `evaluateImmediate()`, the same way the auto-detect toggle already did.

**Case variants were dead entries.** Bundle identifiers are matched case-insensitively in practice, but the list deduplicated on the exact string and detection compared with an exact `Set` lookup. So `us.Zoom.xos` persisted, rendered as its own row, and never matched anything — a setting that looks applied and silently is not. The stored list now deduplicates without regard to case, keeping whichever spelling you typed first, and both the detection set and every lookup are case-folded. Calendar identifiers are opaque and keep their existing case-sensitive normalization; there is a test pinning that distinction.

**Edits made while recording were dropped forever.** The old guard skipped the restart mid-recording and nothing ever re-applied it, so the change quietly survived only as far as the next relaunch. The restart is now deferred and applied on the next return to idle.

**Restarting wiped this session's "Not a Meeting" dismissals.** Teardown clears them, which is right when you turn detection off, but wrong for a list edit — that is not a new session, and re-prompting for something the user already dismissed is the annoying failure. Dismissals now carry across a restart-for-list-edit and are still cleared on an explicit disable.

**Adding a built-in app looked like it worked and could not be undone.** You could add `us.zoom.xos` as a custom entry, see it in the list with a remove button, remove it, and detection would carry on regardless. Those additions are now refused with inline "already built in" feedback.

**The merge is now a pure function.** `resolveKnownBundleIDs(defaults:custom:selfID:)` handles bundled defaults plus user additions minus the app's own identifier, so `knownBundleIDs` goes back to being private and the tests assert the merge directly rather than reaching into the actor.

**Interaction with #708.** That PR adds an opt-in "automatically record detected meetings" setting. With both landed, a custom browser entry here means any microphone-using website can start a real recording with no confirmation step, so #708's caption calls that out explicitly. This PR's own caption already warns why browsers are not built in.

Possible follow-up, not done here: an `NSOpenPanel` app picker so the bundle identifier can be chosen from an installed app rather than typed. Free-text entry is honest about what it is — a typo simply never matches, and entries render verbatim — so this seemed like polish for a later pass rather than something to bundle in.

Full suite: 731 tests, 0 failures (up from 727, four new).

## Follow-up: teardown never stopped the detector

A review pass flagged a race here: `disableDetection` schedules `teardown`'s
asynchronous `meetingDetector?.stop()` and clears the property, so the task
could stop the *replacement* detector. That one cannot happen.
`disableDetection` also drops the controller itself (`AppContainer.swift:231-236`)
and `enableDetection` builds a new one, so the task's `self` is the old
controller and the replacement lives on a different object.

The premise underneath it is real, though, and worse: the property is already
nil when the task body runs. `teardown` read `meetingDetector` inside the task,
which runs after the method returns and therefore after `meetingDetector = nil`
on the next line, so the stop always applied to nil. No detector was ever
stopped. Its mic and camera monitors stay alive for the life of the process,
and this branch makes detection restarts routine — one abandoned detector per
custom meeting-app edit.

`teardown` now captures the detector before clearing the property.

`MeetingDetectionControllerTests.testTeardownStopsTheDetectorItStarted` drives a
detector into an active detection through the controller, tears down, and
asserts the detector stopped. It fails on the previous commit.

Reaching that path from a test needed one more fix. `NotificationService`'s
availability probe only ruled out a missing bundle identifier, which the
`xctest` runner does have, so constructing one raised inside
`UNUserNotificationCenter` ("bundleProxyForCurrentProcess is nil"). The probe
now requires an `.app` bundle, which is what its comment always described.

Full suite: 732 tests, 0 failures (up from 731, one new).

## Merge order

Merge after #708. The two branches conflict in `SettingsStore.swift` (3 hunks), `SettingsView.swift`, and
`MeetingDetectionController.swift` — both add settings-backed lists and restart-on-change handling to the
detection controller.

This PR also touches `ContentView.swift`, which #712 edits as well, but those two do not collide.

Happy to rebase whichever way suits your merge queue.

