### PR TITLE
Fix stale 'Waiting for calendar access' banner when the main window is reopened

### DIFF
--- a/OpenOats/Sources/OpenOats/App/AppContainer.swift
+++ b/OpenOats/Sources/OpenOats/App/AppContainer.swift
@@ -271,6 +271,25 @@ final class AppContainer {
         }
     }
 
+    /// Passive repair for background refresh loops.
+    ///
+    /// Builds the calendar manager when it is missing and re-reads TCC when it is
+    /// not, but never calls `requestAccess()`. `updateCalendarIntegration` requests
+    /// access whenever it observes `.notDetermined`, so calling it from a poller
+    /// tick could raise a system permission dialog out of a windowless background
+    /// app. Authorization is only ever requested from an explicit user action —
+    /// the Calendar settings toggle.
+    ///
+    /// Never clears the manager: disabling the integration is the toggle's job.
+    func ensureCalendarIntegrationReady(enabled: Bool) {
+        guard enabled else { return }
+        if calendarManager == nil {
+            setCalendarManager(CalendarManager())
+        } else {
+            calendarManager?.refreshFromSystem()
+        }
+    }
+
     /// Recreates the calendar manager so EventKit state is reloaded from scratch.
     /// Use this when permission or visible calendars may have changed in System Settings
     /// and a soft status refresh is not sufficient.

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -335,10 +335,12 @@ struct ContentView: View {
             overlayManager.defaults = container.defaults
             miniBarManager.defaults = container.defaults
 
-            // Setup calendar integration before the first await so the home timeline
-            // never transiently shows "Waiting for calendar access" on users who already
-            // granted permission. updateCalendarIntegration is synchronous and safe to
-            // call here.
+            // Set up calendar integration before the first await. A missing manager no
+            // longer reads as "waiting for access" — HomeTimelineCalendarNotice.resolve
+            // treats it as no notice at all — so this is no longer needed to suppress a
+            // flicker. It stays because it is the one call that may request Calendar
+            // authorization, and doing that here keeps the request tied to the window
+            // appearing rather than to a background refresh tick.
             container.updateCalendarIntegration(enabled: settings.calendarIntegrationEnabled)
 
             await container.seedIfNeeded(coordinator: coordinator)

--- a/OpenOats/Sources/OpenOats/Views/HomeTimelineModels.swift
+++ b/OpenOats/Sources/OpenOats/Views/HomeTimelineModels.swift
@@ -145,4 +145,30 @@ enum HomeTimelineCalendarNotice: Equatable {
             return nil
         }
     }
+
+    /// Empty-state copy for the timeline, derived from the same resolution as the
+    /// notice so the two cannot drift apart. A `nil` notice — access granted, or no
+    /// manager built yet — gets neutral copy, never permission-flavoured copy.
+    static func emptyTimelineCopy(
+        integrationEnabled: Bool,
+        accessState: CalendarManager.AccessState?
+    ) -> (title: String, description: String) {
+        switch resolve(integrationEnabled: integrationEnabled, accessState: accessState) {
+        case .integrationOff:
+            return (
+                "No saved meetings yet",
+                "Recorded meetings will appear here even while Calendar integration is off."
+            )
+        case .accessDenied, .waitingForAccess:
+            return (
+                "No saved meetings yet",
+                "Saved meetings will appear here even before Calendar access is available."
+            )
+        case nil:
+            return (
+                "No meetings yet",
+                "Upcoming calendar meetings and saved history will appear here."
+            )
+        }
+    }
 }

--- a/OpenOats/Sources/OpenOats/Views/HomeTimelineModels.swift
+++ b/OpenOats/Sources/OpenOats/Views/HomeTimelineModels.swift
@@ -121,3 +121,28 @@ enum HomeTimelineGrouping {
         }
     }
 }
