### PR TITLE
Render live-transcript storage write errors instead of dropping them

### DIFF
--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -417,21 +417,42 @@ struct ContentView: View {
 
     private func storageErrorBanner(message: String) -> some View {
         VStack(spacing: 0) {
-            HStack(spacing: 10) {
+            HStack(alignment: .top, spacing: 10) {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .font(.system(size: 12))
                     .foregroundStyle(.orange)
+                    .padding(.top, 1)
 
-                Text("Storage error: \(message)")
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .accessibilityIdentifier("app.storageErrorBanner")
-                Spacer()
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Transcript writes are failing — this recording may not be saved.")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    // The underlying error is often a long localizedDescription:
+                    // cap it so it can never crowd out the Dismiss button.
+                    Text(message)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.primary)
+                        .lineLimit(2)
+                        .truncationMode(.tail)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .help(message)
+                        .accessibilityIdentifier("app.storageErrorBanner")
+
+                    Text("Check that the disk has free space and that OpenOats has permission to write to its folder.")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
                 Button("Dismiss") {
                     coordinator.lastStorageError = nil
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
+                .layoutPriority(1)
                 .accessibilityIdentifier("app.storageErrorDismissButton")
             }
             .padding(.horizontal, 16)

--- a/OpenOats/Sources/OpenOats/Views/ContentView.swift
+++ b/OpenOats/Sources/OpenOats/Views/ContentView.swift
@@ -70,6 +70,11 @@ struct ContentView: View {
 
             Divider()
 
+            // Storage write-error banner (live transcript writes failed)
+            if let storageError = coordinator.lastStorageError {
+                storageErrorBanner(message: storageError)
+            }
+
             // Post-session banner
             if let lastSession = controllerState.lastEndedSession {
                 PostSessionBanner(
@@ -408,6 +413,33 @@ struct ContentView: View {
 
     private func stopSession() {
         liveSessionController?.stopSession(settings: settings)
+    }
+
+    private func storageErrorBanner(message: String) -> some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.orange)
+
+                Text("Storage error: \(message)")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .accessibilityIdentifier("app.storageErrorBanner")
+                Spacer()
+                Button("Dismiss") {
+                    coordinator.lastStorageError = nil
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityIdentifier("app.storageErrorDismissButton")
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(.ultraThinMaterial)
+
+            Divider()
+        }
     }
 
     private func openSettingsWindow() {


### PR DESCRIPTION
## Root cause

`AppCoordinator.lastStorageError` (`OpenOats/Sources/OpenOats/App/AppCoordinator.swift:101-105`) is a dead error channel. It is populated by the write-error handler wired in `LiveSessionController` (`App/LiveSessionController.swift:657-661`) — `SessionRepository.reportWriteError` fires it once per session when live-JSONL transcript writes fail ("No file handle available for session write", "Failed to write record: …", "Failed to open live transcript file: …") — but no view reads the property. A user whose live transcript is silently not being written sees nothing.

## What changed

Smallest possible diff, `Views/ContentView.swift` only:

- `rootContent` renders a banner when `coordinator.lastStorageError` is non-nil, inserted in the existing banner stack next to the post-session banner.
- The banner reuses the established shape of `PostSessionBanner.failedSessionBanner` (warning triangle, 12pt secondary text, `.ultraThinMaterial`, trailing `Divider`), plus a bordered Dismiss button that clears the property.
- Accessibility identifiers follow the existing `app.*` convention (`app.storageErrorBanner`, `app.storageErrorDismissButton`).

No changes to the error producer or handler wiring; `lastStorageError` was already cleared on session start (`LiveSessionController.swift:654`).

## Testing

- `swift build -c debug`, full `swift test` (723 tests, 0 failures), and `swift build -c release` pass locally (macOS, arm64).
- View-only change; no unit tests added. Verified the banner compiles into the existing banner stack and that dismiss just nils the observable property (same pattern the handler writes).

## Risk

Very low. The view reads an already-maintained `@Observable` property; when the property stays nil (the normal case), the rendered tree is unchanged.


---

## Revised after self-review

### Copy states the consequence, not the internals

The banner led with `Storage error: <localizedDescription>`, which reports an internal fact and leaves the user to infer what it means for them. It now reads:

> **Transcript writes are failing — this recording may not be saved.**
> `<the underlying error>`
> Check that the disk has free space and that OpenOats has permission to write to its folder.

Consequence first, then the detail, then something to do about it. The message uses the primary foreground style rather than `.secondary`; only the remedy hint stays secondary.

### Layout

`localizedDescription` can be long. The error line is capped with `.lineLimit(2)` and tail truncation, with the full text available as a tooltip; the text column takes the flexible width and the Dismiss button keeps its intrinsic size via `layoutPriority`. A long error can no longer squeeze the button out of the banner.

### Latch semantics

Worth stating explicitly, because the behaviour is not obvious from the diff and it is what makes a plain Dismiss button safe here:

- `SessionRepository.hasReportedWriteError` is reset in `startSession` (`SessionRepository.swift:262`) and `resumeAbandonedSession` (`:297`), so the repository reports **at most one** write error per recording.
- `LiveSessionController.startTranscription` clears `coordinator.lastStorageError` (`LiveSessionController.swift:654`) before wiring the handler, so a new recording starts with no banner.

So Dismiss means "acknowledged for this recording": it cannot suppress a future recording's failure, and there is no persisted state to leak between sessions. The flip side, by the same design, is that dismissing hides the banner for the rest of the current recording even if writes keep failing — the underlying handler only fires once per recording either way.

### Testing

Full `swift test` is 723 tests, 0 failures — unchanged, since this remains a view-only change; `swift build` clean (macOS, arm64).
