### PR TITLE
Retry notes-folder mirrors that fail while the folder is unreachable

### DIFF
--- a/OpenOats/Sources/OpenOats/Storage/MirrorAttemptLedger.swift
+++ b/OpenOats/Sources/OpenOats/Storage/MirrorAttemptLedger.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Bookkeeping that bounds notes-folder mirror work.
+///
+/// A mirror writes into a user-chosen folder that may live on a network mount.
+/// When that mount is unreachable, a single attempt can block for the mount's
+/// own timeout — tens of seconds for SMB. Retries are driven by ordinary app
+/// activity (every recording start re-applies the notes folder), so without
+/// bookkeeping the outstanding work for a permanently dead mount grows without
+/// bound.
+///
+/// The ledger imposes two limits, which together bound the cost of a dead mount
+/// to one blocked attempt per pending session per `retryBackoff`:
+///
+/// - **In-flight guard.** A session with a running attempt never starts a
+///   second one. A request that arrives during an attempt is coalesced into a
+///   single re-run.
+/// - **Failure backoff.** A session whose last attempt failed is not retried
+///   again until `retryBackoff` has elapsed.
+///
+/// Attempts carry a monotonically increasing id so a report can be matched to
+/// the attempt that produced it. A report from a superseded attempt is ignored
+/// — otherwise a slow success could clear the pending flag of a newer attempt
+/// that actually failed, silently dropping the durable retry.
+struct MirrorAttemptLedger: Sendable {
+    /// Minimum interval between retries of a session whose last attempt failed.
+    let retryBackoff: TimeInterval
+
+    /// Sessions whose most recent mirror failed and which should be retried.
+    private(set) var pendingSessionIDs: Set<String> = []
+
+    private var nextAttemptID = 0
+    /// Attempt id of the running attempt per session, if any.
+    private var inFlightAttemptIDs: [String: Int] = [:]
+    private var lastFailureDates: [String: Date] = [:]
+    /// Sessions that asked for a mirror while one was already running.
+    private var rescheduleRequests: Set<String> = []
+
+    init(retryBackoff: TimeInterval) {
+        self.retryBackoff = retryBackoff
+    }
+
+    /// Reserve an attempt for `sessionID`.
+    /// - Returns: the attempt id, or `nil` when an attempt is already running.
+    mutating func beginAttempt(sessionID: String) -> Int? {
+        guard inFlightAttemptIDs[sessionID] == nil else { return nil }
+        nextAttemptID += 1
+        inFlightAttemptIDs[sessionID] = nextAttemptID
+        return nextAttemptID
+    }
+
+    /// Record the outcome of an attempt.
+    /// - Returns: `false` when the report comes from a superseded attempt, in
+    ///   which case the caller must not touch any persisted state.
+    mutating func finishAttempt(
+        sessionID: String,
+        attempt: Int,
+        succeeded: Bool,
+        now: Date = Date()
+    ) -> Bool {
+        guard inFlightAttemptIDs[sessionID] == attempt else { return false }
+        inFlightAttemptIDs[sessionID] = nil
+        if succeeded {
+            pendingSessionIDs.remove(sessionID)
+            lastFailureDates[sessionID] = nil
+        } else {
+            pendingSessionIDs.insert(sessionID)
+            lastFailureDates[sessionID] = now
+        }
+        return true
+    }
+
+    /// Pending sessions the retry pass may drive right now: no attempt running,
+    /// and outside the failure backoff window.
+    func retryableSessionIDs(excluding excluded: String? = nil, now: Date = Date()) -> [String] {
+        pendingSessionIDs
+            .filter { sessionID in
+                sessionID != excluded
+                    && inFlightAttemptIDs[sessionID] == nil
+                    && !isBackingOff(sessionID, now: now)
+            }
+            .sorted()
+    }
+
+    /// Note that a mirror was requested while an attempt was already running,
+    /// so the newer content is re-mirrored once that attempt reports.
+    mutating func requestReschedule(sessionID: String) {
+        rescheduleRequests.insert(sessionID)
+    }
+
+    /// Consume any coalesced request recorded during the last attempt.
+    mutating func takeRescheduleRequest(sessionID: String) -> Bool {
+        rescheduleRequests.remove(sessionID) != nil
+    }
+
+    /// Seed pending sessions discovered by the startup scan.
+    mutating func restorePending(_ sessionIDs: Set<String>) {
+        pendingSessionIDs.formUnion(sessionIDs)
+    }
+
+    /// Drop every trace of a session, used when it is deleted so a dead mount
+    /// cannot keep re-driving it. Any attempt still running is thereby
+    /// superseded and its report ignored.
+    mutating func forget(sessionID: String) {
+        pendingSessionIDs.remove(sessionID)
+        lastFailureDates[sessionID] = nil
+        inFlightAttemptIDs[sessionID] = nil
+        rescheduleRequests.remove(sessionID)
+    }
+
+    /// Drop the failure backoff for every session. Called when the notes folder
+    /// changes destination: past failures say nothing about the new folder.
+    mutating func clearFailureBackoff() {
+        lastFailureDates.removeAll()
+    }
+
+    private func isBackingOff(_ sessionID: String, now: Date) -> Bool {
+        guard let failedAt = lastFailureDates[sessionID] else { return false }
+        return now.timeIntervalSince(failedAt) < retryBackoff
+    }
+}

--- a/OpenOats/Sources/OpenOats/Storage/MirrorAttemptLedger.swift
+++ b/OpenOats/Sources/OpenOats/Storage/MirrorAttemptLedger.swift
@@ -22,6 +22,11 @@ import Foundation
 /// the attempt that produced it. A report from a superseded attempt is ignored
 /// — otherwise a slow success could clear the pending flag of a newer attempt
 /// that actually failed, silently dropping the durable retry.