+
+/// Which calendar notice, if any, the home timeline should show.
+enum HomeTimelineCalendarNotice: Equatable {
+    case integrationOff
+    case accessDenied
+    case waitingForAccess
+
+    /// A `nil` access state means the `CalendarManager` has not been built yet.
+    /// That is an internal condition, not a pending permission decision, so it
+    /// must never surface the "waiting for access" notice.
+    static func resolve(
+        integrationEnabled: Bool,
+        accessState: CalendarManager.AccessState?
+    ) -> HomeTimelineCalendarNotice? {
+        guard integrationEnabled else { return .integrationOff }
+        switch accessState {
+        case .denied:
+            return .accessDenied
+        case .notDetermined:
+            return .waitingForAccess
+        case .authorized, nil:
+            return nil
+        }
+    }
+}

--- a/OpenOats/Sources/OpenOats/Views/HomeTimelineWorkspaceView.swift
+++ b/OpenOats/Sources/OpenOats/Views/HomeTimelineWorkspaceView.swift
@@ -79,7 +79,7 @@ struct HomeTimelineWorkspaceView: View {
     }
 
     @ViewBuilder
-    private func workspace(controller: NotesController, accessState: CalendarManager.AccessState) -> some View {
+    private func workspace(controller: NotesController, accessState: CalendarManager.AccessState?) -> some View {
         let groups = HomeTimelineGrouping.groups(
             calendarEvents: calendarEvents,
             savedSessions: controller.state.sessionHistory
@@ -119,7 +119,7 @@ struct HomeTimelineWorkspaceView: View {
     private func timelinePane(
         controller: NotesController,
         groups: [HomeTimelineDayGroup],
-        accessState: CalendarManager.AccessState,
+        accessState: CalendarManager.AccessState?,
         isDetailVisible: Bool
     ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -227,10 +227,14 @@ struct HomeTimelineWorkspaceView: View {
 
     @ViewBuilder
     private func calendarAccessNotice(
-        accessState: CalendarManager.AccessState,
+        accessState: CalendarManager.AccessState?,
         hasCalendarEntries: Bool
     ) -> some View {
-        if !settings.calendarIntegrationEnabled {
+        switch HomeTimelineCalendarNotice.resolve(
+            integrationEnabled: settings.calendarIntegrationEnabled,
+            accessState: accessState
+        ) {
+        case .integrationOff:
             HomeTimelineNotice(
                 icon: "calendar.badge.exclamationmark",
                 title: "Calendar integration is off",
@@ -238,7 +242,7 @@ struct HomeTimelineWorkspaceView: View {
                 actionTitle: "Open Settings",
                 action: nil
             )
-        } else if accessState == .denied {
+        case .accessDenied:
             HomeTimelineNotice(
                 icon: "exclamationmark.triangle.fill",
                 title: "Calendar access denied",
@@ -246,7 +250,7 @@ struct HomeTimelineWorkspaceView: View {
                 actionTitle: "Open Privacy Settings",
                 action: openCalendarPrivacySettings
             )
-        } else if accessState == .notDetermined {
+        case .waitingForAccess:
             HomeTimelineNotice(
                 icon: "calendar",
                 title: "Waiting for calendar access",
@@ -254,10 +258,12 @@ struct HomeTimelineWorkspaceView: View {
                 actionTitle: nil,
                 action: nil
             )
+        case nil:
+            EmptyView()
         }
     }
 
-    private func emptyTimeline(accessState: CalendarManager.AccessState) -> some View {
+    private func emptyTimeline(accessState: CalendarManager.AccessState?) -> some View {
         let copy = emptyTimelineCopy(accessState: accessState)
 
         return ContentUnavailableView {
@@ -269,7 +275,7 @@ struct HomeTimelineWorkspaceView: View {
         .padding(.vertical, 30)
     }
 
-    private func emptyTimelineCopy(accessState: CalendarManager.AccessState) -> (title: String, description: String) {
+    private func emptyTimelineCopy(accessState: CalendarManager.AccessState?) -> (title: String, description: String) {
         if !settings.calendarIntegrationEnabled {
             return (
                 "No saved meetings yet",
@@ -362,7 +368,19 @@ struct HomeTimelineWorkspaceView: View {
 
     @MainActor
     private func refreshCalendarEvents() async {
-        guard settings.calendarIntegrationEnabled, let manager = container.calendarManager else {
+        guard settings.calendarIntegrationEnabled else {
+            calendarEvents = []
+            return
+        }
+
+        if container.calendarManager == nil {
+            // Reopening the hidden main window (makeKeyAndOrderFront) fires no
+            // onAppear, so the manager may not exist yet. Mirror the Settings-tab
+            // repair (CalendarSettingsView.refresh) and build it from the refresh loop.
+            container.updateCalendarIntegration(enabled: true)
+        }
+
+        guard let manager = container.calendarManager else {
             calendarEvents = []
             return
         }
@@ -401,16 +419,19 @@ struct HomeTimelineWorkspaceView: View {
         calendarEvents = combined
     }
 
-    private var currentAccessState: CalendarManager.AccessState {
-        guard settings.calendarIntegrationEnabled else { return .notDetermined }
-        return container.calendarManager?.accessState ?? .notDetermined
+    /// The current calendar access state, or nil when the `CalendarManager` has
+    /// not been built yet. A missing manager is an internal condition, not a
+    /// pending permission decision, so it must not read as `.notDetermined`.
+    private var currentAccessState: CalendarManager.AccessState? {
+        guard settings.calendarIntegrationEnabled else { return nil }
+        return container.calendarManager?.accessState
     }
 
-    private func refreshTaskID(for accessState: CalendarManager.AccessState) -> String {
+    private func refreshTaskID(for accessState: CalendarManager.AccessState?) -> String {
         "\(settings.calendarIntegrationEnabled)-\(accessStateTag(for: accessState))-\(refreshTick)"
     }
 
-    private func accessStateTag(for accessState: CalendarManager.AccessState) -> String {
+    private func accessStateTag(for accessState: CalendarManager.AccessState?) -> String {
         switch accessState {
         case .authorized:
             return "authorized"
@@ -418,16 +439,20 @@ struct HomeTimelineWorkspaceView: View {
             return "denied"
         case .notDetermined:
             return "not-determined"
+        case nil:
+            return "unavailable"
         }
     }
 
-    private func refreshInterval(for accessState: CalendarManager.AccessState) -> Duration {
+    private func refreshInterval(for accessState: CalendarManager.AccessState?) -> Duration {
         switch accessState {
         case .authorized:
             return .seconds(60)
         case .denied:
             return .seconds(300)
-        case .notDetermined:
+        case .notDetermined, nil:
+            // Poll quickly: refreshCalendarEvents() builds a missing manager, so a
+            // reopened window self-heals on the next tick.
             return .seconds(1)
         }
     }

--- a/OpenOats/Sources/OpenOats/Views/HomeTimelineWorkspaceView.swift
+++ b/OpenOats/Sources/OpenOats/Views/HomeTimelineWorkspaceView.swift
@@ -230,36 +230,41 @@ struct HomeTimelineWorkspaceView: View {
         accessState: CalendarManager.AccessState?,
         hasCalendarEntries: Bool
     ) -> some View {
-        switch HomeTimelineCalendarNotice.resolve(
+        // `if let` rather than a `switch` with an `EmptyView` default. The
+        // original if/else-if chain yielded an optional view when no notice
+        // applied, and this sits as the first child of a spaced VStack, so
+        // keeping the optional shape leaves the no-notice layout exactly as it
+        // was instead of relying on EmptyView collapsing the same way.
+        if let notice = HomeTimelineCalendarNotice.resolve(
             integrationEnabled: settings.calendarIntegrationEnabled,
             accessState: accessState
         ) {
-        case .integrationOff:
-            HomeTimelineNotice(
-                icon: "calendar.badge.exclamationmark",
-                title: "Calendar integration is off",
-                message: "Saved meetings are still available here.",
-                actionTitle: "Open Settings",
-                action: nil
-            )
-        case .accessDenied:
-            HomeTimelineNotice(
-                icon: "exclamationmark.triangle.fill",
-                title: "Calendar access denied",
-                message: hasCalendarEntries ? "" : "Grant Calendar access to include upcoming meetings.",
-                actionTitle: "Open Privacy Settings",
-                action: openCalendarPrivacySettings
-            )
-        case .waitingForAccess:
-            HomeTimelineNotice(
-                icon: "calendar",
-                title: "Waiting for calendar access",
-                message: "Saved meetings are still available while OpenOats waits for Calendar access.",
-                actionTitle: nil,
-                action: nil
-            )
-        case nil:
-            EmptyView()
+            switch notice {
+            case .integrationOff:
+                HomeTimelineNotice(
+                    icon: "calendar.badge.exclamationmark",
+                    title: "Calendar integration is off",
+                    message: "Saved meetings are still available here.",
+                    actionTitle: "Open Settings",
+                    action: nil
+                )
+            case .accessDenied:
+                HomeTimelineNotice(
+                    icon: "exclamationmark.triangle.fill",
+                    title: "Calendar access denied",
+                    message: hasCalendarEntries ? "" : "Grant Calendar access to include upcoming meetings.",
+                    actionTitle: "Open Privacy Settings",
+                    action: openCalendarPrivacySettings
+                )
+            case .waitingForAccess:
+                HomeTimelineNotice(
+                    icon: "calendar",
+                    title: "Waiting for calendar access",
+                    message: "Saved meetings are still available while OpenOats waits for Calendar access.",
+                    actionTitle: nil,
+                    action: nil
+                )
+            }
         }
     }
 
@@ -276,21 +281,9 @@ struct HomeTimelineWorkspaceView: View {
     }
 
     private func emptyTimelineCopy(accessState: CalendarManager.AccessState?) -> (title: String, description: String) {
-        if !settings.calendarIntegrationEnabled {
-            return (
-                "No saved meetings yet",
-                "Recorded meetings will appear here even while Calendar integration is off."
-            )
-        }
-        if accessState == .authorized {
-            return (
-                "No meetings yet",
-                "Upcoming calendar meetings and saved history will appear here."
-            )
-        }
-        return (
-            "No saved meetings yet",
-            "Saved meetings will appear here even before Calendar access is available."
+        HomeTimelineCalendarNotice.emptyTimelineCopy(
+            integrationEnabled: settings.calendarIntegrationEnabled,
+            accessState: accessState
         )
     }
 
@@ -373,19 +366,17 @@ struct HomeTimelineWorkspaceView: View {
             return
         }
 
-        if container.calendarManager == nil {
-            // Reopening the hidden main window (makeKeyAndOrderFront) fires no
-            // onAppear, so the manager may not exist yet. Mirror the Settings-tab
-            // repair (CalendarSettingsView.refresh) and build it from the refresh loop.
-            container.updateCalendarIntegration(enabled: true)
-        }
+        // Reopening the hidden main window (makeKeyAndOrderFront) fires no onAppear,
+        // so nothing on this surface rebuilds a missing manager. Repair from the
+        // refresh loop instead. This entry point builds the manager and re-reads TCC
+        // but never requests authorization, so a poller tick in a windowless app can
+        // never raise a permission dialog.
+        container.ensureCalendarIntegrationReady(enabled: settings.calendarIntegrationEnabled)
 
         guard let manager = container.calendarManager else {
             calendarEvents = []
             return
         }
-
-        manager.refreshFromSystem()
 
         guard manager.accessState == .authorized else {
             calendarEvents = []

--- a/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
+++ b/OpenOats/Sources/OpenOats/Views/IdleHomeDashboardView.swift
@@ -82,28 +82,29 @@ struct IdleHomeDashboardView: View {
     }
 
     @ViewBuilder
-    private func comingUpCard(accessState: CalendarManager.AccessState) -> some View {
+    private func comingUpCard(accessState: CalendarManager.AccessState?) -> some View {
         Group {
-            if !settings.calendarIntegrationEnabled {
+            switch HomeTimelineCalendarNotice.resolve(
+                integrationEnabled: settings.calendarIntegrationEnabled,
+                accessState: accessState
+            ) {
+            case .integrationOff:
                 disabledCalendarCard
-            } else {
-                switch accessState {
-                case .authorized:
-                    if events.isEmpty && earlierTodayEvents.isEmpty {
-                        emptyStateCard(
-                            title: "No upcoming meetings",
-                            description: "OpenOats will show your next calendar meetings here."
-                        )
-                    } else {
-                        upcomingMeetingsCard
-                    }
-                case .denied:
-                    deniedCalendarCard
-                case .notDetermined:
+            case .accessDenied:
+                deniedCalendarCard
+            case .waitingForAccess:
+                emptyStateCard(
+                    title: "Waiting for calendar access",
+                    description: "OpenOats will show your upcoming meetings once Calendar access is granted."
+                )
+            case nil:
+                if events.isEmpty && earlierTodayEvents.isEmpty {
                     emptyStateCard(
-                        title: "Waiting for calendar access",
-                        description: "OpenOats will show your upcoming meetings once Calendar access is granted."
+                        title: "No upcoming meetings",
+                        description: "OpenOats will show your next calendar meetings here."
                     )
+                } else {
+                    upcomingMeetingsCard
                 }
             }
         }
@@ -251,16 +252,19 @@ struct IdleHomeDashboardView: View {
         }
     }
 
-    private var currentAccessState: CalendarManager.AccessState {
-        guard settings.calendarIntegrationEnabled else { return .notDetermined }
-        return container.calendarManager?.accessState ?? .notDetermined
+    /// The current calendar access state, or nil when the `CalendarManager` has not
+    /// been built yet. A missing manager is an internal condition, not a pending
+    /// permission decision, so it must not read as `.notDetermined`.
+    private var currentAccessState: CalendarManager.AccessState? {
+        guard settings.calendarIntegrationEnabled else { return nil }
+        return container.calendarManager?.accessState
     }
 
-    private func refreshTaskID(for accessState: CalendarManager.AccessState) -> String {
+    private func refreshTaskID(for accessState: CalendarManager.AccessState?) -> String {
         "\(settings.calendarIntegrationEnabled)-\(accessStateTag(for: accessState))-\(refreshTick)"
     }
 
-    private func accessStateTag(for accessState: CalendarManager.AccessState) -> String {
+    private func accessStateTag(for accessState: CalendarManager.AccessState?) -> String {
         switch accessState {
         case .authorized:
             return "authorized"
@@ -268,16 +272,18 @@ struct IdleHomeDashboardView: View {
             return "denied"
         case .notDetermined:
             return "not-determined"
+        case nil:
+            return "unavailable"
         }
     }
 
-    private func refreshInterval(for accessState: CalendarManager.AccessState) -> Duration {
+    private func refreshInterval(for accessState: CalendarManager.AccessState?) -> Duration {
         switch accessState {
         case .authorized:
             return .seconds(60)
         case .denied:
             return .seconds(300)
-        case .notDetermined:
+        case .notDetermined, nil:
             return .seconds(1)
         }
     }

--- a/OpenOats/Tests/OpenOatsTests/HomeTimelineCalendarNoticeTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/HomeTimelineCalendarNoticeTests.swift
@@ -3,14 +3,14 @@ import XCTest
 
 final class HomeTimelineCalendarNoticeTests: XCTestCase {
     func testIntegrationOffWinsRegardlessOfAccessState() {
-        XCTAssertEqual(
-            HomeTimelineCalendarNotice.resolve(integrationEnabled: false, accessState: nil),
-            .integrationOff
-        )
-        XCTAssertEqual(
-            HomeTimelineCalendarNotice.resolve(integrationEnabled: false, accessState: .authorized),
-            .integrationOff
-        )
+        let states: [CalendarManager.AccessState?] = [nil, .authorized, .denied, .notDetermined]
+        for state in states {
+            XCTAssertEqual(
+                HomeTimelineCalendarNotice.resolve(integrationEnabled: false, accessState: state),
+                .integrationOff,
+                "integration off must win for access state \(String(describing: state))"
+            )
+        }
     }
 
     func testAuthorizedShowsNoNotice() {
@@ -39,5 +39,73 @@ final class HomeTimelineCalendarNoticeTests: XCTestCase {
         XCTAssertNil(
             HomeTimelineCalendarNotice.resolve(integrationEnabled: true, accessState: nil)
         )
+    }
+
+    // MARK: - Empty timeline copy
+
+    private func copy(
+        integrationEnabled: Bool,
+        accessState: CalendarManager.AccessState?
+    ) -> (title: String, description: String) {
+        HomeTimelineCalendarNotice.emptyTimelineCopy(
+            integrationEnabled: integrationEnabled,
+            accessState: accessState
+        )
+    }
+
+    func testEmptyCopyMentionsIntegrationOffWhenDisabled() {
+        let states: [CalendarManager.AccessState?] = [nil, .authorized, .denied, .notDetermined]
+        for state in states {
+            XCTAssertEqual(
+                copy(integrationEnabled: false, accessState: state).description,
+                "Recorded meetings will appear here even while Calendar integration is off."
+            )
+        }
+    }
+
+    func testEmptyCopyIsPermissionFlavouredOnlyForRealPermissionStates() {
+        let permissionFlavoured = "Saved meetings will appear here even before Calendar access is available."
+        XCTAssertEqual(
+            copy(integrationEnabled: true, accessState: .denied).description,
+            permissionFlavoured
+        )
+        XCTAssertEqual(
+            copy(integrationEnabled: true, accessState: .notDetermined).description,
+            permissionFlavoured
+        )
+    }
+
+    func testEmptyCopyIsNeutralWhenManagerIsMissing() {
+        // Regression: a nil CalendarManager is an internal condition. It must not
+        // produce copy that blames a pending Calendar permission decision.
+        let neutral = (
+            title: "No meetings yet",
+            description: "Upcoming calendar meetings and saved history will appear here."
+        )
+        XCTAssertEqual(copy(integrationEnabled: true, accessState: nil).title, neutral.title)
+        XCTAssertEqual(copy(integrationEnabled: true, accessState: nil).description, neutral.description)
+        XCTAssertEqual(copy(integrationEnabled: true, accessState: .authorized).title, neutral.title)
+        XCTAssertEqual(copy(integrationEnabled: true, accessState: .authorized).description, neutral.description)
+    }
+
+    func testEmptyCopyNeverDriftsFromNotice() {
+        // The copy must be a function of the resolved notice, never an independent
+        // reading of the same inputs.
+        let states: [CalendarManager.AccessState?] = [nil, .authorized, .denied, .notDetermined]
+        for enabled in [true, false] {
+            for state in states {
+                let notice = HomeTimelineCalendarNotice.resolve(
+                    integrationEnabled: enabled,
+                    accessState: state
+                )
+                let description = copy(integrationEnabled: enabled, accessState: state).description
+                let mentionsAccess = description.contains("Calendar access")
+                XCTAssertEqual(
+                    mentionsAccess,
+                    notice == .accessDenied || notice == .waitingForAccess,
+                    "copy for notice \(String(describing: notice)) disagrees with the notice"
+                )
+            }
+        }
     }
 }

--- a/OpenOats/Tests/OpenOatsTests/HomeTimelineCalendarNoticeTests.swift
+++ b/OpenOats/Tests/OpenOatsTests/HomeTimelineCalendarNoticeTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import OpenOatsKit
+
+final class HomeTimelineCalendarNoticeTests: XCTestCase {
+    func testIntegrationOffWinsRegardlessOfAccessState() {
+        XCTAssertEqual(
+            HomeTimelineCalendarNotice.resolve(integrationEnabled: false, accessState: nil),
+            .integrationOff
+        )
+        XCTAssertEqual(
+            HomeTimelineCalendarNotice.resolve(integrationEnabled: false, accessState: .authorized),
+            .integrationOff
+        )
+    }
+
+    func testAuthorizedShowsNoNotice() {
+        XCTAssertNil(
+            HomeTimelineCalendarNotice.resolve(integrationEnabled: true, accessState: .authorized)
+        )
+    }
+
+    func testDeniedShowsDeniedNotice() {
+        XCTAssertEqual(
+            HomeTimelineCalendarNotice.resolve(integrationEnabled: true, accessState: .denied),
+            .accessDenied
+        )
+    }
+
+    func testNotDeterminedShowsWaitingNotice() {
+        XCTAssertEqual(
+            HomeTimelineCalendarNotice.resolve(integrationEnabled: true, accessState: .notDetermined),
+            .waitingForAccess
+        )
+    }
+
+    func testMissingManagerShowsNoNotice() {
+        // Regression: a nil CalendarManager (not yet built for a reshown window)
+        // must not read as "waiting for calendar access".
+        XCTAssertNil(
+            HomeTimelineCalendarNotice.resolve(integrationEnabled: true, accessState: nil)
+        )
+    }
+}


### PR DESCRIPTION
## Bug

On a real install with Calendar access granted, the Meetings home shows **"Waiting for calendar access"**. Opening the Settings window repairs it.

## What produces it

`currentAccessState` mapped a missing `CalendarManager` onto a real permission state:

```swift
return container.calendarManager?.accessState ?? .notDetermined
```

A missing manager is an internal condition. It is not a pending permission decision. The two shared one sentinel, so "the manager is not built yet" rendered as "the user has not answered the permission prompt yet".

Opening Settings repairs it because the Calendar tab runs `syncCalendarIntegration()`, which builds the manager on the shared container.

## Fix

**Remove the sentinel conflation.** `currentAccessState` is now `CalendarManager.AccessState?`. Nil means "manager not built" and renders no notice at all. Only a real `.notDetermined` from EventKit shows the waiting copy. The decision is extracted into a pure `HomeTimelineCalendarNotice.resolve(integrationEnabled:accessState:)` and unit-tested. `IdleHomeDashboardView` routes through the same resolver, so the two surfaces cannot drift.

**Repair a missing manager passively.** `AppContainer.ensureCalendarIntegrationReady(enabled:)` builds the manager when it is missing and re-reads system authorization when it is not. It never calls `requestAccess()`, so a background refresh tick cannot raise a TCC dialog out of a windowless app. `updateCalendarIntegration` keeps the single authorization request, tied to the window appearing.

## Retracted: the re-bootstrap diagnosis

An earlier revision claimed the recurring banner came from a **second `AppContainer`**, on the reasoning that `OpenOatsRootApp` is constructed inside the `@main` App's `body` and so could be re-initialised on each evaluation. That was established by reading code. The review asked for runtime confirmation.

I instrumented `bootstrap()` with a call counter and drove the reported repro in-process on the UI-test host: order the main window out, set the activation policy to `.accessory`, then set it back to `.regular` and `makeKeyAndOrderFront` the same window.

```
PROBE bootstrap call #1
PROBE pre-hide  calls=1 windows=1
PROBE hidden    calls=1
PROBE reopened existing window
PROBE final     calls=1
```

`bootstrap()` runs exactly once per process. The window is ordered out and never destroyed, and the reopen re-uses it. The container is the same object throughout. **The diagnosis was wrong, so the memoisation is gone from this PR.**

That retires the updater concern completely. This PR no longer touches `AppContainer.bootstrap()` and no longer changes how many `AppUpdaterController` instances are constructed or started. The whole diff to `AppContainer.swift` is now `ensureCalendarIntegrationReady`.

What I have not pinned down is why the banner returns after a Settings repair, given that the container persists. These changes make the nil state harmless and self-healing whichever path produces it, but I am not claiming to have found that trigger.

## Layout caveat, resolved rather than tested

The previous revision replaced an Optional notice view with a `switch` whose default arm was `EmptyView()`, and I flagged the authorized-case layout as unverified. The notice is the first child of a `VStack(alignment: .leading, spacing: 14)`, so an `EmptyView` that takes a spacing slot would shift the whole timeline. It is an `if let` now, which keeps the original Optional shape. There is no layout change left to verify.

## Follow-ups, deliberately not here

`OpenOatsRootApp` being built inside the `@main` App's `body` is still an odd shape — its `@State` never receives scene-graph storage. The probe shows the hazard is not reachable through the reopen path, so it is latent rather than active. Making `OpenOatsRootApp` the `@main` App, or holding the context in a `let` on the App type, is the clean fix and belongs in its own PR.

`IdleHomeDashboardView` is dead code, never instantiated in Sources, Tests, or UITests. I fixed it rather than deleted it to keep this diff honest. Deleting it is a clean follow-up if you want it gone.

## Verification

- `swift build` — Build complete
- `swift test` — 808 tests, 0 failures
- Rebased on current `main`; previously conflicting, now mergeable