+///
+/// An attempt that was running when the notes folder changed is superseded in
+/// the same way, because it wrote to the folder the user has since replaced:
+/// its success says nothing about the new destination and its failure must not
+/// back the new destination off.
 struct MirrorAttemptLedger: Sendable {
     /// Minimum interval between retries of a session whose last attempt failed.
     let retryBackoff: TimeInterval
@@ -35,6 +40,23 @@ struct MirrorAttemptLedger: Sendable {
     private var lastFailureDates: [String: Date] = [:]
     /// Sessions that asked for a mirror while one was already running.
     private var rescheduleRequests: Set<String> = []
+    /// Attempts that were running when the notes folder changed, and so wrote
+    /// to a destination the user has since replaced.
+    private var staleDestinationAttemptIDs: Set<Int> = []
+
+    /// What the caller must do with a reported attempt.
+    enum AttemptOutcome: Equatable {
+        /// The report belongs to an attempt this ledger no longer tracks, such
+        /// as one for a session that was deleted. Touch no persisted state.
+        case ignored
+        /// The report describes the current destination. Persist the pending
+        /// flag it implies.
+        case recorded
+        /// The attempt wrote to a destination that has since been replaced, so
+        /// the current one still has no export. The session stays pending and
+        /// must be re-driven against the new destination.
+        case staleDestination
+    }
 
     init(retryBackoff: TimeInterval) {
         self.retryBackoff = retryBackoff
@@ -49,17 +71,22 @@ struct MirrorAttemptLedger: Sendable {
         return nextAttemptID
     }
 
-    /// Record the outcome of an attempt.
-    /// - Returns: `false` when the report comes from a superseded attempt, in
-    ///   which case the caller must not touch any persisted state.
+    /// Record the outcome of an attempt, and free the session's attempt slot.
+    /// - Returns: how the caller must treat the report.
     mutating func finishAttempt(
         sessionID: String,
         attempt: Int,
         succeeded: Bool,
         now: Date = Date()
-    ) -> Bool {
-        guard inFlightAttemptIDs[sessionID] == attempt else { return false }
+    ) -> AttemptOutcome {
+        guard inFlightAttemptIDs[sessionID] == attempt else { return .ignored }
         inFlightAttemptIDs[sessionID] = nil
+        guard staleDestinationAttemptIDs.remove(attempt) == nil else {
+            // Neither outcome describes the current notes folder, so record no
+            // success and no backoff. The session keeps its durable retry.
+            pendingSessionIDs.insert(sessionID)
+            return .staleDestination
+        }
         if succeeded {
             pendingSessionIDs.remove(sessionID)
             lastFailureDates[sessionID] = nil
@@ -67,7 +94,7 @@ struct MirrorAttemptLedger: Sendable {
             pendingSessionIDs.insert(sessionID)
             lastFailureDates[sessionID] = now
         }
-        return true
+        return .recorded
     }
 
     /// Pending sessions the retry pass may drive right now: no attempt running,
@@ -104,14 +131,23 @@ struct MirrorAttemptLedger: Sendable {
     mutating func forget(sessionID: String) {
         pendingSessionIDs.remove(sessionID)
         lastFailureDates[sessionID] = nil
+        if let attempt = inFlightAttemptIDs[sessionID] {
+            staleDestinationAttemptIDs.remove(attempt)
+        }
         inFlightAttemptIDs[sessionID] = nil
         rescheduleRequests.remove(sessionID)
     }
 
-    /// Drop the failure backoff for every session. Called when the notes folder
-    /// changes destination: past failures say nothing about the new folder.
-    mutating func clearFailureBackoff() {
+    /// Note that the notes folder now points somewhere else.
+    ///
+    /// Past failures say nothing about the new folder, so the backoff is
+    /// dropped. Every running attempt is writing to the old folder, so it is
+    /// marked stale: its report leaves the session pending, and the caller
+    /// re-drives it against the new destination. No attempt starts here, so a
+    /// session still has at most one in flight.
+    mutating func destinationChanged() {
         lastFailureDates.removeAll()
+        staleDestinationAttemptIDs.formUnion(inFlightAttemptIDs.values)
     }
 
     private func isBackingOff(_ sessionID: String, now: Date) -> Bool {

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -262,13 +262,14 @@ actor SessionRepository {
         // start. Only a genuinely new destination is evidence that a previously
         // failed mirror can now succeed, so the failure backoff is kept
         // otherwise — that is what stops a dead mount from being re-driven once
-        // per recording.
+        // per recording. A new destination also invalidates whatever attempts
+        // are running against the old one.
         let destinationChanged = url != notesFolderPath
         notesFolderPath = url
         notesFolderIsSecurityScoped = securityScoped
         meetingTranscriptDateFolderFormat = dateSubfolderFormat
         if destinationChanged {
-            mirrorAttempts.clearFailureBackoff()
+            mirrorAttempts.destinationChanged()
         }
         retryPendingMirrors()
     }
@@ -2047,19 +2048,32 @@ actor SessionRepository {
     /// forgotten) mid-attempt can start a fresh attempt afterwards, and a slow
     /// success from the old one must not clear the newer attempt's pending flag.
     private func mirrorDidFinish(sessionID: String, attempt: Int, succeeded: Bool) {
-        guard mirrorAttempts.finishAttempt(
+        switch mirrorAttempts.finishAttempt(
             sessionID: sessionID,
             attempt: attempt,
             succeeded: succeeded
-        ) else { return }
+        ) {
+        case .ignored:
+            return
 
-        persistMirrorPending(!succeeded, sessionID: sessionID)
-
-        let hasQueuedRequest = mirrorAttempts.takeRescheduleRequest(sessionID: sessionID)
-        // On failure the session is already pending and the backoff governs the
-        // next attempt, so only a success re-drives a coalesced request.
-        if succeeded, hasQueuedRequest {
+        case .staleDestination:
+            // The attempt wrote to the folder the user has since replaced, so
+            // the current one still has no export: keep the durable flag and
+            // re-drive now that the session's attempt slot is free. A request
+            // coalesced during the attempt is satisfied by that same re-run.
+            persistMirrorPending(true, sessionID: sessionID)
+            _ = mirrorAttempts.takeRescheduleRequest(sessionID: sessionID)
             startMirrorAttempt(sessionID: sessionID)
+
+        case .recorded:
+            persistMirrorPending(!succeeded, sessionID: sessionID)
+
+            let hasQueuedRequest = mirrorAttempts.takeRescheduleRequest(sessionID: sessionID)
+            // On failure the session is already pending and the backoff governs
+            // the next attempt, so only a success re-drives a coalesced request.
+            if succeeded, hasQueuedRequest {
+                startMirrorAttempt(sessionID: sessionID)
+            }
         }
     }
 

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -159,6 +159,9 @@ struct SessionMetadata: Codable, Sendable {
     var customNotesGuidance: String?
     /// Per-session custom speaker display names. Keys are Speaker.storageKey values.
     var speakerNames: [String: String]?
+    /// Set when the most recent notes-folder mirror failed (e.g. the folder is
+    /// on an unreachable network mount) so the export can be retried later.
+    var mirrorPending: Bool? = nil
 }
 
 // MARK: - SessionRepository
@@ -205,6 +208,10 @@ actor SessionRepository {
     /// `startAccessingSecurityScopedResource()` before file I/O.
     private var notesFolderIsSecurityScoped = false
 
+    /// Sessions whose most recent notes-folder mirror failed and should be retried.
+    /// Mirrors the durable `SessionMetadata.mirrorPending` flags.
+    private var pendingMirrorSessionIDs: Set<String> = []
+
     init(rootDirectory: URL? = nil) {
         let baseDirectory: URL
         if let rootDirectory {
@@ -228,6 +235,8 @@ actor SessionRepository {
         Self.dropMetadataNeverIndex(in: sessionsDirectory)
 
         Self.cleanupExpiredRetainedBatchAudio(in: sessionsDirectory)
+
+        Task { await self.restorePendingMirrors() }
     }
 
     // MARK: - Configuration
@@ -244,6 +253,7 @@ actor SessionRepository {
         notesFolderPath = url
         notesFolderIsSecurityScoped = securityScoped
         meetingTranscriptDateFolderFormat = dateSubfolderFormat
+        retryPendingMirrors()
     }
 
     /// Register a callback invoked once per session when a write error occurs.
@@ -1921,13 +1931,46 @@ actor SessionRepository {
     /// - Parameter notesMarkdown: Pass the markdown when already in memory (e.g. from saveNotes)
     ///   to avoid a redundant disk read; nil causes the background task to read it from disk.
     private func scheduleMirror(sessionID: String, notesMarkdown: String? = nil) {
+        scheduleMirrorCore(sessionID: sessionID, notesMarkdown: notesMarkdown)
+        retryPendingMirrors(excluding: sessionID)
+    }
+
+    /// Scan session metadata for mirrors that failed in a previous run and
+    /// retry them. Called once from init.
+    private func restorePendingMirrors() {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(
+            at: sessionsDirectory,
+            includingPropertiesForKeys: nil
+        ) else { return }
+        for entry in contents {
+            let sessionID = entry.lastPathComponent
+            if loadSessionMetadataFile(sessionID: sessionID)?.mirrorPending == true {
+                pendingMirrorSessionIDs.insert(sessionID)
+            }
+        }
+        retryPendingMirrors()
+    }
+
+    /// Re-schedule mirrors that previously failed (e.g. the notes folder lives
+    /// on a network mount that was unreachable). Runs whenever the notes folder
+    /// is (re)configured and piggybacks on every scheduled mirror, so pending
+    /// exports heal as soon as the folder is reachable again.
+    private func retryPendingMirrors(excluding excludedSessionID: String? = nil) {
+        guard notesFolderPath != nil else { return }
+        for sessionID in pendingMirrorSessionIDs where sessionID != excludedSessionID {
+            scheduleMirrorCore(sessionID: sessionID)
+        }
+    }
+
+    private func scheduleMirrorCore(sessionID: String, notesMarkdown: String? = nil) {
         guard let outputDir = notesFolderPath else { return }
         let sessDir = sessionsDirectory
         let isSecurityScoped = notesFolderIsSecurityScoped
         let dateSubfolderFormat = meetingTranscriptDateFolderFormat
         let meta = loadSessionMetadataFile(sessionID: sessionID)
-        Task.detached(priority: .background) {
-            SessionRepository.performMirror(
+        Task.detached(priority: .background) { [weak self] in
+            let succeeded = SessionRepository.performMirror(
                 sessionID: sessionID,
                 meta: meta,
                 notesMarkdown: notesMarkdown,
@@ -1936,9 +1979,27 @@ actor SessionRepository {
                 dateSubfolderFormat: dateSubfolderFormat,
                 sessionsDirectory: sessDir
             )
+            await self?.mirrorDidFinish(sessionID: sessionID, succeeded: succeeded)
         }
     }
 
+    /// Record the outcome of a mirror attempt, persisting a pending flag in the
+    /// session metadata so a failed export survives an app relaunch.
+    private func mirrorDidFinish(sessionID: String, succeeded: Bool) {
+        if succeeded {
+            pendingMirrorSessionIDs.remove(sessionID)
+        } else {
+            pendingMirrorSessionIDs.insert(sessionID)
+        }
+        let shouldFlag = !succeeded
+        guard var meta = loadSessionMetadataFile(sessionID: sessionID),
+              (meta.mirrorPending == true) != shouldFlag else { return }
+        meta.mirrorPending = shouldFlag ? true : nil
+        writeSessionMetadata(meta, sessionID: sessionID)
+    }
+
+    /// Returns `true` when the mirror was written (or there was nothing to
+    /// mirror), `false` when the export failed and should be retried.
     private nonisolated static func performMirror(
         sessionID: String,
         meta: SessionMetadata?,
@@ -1947,7 +2008,7 @@ actor SessionRepository {
         isSecurityScoped: Bool,
         dateSubfolderFormat: MeetingTranscriptDateFolderFormat?,
         sessionsDirectory: URL
-    ) {
+    ) -> Bool {
         // Acquire security-scoped access if the URL was resolved from a bookmark
         let didStartAccess = isSecurityScoped && outputDir.startAccessingSecurityScopedResource()
         defer {
@@ -1956,7 +2017,7 @@ actor SessionRepository {
 
         let dir = sessionsDirectory.appendingPathComponent(sessionID, isDirectory: true)
         let records = readTranscript(sessionID: sessionID, dir: dir, sessionsDirectory: sessionsDirectory)
-        guard !records.isEmpty else { return }
+        guard !records.isEmpty else { return true }
 
         let resolvedMarkdown = notesMarkdown
             ?? readNotes(sessionID: sessionID, dir: dir, sessionsDirectory: sessionsDirectory)?.markdown
@@ -1990,7 +2051,7 @@ actor SessionRepository {
             preferPackage: !referencedAssetPaths.isEmpty
         )
 
-        guard let outputTarget else { return }
+        guard let outputTarget else { return false }
 
         if let packageDirectoryURL = outputTarget.packageDirectoryURL {
             synchronizeMirroredAssets(
@@ -1999,6 +2060,7 @@ actor SessionRepository {
                 into: packageDirectoryURL
             )
         }
+        return true
     }
 
     private nonisolated static func mirrorDirectory(

--- a/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
+++ b/OpenOats/Sources/OpenOats/Storage/SessionRepository.swift
@@ -208,11 +208,17 @@ actor SessionRepository {
     /// `startAccessingSecurityScopedResource()` before file I/O.
     private var notesFolderIsSecurityScoped = false
 
-    /// Sessions whose most recent notes-folder mirror failed and should be retried.
-    /// Mirrors the durable `SessionMetadata.mirrorPending` flags.
-    private var pendingMirrorSessionIDs: Set<String> = []
+    /// Bounds retry work for notes-folder mirrors that keep failing (e.g. an
+    /// unreachable network mount). Tracks the sessions whose most recent mirror
+    /// failed, mirroring the durable `SessionMetadata.mirrorPending` flags.
+    private var mirrorAttempts: MirrorAttemptLedger
 
-    init(rootDirectory: URL? = nil) {
+    /// Default minimum interval between retries of a failed mirror.
+    static let defaultMirrorRetryBackoff: TimeInterval = 5 * 60
+
+    /// - Parameter mirrorRetryBackoff: Minimum interval between retries of a
+    ///   session whose notes-folder mirror failed. Lowered by tests.
+    init(rootDirectory: URL? = nil, mirrorRetryBackoff: TimeInterval = SessionRepository.defaultMirrorRetryBackoff) {
         let baseDirectory: URL
         if let rootDirectory {
             baseDirectory = rootDirectory
@@ -230,6 +236,8 @@ actor SessionRepository {
 
         decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
+
+        mirrorAttempts = MirrorAttemptLedger(retryBackoff: mirrorRetryBackoff)
 
         try? FileManager.default.createDirectory(at: sessionsDirectory, withIntermediateDirectories: true)
         Self.dropMetadataNeverIndex(in: sessionsDirectory)
@@ -250,9 +258,18 @@ actor SessionRepository {
         securityScoped: Bool = false,
         dateSubfolderFormat: MeetingTranscriptDateFolderFormat? = nil
     ) {
+        // startTranscription re-applies the same folder at every recording
+        // start. Only a genuinely new destination is evidence that a previously
+        // failed mirror can now succeed, so the failure backoff is kept
+        // otherwise — that is what stops a dead mount from being re-driven once
+        // per recording.
+        let destinationChanged = url != notesFolderPath
         notesFolderPath = url
         notesFolderIsSecurityScoped = securityScoped
         meetingTranscriptDateFolderFormat = dateSubfolderFormat
+        if destinationChanged {
+            mirrorAttempts.clearFailureBackoff()
+        }
         retryPendingMirrors()
     }
 
@@ -478,7 +495,10 @@ actor SessionRepository {
             calendarEvent: metadata.calendarEvent,
             transcriptIssue: metadata.transcriptIssue,
             transcriptRecovery: nil,
-            speakerNames: speakerNames
+            speakerNames: speakerNames,
+            // Hand-built metadata: carry the durable mirror flag across, or a
+            // pending export is lost the moment the session is finalized.
+            mirrorPending: existingMetadata?.mirrorPending
         )
         writeSessionMetadata(sessionMeta, sessionID: sessionID)
 
@@ -643,7 +663,8 @@ actor SessionRepository {
                 source: meta.source,
                 calendarEvent: meta.calendarEvent,
                 transcriptIssue: nil,
-                transcriptRecovery: transcriptRecovery
+                transcriptRecovery: transcriptRecovery,
+                mirrorPending: meta.mirrorPending
             )
             writeSessionMetadata(refreshedMeta, sessionID: sessionID)
         }
@@ -1319,6 +1340,8 @@ actor SessionRepository {
     }
 
     func deleteSession(sessionID: String) {
+        // Stop tracking the session for mirror retries; nothing left to mirror.
+        mirrorAttempts.forget(sessionID: sessionID)
         let fm = FileManager.default
         let dir = sessionDirectory(for: sessionID)
 
@@ -1338,6 +1361,7 @@ actor SessionRepository {
     }
 
     func moveToRecentlyDeleted(sessionID: String) {
+        mirrorAttempts.forget(sessionID: sessionID)
         let fm = FileManager.default
         try? fm.createDirectory(at: recentlyDeletedDirectory, withIntermediateDirectories: true)
 
@@ -1931,40 +1955,73 @@ actor SessionRepository {
     /// - Parameter notesMarkdown: Pass the markdown when already in memory (e.g. from saveNotes)
     ///   to avoid a redundant disk read; nil causes the background task to read it from disk.
     private func scheduleMirror(sessionID: String, notesMarkdown: String? = nil) {
-        scheduleMirrorCore(sessionID: sessionID, notesMarkdown: notesMarkdown)
+        startMirrorAttempt(sessionID: sessionID, notesMarkdown: notesMarkdown)
         retryPendingMirrors(excluding: sessionID)
     }
 
     /// Scan session metadata for mirrors that failed in a previous run and
     /// retry them. Called once from init.
-    private func restorePendingMirrors() {
+    private func restorePendingMirrors() async {
+        let sessDir = sessionsDirectory
+        let pending = await Task.detached(priority: .utility) {
+            SessionRepository.scanPendingMirrorSessionIDs(in: sessDir)
+        }.value
+        mirrorAttempts.restorePending(pending)
+        retryPendingMirrors()
+    }
+
+    /// Read the durable `mirrorPending` flags off the actor. The scan decodes
+    /// one JSON file per session directory; running it actor-isolated would
+    /// queue every other repository call behind it at launch.
+    private nonisolated static func scanPendingMirrorSessionIDs(in sessionsDirectory: URL) -> Set<String> {
         let fm = FileManager.default
         guard let contents = try? fm.contentsOfDirectory(
             at: sessionsDirectory,
             includingPropertiesForKeys: nil
-        ) else { return }
+        ) else { return [] }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        var pending: Set<String> = []
         for entry in contents {
             let sessionID = entry.lastPathComponent
-            if loadSessionMetadataFile(sessionID: sessionID)?.mirrorPending == true {
-                pendingMirrorSessionIDs.insert(sessionID)
-            }
+            // Canonical session directories only, matching the batch-audio
+            // cleanup scan; this skips .recently-deleted and stray files.
+            guard sessionID.hasPrefix("session_") else { continue }
+            guard let data = try? Data(contentsOf: entry.appendingPathComponent("session.json")),
+                  let meta = try? decoder.decode(SessionMetadata.self, from: data),
+                  meta.mirrorPending == true else { continue }
+            pending.insert(sessionID)
         }
-        retryPendingMirrors()
+        return pending
     }
 
-    /// Re-schedule mirrors that previously failed (e.g. the notes folder lives
-    /// on a network mount that was unreachable). Runs whenever the notes folder
-    /// is (re)configured and piggybacks on every scheduled mirror, so pending
+    /// Re-drive mirrors that previously failed (e.g. the notes folder lives on
+    /// a network mount that was unreachable). Runs whenever the notes folder is
+    /// (re)configured and piggybacks on every scheduled mirror, so pending
     /// exports heal as soon as the folder is reachable again.
+    ///
+    /// Only sessions with no attempt running and outside the failure backoff
+    /// are driven, so a permanently dead mount costs at most one blocked
+    /// attempt per pending session per backoff interval.
     private func retryPendingMirrors(excluding excludedSessionID: String? = nil) {
         guard notesFolderPath != nil else { return }
-        for sessionID in pendingMirrorSessionIDs where sessionID != excludedSessionID {
-            scheduleMirrorCore(sessionID: sessionID)
+        for sessionID in mirrorAttempts.retryableSessionIDs(excluding: excludedSessionID) {
+            startMirrorAttempt(sessionID: sessionID)
         }
     }
 
-    private func scheduleMirrorCore(sessionID: String, notesMarkdown: String? = nil) {
+    /// Start one mirror attempt unless this session already has one running, in
+    /// which case the request is coalesced into a single re-run.
+    private func startMirrorAttempt(sessionID: String, notesMarkdown: String? = nil) {
         guard let outputDir = notesFolderPath else { return }
+        guard let attempt = mirrorAttempts.beginAttempt(sessionID: sessionID) else {
+            // An attempt is already running, possibly blocked on an unreachable
+            // mount. Re-mirror once it reports so newer notes are not lost.
+            mirrorAttempts.requestReschedule(sessionID: sessionID)
+            return
+        }
         let sessDir = sessionsDirectory
         let isSecurityScoped = notesFolderIsSecurityScoped
         let dateSubfolderFormat = meetingTranscriptDateFolderFormat
@@ -1979,22 +2036,37 @@ actor SessionRepository {
                 dateSubfolderFormat: dateSubfolderFormat,
                 sessionsDirectory: sessDir
             )
-            await self?.mirrorDidFinish(sessionID: sessionID, succeeded: succeeded)
+            await self?.mirrorDidFinish(sessionID: sessionID, attempt: attempt, succeeded: succeeded)
         }
     }
 
     /// Record the outcome of a mirror attempt, persisting a pending flag in the
     /// session metadata so a failed export survives an app relaunch.
-    private func mirrorDidFinish(sessionID: String, succeeded: Bool) {
-        if succeeded {
-            pendingMirrorSessionIDs.remove(sessionID)
-        } else {
-            pendingMirrorSessionIDs.insert(sessionID)
+    ///
+    /// Reports from superseded attempts are dropped: a session deleted (and so
+    /// forgotten) mid-attempt can start a fresh attempt afterwards, and a slow
+    /// success from the old one must not clear the newer attempt's pending flag.
+    private func mirrorDidFinish(sessionID: String, attempt: Int, succeeded: Bool) {
+        guard mirrorAttempts.finishAttempt(
+            sessionID: sessionID,
+            attempt: attempt,
+            succeeded: succeeded
+        ) else { return }
+
+        persistMirrorPending(!succeeded, sessionID: sessionID)
+
+        let hasQueuedRequest = mirrorAttempts.takeRescheduleRequest(sessionID: sessionID)
+        // On failure the session is already pending and the backoff governs the
+        // next attempt, so only a success re-drives a coalesced request.
+        if succeeded, hasQueuedRequest {
+            startMirrorAttempt(sessionID: sessionID)
         }
-        let shouldFlag = !succeeded
+    }
+
+    private func persistMirrorPending(_ pending: Bool, sessionID: String) {
         guard var meta = loadSessionMetadataFile(sessionID: sessionID),
-              (meta.mirrorPending == true) != shouldFlag else { return }
-        meta.mirrorPending = shouldFlag ? true : nil
+              (meta.mirrorPending == true) != pending else { return }
+        meta.mirrorPending = pending ? true : nil
         writeSessionMetadata(meta, sessionID: sessionID)
     }
 
@@ -2054,7 +2126,7 @@ actor SessionRepository {
         guard let outputTarget else { return false }
 
         if let packageDirectoryURL = outputTarget.packageDirectoryURL {
-            synchronizeMirroredAssets(
+            return synchronizeMirroredAssets(
                 referencedAssetPaths: referencedAssetPaths,
                 from: dir,
                 into: packageDirectoryURL
@@ -2128,11 +2200,17 @@ actor SessionRepository {
         return components.joined(separator: "/")
     }
 
+    /// Copy the assets a mirrored note references into the package directory.
+    /// - Returns: `false` when a referenced asset exists but could not be
+    ///   copied, so the mirror is retried. A referenced asset that is missing
+    ///   from the session is skipped and does not fail the mirror — retrying
+    ///   would never bring it back.
+    @discardableResult
     private nonisolated static func synchronizeMirroredAssets(
         referencedAssetPaths: Set<String>,
         from sessionDirectory: URL,
         into packageDirectory: URL
-    ) {
+    ) -> Bool {
         let fm = FileManager.default
         let mirroredAssetDirectories = [
             packageDirectory.appendingPathComponent("attachments", isDirectory: true),
@@ -2143,8 +2221,9 @@ actor SessionRepository {
             try? fm.removeItem(at: directory)
         }
 
-        guard !referencedAssetPaths.isEmpty else { return }
+        guard !referencedAssetPaths.isEmpty else { return true }
 
+        var allCopied = true
         for relativePath in referencedAssetPaths.sorted() {
             let sourceURL = sessionDirectory.appendingPathComponent(relativePath)
             guard fm.fileExists(atPath: sourceURL.path) else { continue }
@@ -2160,8 +2239,10 @@ actor SessionRepository {
                 try? fm.setAttributes([.posixPermissions: 0o600], ofItemAtPath: destinationURL.path)
             } catch {
                 Log.sessionRepository.error("Failed to mirror note asset \(relativePath, privacy: .public): \(error, privacy: .public)")
+                allCopied = false
             }
         }
+        return allCopied
     }
 
     // MARK: - Spotlight

--- a/OpenOats/Tests/OpenOatsTests/MirrorAttemptLedgerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MirrorAttemptLedgerTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class MirrorAttemptLedgerTests: XCTestCase {
+
+    private let backoff: TimeInterval = 300
+    private let t0 = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func makeLedger() -> MirrorAttemptLedger {
+        MirrorAttemptLedger(retryBackoff: backoff)
+    }
+
+    // MARK: - In-flight guard
+
+    func testSecondAttemptIsRefusedWhileOneIsRunning() throws {
+        var ledger = makeLedger()
+
+        XCTAssertNotNil(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertNil(
+            ledger.beginAttempt(sessionID: "session_a"),
+            "A session with a running attempt must not start a second one"
+        )
+        // A different session is unaffected.
+        XCTAssertNotNil(ledger.beginAttempt(sessionID: "session_b"))
+    }
+
+    func testAttemptCanRestartAfterTheRunningOneReports() throws {
+        var ledger = makeLedger()
+
+        let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: true, now: t0))
+        XCTAssertNotNil(ledger.beginAttempt(sessionID: "session_a"))
+    }
+
+    func testRetryPassSkipsSessionsWithARunningAttempt() throws {
+        var ledger = makeLedger()
+
+        let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0))
+        XCTAssertEqual(
+            ledger.retryableSessionIDs(now: t0.addingTimeInterval(backoff + 1)),
+            ["session_a"]
+        )
+
+        // Once the retry starts, the session drops out of the retryable set, so
+        // repeated passes cannot pile attempts onto a blocked mount.
+        XCTAssertNotNil(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertTrue(ledger.retryableSessionIDs(now: t0.addingTimeInterval(backoff + 1)).isEmpty)
+    }
+
+    // MARK: - Failure backoff
+
+    func testFailedSessionIsNotRetriedInsideTheBackoffWindow() throws {
+        var ledger = makeLedger()
+
+        let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0))
+
+        XCTAssertTrue(ledger.retryableSessionIDs(now: t0).isEmpty)
+        XCTAssertTrue(ledger.retryableSessionIDs(now: t0.addingTimeInterval(backoff - 1)).isEmpty)
+        XCTAssertEqual(ledger.retryableSessionIDs(now: t0.addingTimeInterval(backoff)), ["session_a"])
+    }
+
+    func testChangingTheNotesFolderClearsTheBackoff() throws {
+        var ledger = makeLedger()
+
+        let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0))
+        XCTAssertTrue(ledger.retryableSessionIDs(now: t0).isEmpty)
+
+        ledger.clearFailureBackoff()
+        XCTAssertEqual(ledger.retryableSessionIDs(now: t0), ["session_a"])
+    }
+
+    func testExcludedSessionIsNotRetried() throws {
+        var ledger = makeLedger()
+
+        let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0))
+
+        let later = t0.addingTimeInterval(backoff + 1)
+        XCTAssertTrue(ledger.retryableSessionIDs(excluding: "session_a", now: later).isEmpty)
+        XCTAssertEqual(ledger.retryableSessionIDs(excluding: "session_b", now: later), ["session_a"])
+    }
+
+    // MARK: - Attempt ordering
+
+    func testLateReportFromSupersededAttemptIsIgnored() throws {
+        var ledger = makeLedger()
+
+        // Attempt 1 starts and blocks (e.g. on an unreachable mount).
+        let first = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+
+        // The session is deleted and re-created, which clears the reservation
+        // and lets a second attempt start while the first is still running.
+        ledger.forget(sessionID: "session_a")
+        let second = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertNotEqual(first, second)
+
+        // Attempt 2 finishes first, and fails.
+        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: second, succeeded: false, now: t0))
+        XCTAssertEqual(ledger.pendingSessionIDs, ["session_a"])
+
+        // Attempt 1 reports success afterwards. It is superseded, so it must
+        // neither be accepted nor clear the pending flag attempt 2 set.
+        XCTAssertFalse(
+            ledger.finishAttempt(sessionID: "session_a", attempt: first, succeeded: true, now: t0),
+            "A report from a superseded attempt must be rejected"
+        )
+        XCTAssertEqual(
+            ledger.pendingSessionIDs,
+            ["session_a"],
+            "A superseded success must not drop the durable retry"
+        )
+    }
+
+    func testForgettingASessionDropsPendingAndBackoffState() throws {
+        var ledger = makeLedger()
+
+        let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0))
+        XCTAssertEqual(ledger.pendingSessionIDs, ["session_a"])
+
+        ledger.forget(sessionID: "session_a")
+        XCTAssertTrue(ledger.pendingSessionIDs.isEmpty)
+        XCTAssertTrue(ledger.retryableSessionIDs(now: t0).isEmpty)
+    }
+
+    // MARK: - Coalescing
+
+    func testRescheduleRequestIsDeliveredOnce() throws {
+        var ledger = makeLedger()
+
+        XCTAssertFalse(ledger.takeRescheduleRequest(sessionID: "session_a"))
+
+        ledger.requestReschedule(sessionID: "session_a")
+        ledger.requestReschedule(sessionID: "session_a")
+        XCTAssertTrue(
+            ledger.takeRescheduleRequest(sessionID: "session_a"),
+            "Requests arriving during an attempt collapse into one re-run"
+        )
+        XCTAssertFalse(ledger.takeRescheduleRequest(sessionID: "session_a"))
+    }
+
+    // MARK: - Restore
+
+    func testRestoredPendingSessionsAreImmediatelyRetryable() throws {
+        var ledger = makeLedger()
+
+        ledger.restorePending(["session_a", "session_b"])
+        XCTAssertEqual(ledger.retryableSessionIDs(now: t0), ["session_a", "session_b"])
+    }
+}

--- a/OpenOats/Tests/OpenOatsTests/MirrorAttemptLedgerTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/MirrorAttemptLedgerTests.swift
@@ -28,7 +28,7 @@ final class MirrorAttemptLedgerTests: XCTestCase {
         var ledger = makeLedger()
 
         let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
-        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: true, now: t0))
+        XCTAssertEqual(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: true, now: t0), .recorded)
         XCTAssertNotNil(ledger.beginAttempt(sessionID: "session_a"))
     }
 
@@ -36,7 +36,7 @@ final class MirrorAttemptLedgerTests: XCTestCase {
         var ledger = makeLedger()
 
         let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
-        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0))
+        XCTAssertEqual(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0), .recorded)
         XCTAssertEqual(
             ledger.retryableSessionIDs(now: t0.addingTimeInterval(backoff + 1)),
             ["session_a"]
@@ -54,7 +54,7 @@ final class MirrorAttemptLedgerTests: XCTestCase {
         var ledger = makeLedger()
 
         let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
-        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0))
+        XCTAssertEqual(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0), .recorded)
 
         XCTAssertTrue(ledger.retryableSessionIDs(now: t0).isEmpty)
         XCTAssertTrue(ledger.retryableSessionIDs(now: t0.addingTimeInterval(backoff - 1)).isEmpty)
@@ -65,18 +65,95 @@ final class MirrorAttemptLedgerTests: XCTestCase {
         var ledger = makeLedger()
 
         let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
-        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0))
+        XCTAssertEqual(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0), .recorded)
         XCTAssertTrue(ledger.retryableSessionIDs(now: t0).isEmpty)
 
-        ledger.clearFailureBackoff()
+        ledger.destinationChanged()
         XCTAssertEqual(ledger.retryableSessionIDs(now: t0), ["session_a"])
+    }
+
+    // MARK: - Destination changes under a running attempt
+
+    func testSuccessAgainstTheOldFolderKeepsTheSessionPending() throws {
+        var ledger = makeLedger()
+
+        // An attempt is running against the old folder when the user picks a
+        // new one. The retry pass cannot drive the session while that attempt
+        // holds the slot, so the report itself has to hand it over.
+        let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        ledger.destinationChanged()
+        XCTAssertTrue(ledger.retryableSessionIDs(now: t0).isEmpty)
+
+        XCTAssertEqual(
+            ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: true, now: t0),
+            .staleDestination,
+            "A success against the replaced folder says nothing about the new one"
+        )
+        XCTAssertEqual(
+            ledger.pendingSessionIDs,
+            ["session_a"],
+            "The new destination has no export, so the session stays pending"
+        )
+        XCTAssertEqual(ledger.retryableSessionIDs(now: t0), ["session_a"])
+    }
+
+    func testFailureAgainstTheOldFolderDoesNotBackOffTheNewOne() throws {
+        var ledger = makeLedger()
+
+        let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        ledger.destinationChanged()
+
+        XCTAssertEqual(
+            ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0),
+            .staleDestination
+        )
+        XCTAssertEqual(
+            ledger.retryableSessionIDs(now: t0),
+            ["session_a"],
+            "A dead old mount must not hold the new folder off for a backoff interval"
+        )
+    }
+
+    func testOnlyOneAttemptRunsWhileTheDestinationChanges() throws {
+        var ledger = makeLedger()
+
+        let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        ledger.destinationChanged()
+        ledger.destinationChanged()
+
+        // Repeated changes cannot stack attempts onto a blocked mount: the slot
+        // stays taken until the running attempt reports.
+        XCTAssertNil(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertTrue(ledger.retryableSessionIDs(now: t0).isEmpty)
+
+        XCTAssertEqual(
+            ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0),
+            .staleDestination
+        )
+        XCTAssertNotNil(ledger.beginAttempt(sessionID: "session_a"))
+    }
+
+    func testAttemptStartedAfterTheChangeIsRecordedNormally() throws {
+        var ledger = makeLedger()
+
+        ledger.destinationChanged()
+        let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
+        XCTAssertEqual(
+            ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0),
+            .recorded,
+            "An attempt started against the new folder reports on the new folder"
+        )
+        XCTAssertTrue(
+            ledger.retryableSessionIDs(now: t0.addingTimeInterval(backoff - 1)).isEmpty,
+            "Its failure backs the session off as usual"
+        )
     }
 
     func testExcludedSessionIsNotRetried() throws {
         var ledger = makeLedger()
 
         let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
-        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0))
+        XCTAssertEqual(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0), .recorded)
 
         let later = t0.addingTimeInterval(backoff + 1)
         XCTAssertTrue(ledger.retryableSessionIDs(excluding: "session_a", now: later).isEmpty)
@@ -98,13 +175,14 @@ final class MirrorAttemptLedgerTests: XCTestCase {
         XCTAssertNotEqual(first, second)
 
         // Attempt 2 finishes first, and fails.
-        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: second, succeeded: false, now: t0))
+        XCTAssertEqual(ledger.finishAttempt(sessionID: "session_a", attempt: second, succeeded: false, now: t0), .recorded)
         XCTAssertEqual(ledger.pendingSessionIDs, ["session_a"])
 
         // Attempt 1 reports success afterwards. It is superseded, so it must
         // neither be accepted nor clear the pending flag attempt 2 set.
-        XCTAssertFalse(
+        XCTAssertEqual(
             ledger.finishAttempt(sessionID: "session_a", attempt: first, succeeded: true, now: t0),
+            .ignored,
             "A report from a superseded attempt must be rejected"
         )
         XCTAssertEqual(
@@ -118,7 +196,7 @@ final class MirrorAttemptLedgerTests: XCTestCase {
         var ledger = makeLedger()
 
         let attempt = try XCTUnwrap(ledger.beginAttempt(sessionID: "session_a"))
-        XCTAssertTrue(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0))
+        XCTAssertEqual(ledger.finishAttempt(sessionID: "session_a", attempt: attempt, succeeded: false, now: t0), .recorded)
         XCTAssertEqual(ledger.pendingSessionIDs, ["session_a"])
 
         ledger.forget(sessionID: "session_a")

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -390,6 +390,133 @@ final class SessionRepositoryTests: XCTestCase {
         await repo.deleteSession(sessionID: sessionID)
     }
 
+    private func sessionMetadataOnDisk(sessionID: String) -> SessionMetadata? {
+        let url = rootDir
+            .appendingPathComponent("sessions", isDirectory: true)
+            .appendingPathComponent(sessionID, isDirectory: true)
+            .appendingPathComponent("session.json")
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode(SessionMetadata.self, from: data)
+    }
+
+    private func makeMirrorNotes() -> GeneratedNotes {
+        GeneratedNotes(
+            template: TemplateSnapshot(
+                id: UUID(), name: "Mirror", icon: "star", systemPrompt: "Be helpful"
+            ),
+            generatedAt: Date(),
+            markdown: "# Mirror Notes\n\nContent here."
+        )
+    }
+
+    private func pollForMirrorFile(named slug: String, in directory: URL) async -> Bool {
+        for _ in 0..<40 {
+            try? await Task.sleep(for: .milliseconds(100))
+            let contents = try? FileManager.default.contentsOfDirectory(
+                at: directory, includingPropertiesForKeys: nil
+            )
+            if contents?.contains(where: { $0.lastPathComponent.contains(slug) && $0.pathExtension == "md" }) ?? false {
+                return true
+            }
+        }
+        return false
+    }
+
+    func testFailedMirrorSetsPendingFlagAndRetriesWhenFolderRecovers() async throws {
+        // A regular file occupies the notes-folder path, so every mirror write fails.
+        let blockedPath = rootDir.appendingPathComponent("blocked_notes")
+        try Data().write(to: blockedPath)
+        await repo.setNotesFolderPath(blockedPath)
+
+        let sessionID = "test_mirror_pending_session"
+        await repo.seedSession(
+            id: sessionID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date(),
+            title: "Pending Meeting"
+        )
+        await repo.saveNotes(sessionID: sessionID, notes: makeMirrorNotes())
+
+        var pendingObserved = false
+        for _ in 0..<40 {
+            try? await Task.sleep(for: .milliseconds(100))
+            if sessionMetadataOnDisk(sessionID: sessionID)?.mirrorPending == true {
+                pendingObserved = true
+                break
+            }
+        }
+        XCTAssertTrue(pendingObserved, "Failed mirror did not persist mirrorPending in session.json")
+
+        // The folder becomes reachable: reconfiguring the path re-drives the pending mirror.
+        let exportDir = rootDir.appendingPathComponent("recovered_notes", isDirectory: true)
+        try FileManager.default.createDirectory(at: exportDir, withIntermediateDirectories: true)
+        await repo.setNotesFolderPath(exportDir)
+
+        let didMirror = await pollForMirrorFile(named: "pending-meeting", in: exportDir)
+        XCTAssertTrue(didMirror, "Pending mirror was not re-driven after the folder recovered")
+
+        var pendingCleared = false
+        for _ in 0..<40 {
+            if sessionMetadataOnDisk(sessionID: sessionID)?.mirrorPending != true {
+                pendingCleared = true
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+        XCTAssertTrue(pendingCleared, "mirrorPending was not cleared after a successful mirror")
+
+        await repo.deleteSession(sessionID: sessionID)
+    }
+
+    func testPendingMirrorPiggybacksOnNextScheduledMirror() async throws {
+        // Same failure mode, but the path later recovers in place (like a mount
+        // coming back): no reconfiguration, so only a scheduled mirror re-drives it.
+        let exportPath = rootDir.appendingPathComponent("piggyback_notes")
+        try Data().write(to: exportPath)
+        await repo.setNotesFolderPath(exportPath)
+
+        let stuckID = "test_mirror_stuck_session"
+        await repo.seedSession(
+            id: stuckID,
+            records: [SessionRecord(speaker: .you, text: "Hello", timestamp: Date())],
+            startedAt: Date(),
+            title: "Stuck Meeting"
+        )
+        await repo.saveNotes(sessionID: stuckID, notes: makeMirrorNotes())
+
+        var pendingObserved = false
+        for _ in 0..<40 {
+            try? await Task.sleep(for: .milliseconds(100))
+            if sessionMetadataOnDisk(sessionID: stuckID)?.mirrorPending == true {
+                pendingObserved = true
+                break
+            }
+        }
+        XCTAssertTrue(pendingObserved, "Failed mirror did not persist mirrorPending in session.json")
+
+        try FileManager.default.removeItem(at: exportPath)
+        try FileManager.default.createDirectory(at: exportPath, withIntermediateDirectories: true)
+
+        let freshID = "test_mirror_fresh_session"
+        await repo.seedSession(
+            id: freshID,
+            records: [SessionRecord(speaker: .you, text: "Hi", timestamp: Date())],
+            startedAt: Date(),
+            title: "Fresh Meeting"
+        )
+        await repo.saveNotes(sessionID: freshID, notes: makeMirrorNotes())
+
+        let freshMirrored = await pollForMirrorFile(named: "fresh-meeting", in: exportPath)
+        XCTAssertTrue(freshMirrored, "New mirror did not write after the folder recovered")
+        let stuckMirrored = await pollForMirrorFile(named: "stuck-meeting", in: exportPath)
+        XCTAssertTrue(stuckMirrored, "Pending mirror was not re-driven by the next scheduled mirror")
+
+        await repo.deleteSession(sessionID: stuckID)
+        await repo.deleteSession(sessionID: freshID)
+    }
+
     func testSaveNotesMirrorsIntoISODateSubfolder() async throws {
         let exportDir = rootDir.appendingPathComponent("exported_notes_by_date", isDirectory: true)
         try FileManager.default.createDirectory(at: exportDir, withIntermediateDirectories: true)

--- a/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/SessionRepositoryTests.swift
@@ -41,7 +41,9 @@ final class SessionRepositoryTests: XCTestCase {
             .appendingPathComponent("OpenOatsRepoTests", isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: rootDir, withIntermediateDirectories: true)
-        repo = SessionRepository(rootDirectory: rootDir)
+        // Production waits 5 minutes before retrying a failed notes-folder
+        // mirror; the retry policy itself is covered by MirrorAttemptLedgerTests.
+        repo = SessionRepository(rootDirectory: rootDir, mirrorRetryBackoff: 0.05)
     }
 
     override func tearDown() async throws {


### PR DESCRIPTION
## Root cause

`SessionRepository.performMirror` (`OpenOats/Sources/OpenOats/Storage/SessionRepository.swift:1942` on main) writes the notes-folder mirror via `MarkdownMeetingWriter.write`, which catches its own write error and returns nil (`Intelligence/MarkdownMeetingWriter.swift:95`). The caller swallows that with `guard let outputTarget else { return }`, and `scheduleMirror` is a fire-and-forget `Task.detached` from 7 event-triggered call sites. Nothing records the failure and nothing re-drives it. With the notes folder on a network mount that is temporarily unreachable (e.g. SMB share down), the meeting's export is silently never written.

## What changed

- `performMirror` now returns `Bool`: `false` means the export failed and should be retried; an empty transcript ("nothing to mirror") still counts as success.
- The detached mirror task reports its outcome back to the actor (`mirrorDidFinish`), which tracks pending sessions in memory and persists an optional `mirrorPending` flag in `session.json` (`SessionMetadata`) so a failed export survives an app relaunch. Metadata is only written when the flag actually changes, so steady-state success paths never touch `session.json`.
- Re-drive points for pending mirrors:
  - repository init: scans session metadata for persisted flags (alongside the existing `cleanupExpiredRetainedBatchAudio`), then retries;
  - `setNotesFolderPath`: the folder is configured after init, so this is the first moment an init-discovered pending mirror can actually run;
  - piggybacked on every `scheduleMirror`, so a pending export heals on the next meeting event once the mount is back.
- Success behavior is unchanged: same write path, same output.

## Testing

Two new `SessionRepositoryTests` (same polling shape as the existing mirror tests):

1. A regular file occupies the notes-folder path, so every mirror write fails → `mirrorPending: true` is persisted in `session.json`; pointing the notes folder at a writable directory re-drives the export and clears the flag.
2. The blocked path recovers in place (file removed, directory created — no reconfiguration): the next `saveNotes` mirror piggybacks the stuck session; both exports appear.

`swift build -c debug`, full `swift test` (725 tests, 0 failures), and `swift build -c release` pass locally (macOS, arm64). Not verified against a real SMB mount; the failure is simulated by making the target path unwritable, which exercises the same nil-return path in `MarkdownMeetingWriter.write`.

## Risk

Low. Retries only run on existing events (init, folder configuration, scheduled mirrors) — no timers or loops. A deleted session with a pending flag self-clears on retry (empty transcript reads as nothing-to-mirror success). The new metadata field is optional, so existing `session.json` files decode unchanged.


---

## Revised after self-review

### Retry work is now bounded

The first cut re-drove every pending mirror from `setNotesFolderPath` — which `startTranscription` calls at every recording start (`LiveSessionController.swift:676,684`) — and from every `scheduleMirror`, with no guard against an attempt still running. Against a permanently unreachable mount the pending set only grew, and each pass spawned one more detached task doing blocking file I/O, each able to sit on the mount's own timeout.

A new `MirrorAttemptLedger` (`Storage/MirrorAttemptLedger.swift`) enforces:

- **one in-flight attempt per session** — a mirror requested while one is running is coalesced into a single re-run once that attempt reports (the markdown is already on disk, so nothing is lost);
- **a 5-minute failure backoff per session** — a session whose last attempt failed is not retried before then;
- the retry pass drives only sessions that pass both checks.

Re-applying the *same* notes folder no longer clears that backoff; only a genuine change of destination does, since past failures say nothing about a new folder.

**Resulting bound:** with a permanently unreachable notes folder, retry work is at most one blocked attempt per pending session per 5 minutes, however many recordings are started. Before, it was one attempt per pending session per recording start, unbounded and overlapping.

### Ordering race

Attempts now carry a monotonically increasing id, and `mirrorDidFinish` ignores reports from superseded attempts. Without it a slow success could clear the pending flag set by a newer attempt that actually failed, dropping the durable retry silently. This is reachable: deleting a session drops its in-flight reservation (below), so a fresh attempt can start while the old one is still blocked.

### Two writers were dropping the flag

`finalizeSession` and the post-batch metadata refresh hand-construct `SessionMetadata`, so both cleared a persisted `mirrorPending: true` — losing the retry permanently if the app quit before the next report. Both now carry the field across. The post-batch refresh drops `speakerNames` and `customNotesGuidance` in exactly the same way; that is the same defect class, flagged here rather than fixed, to keep this PR to one concern.

### Smaller fixes

- The startup scan is now `nonisolated` and runs off the actor, hopping back with the resulting ID set. It decoded one JSON file per session directory while actor-isolated, queueing every other repository call behind it at launch.
- The scan reads only canonical `session_` directories, matching the batch-audio cleanup scan, so `.recently-deleted` and stray files are skipped.
- Deleting a session, or moving it to Recently Deleted, drops its retry state instead of leaving it in the pending set.
- A failed asset copy in `synchronizeMirroredAssets` now fails the mirror, so it is retried. A *missing* referenced asset is still skipped and does not fail the mirror, because retrying would never bring it back.

### Behaviour worth knowing

**Folder split on retry.** If the notes folder is changed while mirrors are pending, those pending sessions mirror into the **new** folder while their already-exported siblings stay in the old one. This is intended: the new folder is the user's current choice, and writing to a folder the user has moved away from would be worse.

**Interaction with #707.** If both land, a retried notes generation calls `saveNotes` → `scheduleMirror`, which also runs a retry pass — so the pass runs about twice as often per meeting. It is idempotent, and now bounded by the in-flight guard and the backoff, so the extra frequency costs nothing.

### Tests

`MirrorAttemptLedgerTests` covers the in-flight guard, the backoff window, backoff clearing on a folder change, delete pruning, request coalescing, and the ordering race: attempt 1 starts, attempt 2 completes first and fails, and attempt 1's late success is rejected with the pending flag intact. The ledger is a plain value type, so that race is deterministic rather than timing-dependent.

Both existing polling tests are kept; the test repository is constructed with a short backoff so the retry path still runs. Full `swift test` is 735 tests, 0 failures (was 725); `swift build` clean (macOS, arm64).

## Follow-up: a destination change under a running attempt

A review pass found a gap in the ledger. `retryPendingMirrors` skips a session
whose attempt is still running (`MirrorAttemptLedger.swift:79`), so when the
notes folder changed while an attempt was in flight, that session was never
driven to the new folder:

- if the running attempt succeeded against the **old** folder, `mirrorDidFinish`
  cleared the pending state and the durable flag, and the new folder never
  received the export at all;
- if it failed, that failure was recorded as the session's backoff, holding the
  new folder off for a full retry interval although nothing had been tried
  there.

`setNotesFolderPath` now tells the ledger that the destination changed, and
every attempt running at that moment is marked stale. A stale attempt's report
keeps the session pending, records no backoff, and re-drives the mirror against
the new folder. `finishAttempt` returns `recorded` / `ignored` /
`staleDestination` instead of a Bool, so the caller can tell "not mine" from
"not this folder".

**The bound is unchanged.** Nothing starts an attempt while one is running, so a
session still has at most one in flight, and the re-run waits for the running
attempt to report. A permanently unreachable folder still costs at most one
blocked attempt per pending session per backoff interval; a destination change
adds at most one further attempt per session, sequentially, never overlapping.

Four new `MirrorAttemptLedgerTests`: a stale success keeps the session pending,
a stale failure leaves it immediately retryable, repeated destination changes
cannot stack attempts onto a blocked mount, and an attempt started after the
change is recorded normally. Full suite: 739 tests, 0 failures (was 735).

## Merge order

Merge after #705. Both branches edit `SessionRepository.swift` and conflict there (3 hunks plus tests):
#705 adds the audio-retention sweep, this PR adds the mirror-retry ledger.

Happy to rebase whichever way suits your merge queue.

